### PR TITLE
CD에 사용되는 Release 태그 이름을 변경합니다.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 on:
   push:
     tags:
-      - release/dev/v*
+      - dev-v*
 
 jobs:
   deploy:


### PR DESCRIPTION
## About

CD에 사용되는 Release 태그 이름을 변경합니다.

- 어차피 release에 올라가는 것 자체가 release라는 뜻이니 `release`는 떼어냅니다.
- URL 상에서 `/`가 escape 처리되어 보기 좋지 않기 때문에 URL 친화적인 `-`로 변경합니다.

### AS-IS

`release/dev/v1`

### TO-BE

`dev-v1`