### PR TITLE
사용자 요청/응답에 프로필 이미지를 추가합니다.

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // @title 이웃집멍냥 API 문서
-// @version 0.2.0
+// @version 0.3.0
 // @description 이웃집멍냥 백엔드 API 문서입니다.
 // @termsOfService http://swagger.io/terms/
 

--- a/db/migrations/000004_add_profile_image_id_to_users.down.sql
+++ b/db/migrations/000004_add_profile_image_id_to_users.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+  users DROP COLUMN profile_image_id;

--- a/db/migrations/000004_add_profile_image_id_to_users.up.sql
+++ b/db/migrations/000004_add_profile_image_id_to_users.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  users
+ADD
+  COLUMN profile_image_id BIGINT NOT NULL;

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -18,6 +18,7 @@ type MediaService struct {
 
 type MediaServicer interface {
 	UploadMedia(file io.ReadSeeker, mediaType models.MediaType, fileName string) (*models.Media, error)
+	CreateMedia(media *models.Media) (*models.Media, error)
 	FindMediaByID(id int) (*models.Media, error)
 }
 
@@ -51,7 +52,7 @@ func (s *MediaService) UploadMedia(file io.ReadSeeker, mediaType models.MediaTyp
 		return nil, err
 	}
 
-	created, err := s.createMedia(&models.Media{
+	created, err := s.CreateMedia(&models.Media{
 		MediaType: mediaType,
 		URL:       req.HTTPRequest.URL.String(),
 	})
@@ -63,7 +64,7 @@ func (s *MediaService) UploadMedia(file io.ReadSeeker, mediaType models.MediaTyp
 	return created, nil
 }
 
-func (s *MediaService) createMedia(media *models.Media) (*models.Media, error) {
+func (s *MediaService) CreateMedia(media *models.Media) (*models.Media, error) {
 	tx, _ := s.db.Begin()
 
 	created, err := tx.CreateMedia(media)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -15,6 +15,21 @@ type User struct {
 	Password             string               `field:"password"`
 	Nickname             string               `field:"nickname"`
 	Fullname             string               `field:"fullname"`
+	ProfileImageID       int                  `field:"profile_image_id"`
+	FirebaseProviderType FirebaseProviderType `field:"fb_provider_type"`
+	FirebaseUID          string               `field:"fb_uid"`
+	CreatedAt            string               `field:"created_at"`
+	UpdatedAt            string               `field:"updated_at"`
+	DeletedAt            string               `field:"deleted_at"`
+}
+
+type UserWithProfileImage struct {
+	ID                   int                  `field:"id"`
+	Email                string               `field:"email"`
+	Password             string               `field:"password"`
+	Nickname             string               `field:"nickname"`
+	Fullname             string               `field:"fullname"`
+	ProfileImageURL      string               `field:"profile_image_url"`
 	FirebaseProviderType FirebaseProviderType `field:"fb_provider_type"`
 	FirebaseUID          string               `field:"fb_uid"`
 	CreatedAt            string               `field:"created_at"`

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -42,8 +42,6 @@ func addRoutes(r *chi.Mux) {
 		log.Fatalf("error opening database: %v\n", err)
 	}
 
-	userService := user.NewUserService(db)
-	userHandler := newUserHandler(userService)
 	authHandler := newAuthHandler()
 
 	s3Client := s3infra.NewS3Client(
@@ -55,6 +53,9 @@ func addRoutes(r *chi.Mux) {
 	)
 	mediaService := media.NewMediaService(db, s3Client)
 	mediaHandler := newMediaHandler(mediaService)
+
+	userService := user.NewUserService(db, mediaService)
+	userHandler := newUserHandler(userService)
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/user_handler.go
+++ b/internal/server/user_handler.go
@@ -130,7 +130,7 @@ func (h *UserHandler) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userModel, err := h.userService.UpdateUserByUID(uid, updateUserRequest.Nickname)
+	userModel, err := h.userService.UpdateUserByUID(uid, updateUserRequest.Nickname, updateUserRequest.ProfileImageID)
 	if err != nil {
 		commonviews.InternalServerError(w, nil, err.Error())
 		return
@@ -141,6 +141,7 @@ func (h *UserHandler) UpdateMyProfile(w http.ResponseWriter, r *http.Request) {
 		Email:                userModel.Email,
 		Nickname:             userModel.Nickname,
 		Fullname:             userModel.Fullname,
+		ProfileImageURL:      userModel.ProfileImageURL,
 		FirebaseProviderType: userModel.FirebaseProviderType,
 		FirebaseUID:          userModel.FirebaseUID,
 	})

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/database"
+	"github.com/pet-sitter/pets-next-door-api/internal/media"
+	"github.com/pet-sitter/pets-next-door-api/internal/models"
 	"github.com/pet-sitter/pets-next-door-api/internal/tests"
 	"github.com/pet-sitter/pets-next-door-api/internal/views"
 )
@@ -26,12 +28,19 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+
+			service := NewUserService(db, media_service)
 
 			user := &views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			}
@@ -47,12 +56,18 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+			service := NewUserService(db, media_service)
 
 			user := &views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			}
@@ -71,12 +86,19 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+
+			service := NewUserService(db, media_service)
 
 			user := &views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			}
@@ -97,7 +119,8 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			service := NewUserService(db, media_service)
 
 			_, err := service.FindUserByEmail("non-existent@example.com")
 			if err == nil {
@@ -111,12 +134,19 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+
+			service := NewUserService(db, media_service)
 
 			user := &views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			}
@@ -124,7 +154,6 @@ func TestUserService(t *testing.T) {
 			created, _ := service.RegisterUser(user)
 
 			found, err := service.FindUserByUID(created.FirebaseUID)
-
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -138,7 +167,8 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			service := NewUserService(db, media_service)
 
 			_, err := service.FindUserByUID("non-existent")
 			if err == nil {
@@ -152,12 +182,19 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+
+			service := NewUserService(db, media_service)
 
 			user := &views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			}
@@ -183,12 +220,19 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+
+			service := NewUserService(db, media_service)
 
 			user := &views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			}
@@ -197,7 +241,7 @@ func TestUserService(t *testing.T) {
 
 			updatedNickname := "updated"
 
-			_, err := service.UpdateUserByUID(created.FirebaseUID, updatedNickname)
+			_, err := service.UpdateUserByUID(created.FirebaseUID, updatedNickname, profile_image.ID)
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -218,12 +262,19 @@ func TestUserService(t *testing.T) {
 			tearDown := setUp(t)
 			defer tearDown(t)
 
-			service := NewUserService(db)
+			media_service := media.NewMediaService(db, nil)
+			profile_image, _ := media_service.CreateMedia(&models.Media{
+				MediaType: models.IMAGE_MEDIA_TYPE,
+				URL:       "http://example.com",
+			})
+
+			service := NewUserService(db, media_service)
 
 			owner, _ := service.RegisterUser(&views.RegisterUserRequest{
 				Email:                "test@example.com",
 				Nickname:             "nickname",
 				Fullname:             "fullname",
+				ProfileImageID:       profile_image.ID,
 				FirebaseProviderType: "kakao",
 				FirebaseUID:          "uid",
 			})

--- a/internal/views/user.go
+++ b/internal/views/user.go
@@ -6,6 +6,7 @@ type RegisterUserRequest struct {
 	Email                string                      `json:"email" validate:"required,email"`
 	Nickname             string                      `json:"nickname" validate:"required"`
 	Fullname             string                      `json:"fullname" validate:"required"`
+	ProfileImageID       int                         `json:"profileImageId" validate:"required"`
 	FirebaseProviderType models.FirebaseProviderType `json:"fbProviderType" validate:"required"`
 	FirebaseUID          string                      `json:"fbUid" validate:"required"`
 }
@@ -15,6 +16,7 @@ type RegisterUserResponse struct {
 	Email                string                      `json:"email"`
 	Nickname             string                      `json:"nickname"`
 	Fullname             string                      `json:"fullname"`
+	ProfileImageURL      string                      `json:"profileImageUrl"`
 	FirebaseProviderType models.FirebaseProviderType `json:"fbProviderType"`
 	FirebaseUID          string                      `json:"fbUid"`
 }
@@ -24,6 +26,7 @@ type FindUserResponse struct {
 	Email                string                      `json:"email"`
 	Nickname             string                      `json:"nickname"`
 	Fullname             string                      `json:"fullname"`
+	ProfileImageURL      string                      `json:"profileImageUrl"`
 	FirebaseProviderType models.FirebaseProviderType `json:"fbProviderType"`
 	FirebaseUID          string                      `json:"fbUid"`
 }
@@ -45,7 +48,8 @@ type UserStatusView struct {
 }
 
 type UpdateUserRequest struct {
-	Nickname string `json:"nickname"`
+	Nickname       string `json:"nickname"`
+	ProfileImageID int    `json:"profileImageId"`
 }
 
 type UpdateUserResponse struct {
@@ -53,6 +57,7 @@ type UpdateUserResponse struct {
 	Email                string                      `json:"email"`
 	Nickname             string                      `json:"nickname"`
 	Fullname             string                      `json:"fullname"`
+	ProfileImageURL      string                      `json:"profileImageUrl"`
 	FirebaseProviderType models.FirebaseProviderType `json:"fbProviderType"`
 	FirebaseUID          string                      `json:"fbUid"`
 }

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -479,6 +479,9 @@ const docTemplate = `{
                 },
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageUrl": {
+                    "type": "string"
                 }
             }
         },
@@ -518,7 +521,8 @@ const docTemplate = `{
                 "fbProviderType",
                 "fbUid",
                 "fullname",
-                "nickname"
+                "nickname",
+                "profileImageId"
             ],
             "properties": {
                 "email": {
@@ -535,6 +539,9 @@ const docTemplate = `{
                 },
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageId": {
+                    "type": "integer"
                 }
             }
         },
@@ -558,6 +565,9 @@ const docTemplate = `{
                 },
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageUrl": {
+                    "type": "string"
                 }
             }
         },
@@ -566,6 +576,9 @@ const docTemplate = `{
             "properties": {
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageId": {
+                    "type": "integer"
                 }
             }
         },
@@ -588,6 +601,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "nickname": {
+                    "type": "string"
+                },
+                "profileImageUrl": {
                     "type": "string"
                 }
             }
@@ -637,7 +653,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.2.0",
+	Version:          "0.3.0",
 	Host:             "",
 	BasePath:         "/api",
 	Schemes:          []string{},

--- a/pkg/docs/swagger.json
+++ b/pkg/docs/swagger.json
@@ -12,7 +12,7 @@
             "name": "Apache 2.0",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "0.2.0"
+        "version": "0.3.0"
     },
     "basePath": "/api",
     "paths": {
@@ -471,6 +471,9 @@
                 },
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageUrl": {
+                    "type": "string"
                 }
             }
         },
@@ -510,7 +513,8 @@
                 "fbProviderType",
                 "fbUid",
                 "fullname",
-                "nickname"
+                "nickname",
+                "profileImageId"
             ],
             "properties": {
                 "email": {
@@ -527,6 +531,9 @@
                 },
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageId": {
+                    "type": "integer"
                 }
             }
         },
@@ -550,6 +557,9 @@
                 },
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageUrl": {
+                    "type": "string"
                 }
             }
         },
@@ -558,6 +568,9 @@
             "properties": {
                 "nickname": {
                     "type": "string"
+                },
+                "profileImageId": {
+                    "type": "integer"
                 }
             }
         },
@@ -580,6 +593,9 @@
                     "type": "integer"
                 },
                 "nickname": {
+                    "type": "string"
+                },
+                "profileImageUrl": {
                     "type": "string"
                 }
             }

--- a/pkg/docs/swagger.yaml
+++ b/pkg/docs/swagger.yaml
@@ -121,6 +121,8 @@ definitions:
         type: integer
       nickname:
         type: string
+      profileImageUrl:
+        type: string
     type: object
   views.PetView:
     properties:
@@ -153,12 +155,15 @@ definitions:
         type: string
       nickname:
         type: string
+      profileImageId:
+        type: integer
     required:
     - email
     - fbProviderType
     - fbUid
     - fullname
     - nickname
+    - profileImageId
     type: object
   views.RegisterUserResponse:
     properties:
@@ -174,11 +179,15 @@ definitions:
         type: integer
       nickname:
         type: string
+      profileImageUrl:
+        type: string
     type: object
   views.UpdateUserRequest:
     properties:
       nickname:
         type: string
+      profileImageId:
+        type: integer
     type: object
   views.UpdateUserResponse:
     properties:
@@ -193,6 +202,8 @@ definitions:
       id:
         type: integer
       nickname:
+        type: string
+      profileImageUrl:
         type: string
     type: object
   views.UserRegistrationStatus:
@@ -227,7 +238,7 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: http://swagger.io/terms/
   title: 이웃집멍냥 API 문서
-  version: 0.2.0
+  version: 0.3.0
 paths:
   /auth/callback/kakao:
     get:


### PR DESCRIPTION
## About

사용자 요청/응답에 프로필 이미지를 추가합니다.

흐름은 다음과 같습니다.

1. Media API로 프로필 이미지를 업로드한다.
2. Media API의 응답으로 받은 Media ID를 회원가입 / 정보수정 API가 같이 넘긴다.
3. 응답으로 유저 정보와 더불어 `profileImageUrl`을 받게 된다.