### PR TITLE
Dockerfile에서 go build 간에 모든 .go 파일을 추가합니다.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 COPY go.mod *go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o ./server ./cmd/server/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o ./server ./cmd/server/*.go
 # migration script
-RUN CGO_ENABLED=0 GOOS=linux go build -o ./migrate ./cmd/migrate/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o ./migrate ./cmd/migrate/*.go
 
 # Test stage
 FROM build-stage AS run-test-stage


### PR DESCRIPTION
## About

#13 이후 docker build 간에 다음과 같은 오류가 나는 이슈가 생겼습니다.

```sh
...
 => [build-stage 5/7] COPY . .
 => ERROR [build-stage 6/7] RUN CGO_ENABLED=0 GOOS=linux go build -o ./server ./cmd/server/main.go
------
 > [build-stage 6/7] RUN CGO_ENABLED=0 GOOS=linux go build -o ./server ./cmd/server/main.go:
11.31 # command-line-arguments
11.31 cmd/server/main.go:39:7: undefined: NewRouter
------
Dockerfile:7
--------------------
   5 |     RUN go mod download
   6 |     COPY . .
   7 | >>> RUN CGO_ENABLED=0 GOOS=linux go build -o ./server ./cmd/server/main.go
   8 |     # migration script
   9 |     RUN CGO_ENABLED=0 GOOS=linux go build -o ./migrate ./cmd/migrate/main.go
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -o ./server ./cmd/server/main.go" did not complete successfully: exit code: 1
```

Dockerfile에서 go build 간에 모든 .go 파일을 추가합니다.

## Related

[StackOverflow](https://stackoverflow.com/questions/28153203/undefined-function-declared-in-another-file)