### PR TITLE
돌봄조건 데이터 적재가 되지 않는 오류를 해결합니다.

### DIFF
--- a/cmd/import_conditions/main.go
+++ b/cmd/import_conditions/main.go
@@ -12,7 +12,6 @@ func main() {
 	log.Println("Starting to import condition")
 
 	db, err := database.Open(configs.DatabaseURL)
-
 	if err != nil {
 		log.Fatalf("error opening database: %v\n", err)
 	}
@@ -20,7 +19,6 @@ func main() {
 	conditionStore := postgres.NewConditionPostgresStore(db)
 
 	result, err := conditionStore.InitConditions(sos_post.ConditionName)
-
 	if err != nil {
 		log.Fatalf("error initializing condition: %v\n", err)
 	}

--- a/db/migrations/000008_create_posts_table.up.sql
+++ b/db/migrations/000008_create_posts_table.up.sql
@@ -29,7 +29,7 @@ CREATE INDEX IF NOT EXISTS resource_media_resource_id ON resource_media (resourc
 
 CREATE TABLE IF NOT EXISTS sos_conditions
 (
-    id         SERIAL PRIMARY KEY,
+    id         INT PRIMARY KEY,
     name       VARCHAR(50),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/internal/postgres/condition_store.go
+++ b/internal/postgres/condition_store.go
@@ -15,41 +15,41 @@ func NewConditionPostgresStore(db *database.DB) *ConditionPostgresStore {
 	}
 }
 
-func (s *ConditionPostgresStore) InitConditions(condition []sos_post.SosCondition) (string, error) {
-	tx, _ := s.db.Begin()
-	for _, v := range condition {
-		var exists bool
-
-		err := tx.QueryRow(`
-		SELECT EXISTS (
-			SELECT 1
-			FROM sos_conditions
-			WHERE name = $1
-		)`, v).Scan(&exists)
-
-		if err != nil {
-			return "condition init error", err
-		}
-
-		if exists {
-			continue
-		}
-
-		_, err = tx.Exec(`
-		INSERT INTO
-			sos_conditions
-			(
-				name,
-				created_at,
-				updated_at
-			)
-		VALUES ($1, NOW(), NOW())
-		`,
-			v,
-		)
+func (s *ConditionPostgresStore) InitConditions(conditions []sos_post.SosCondition) (string, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return "", err
 	}
 
-	tx.Commit()
+	for n, v := range conditions {
+		_, err := tx.Exec(`
+			INSERT INTO sos_conditions 
+				(
+				 	id,
+					name, 
+					created_at, 
+					updated_at
+				)
+				SELECT $1, $2, now(), now()
+				WHERE NOT EXISTS (
+					SELECT 
+						1 
+					FROM 
+						sos_conditions 
+					WHERE 
+						name = $2::VARCHAR(50)
+				);
+		`, n+1, string(v))
+		if err != nil {
+			tx.Rollback()
+			return "", err
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return "", err
+	}
 
 	return "condition init success", nil
 }


### PR DESCRIPTION
## 작업 내용
- sos_condition 테이블의 PK를 SERIAL 타입에서 INT로 변경하였습니다.
혹여나 데이터가 삭제되어 데이터를 재적재할 때  ID(PK) 값이 변경되지 않도록 수정하였습니다.

- enum과 유사한 상수값으로 변경하면서 발생한 타입 불일치 문제를 해결하였습니다.