### PR TITLE
돌봄급구 수정 API 에러를 해결합니다.

### DIFF
--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -41,7 +41,7 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uid, _ := strconv.Atoi(foundUser.FirebaseUID)
+	uid := foundUser.FirebaseUID
 
 	var writeSosPostRequest sos_post.WriteSosPostRequest
 
@@ -144,12 +144,6 @@ func (h *SosPostHandler) FindSosPosts(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} sos_post.FindSosPostResponse
 // @Router /posts/sos/{id} [get]
 func (h *SosPostHandler) FindSosPostByID(w http.ResponseWriter, r *http.Request) {
-	_, err := h.authService.VerifyAuthAndGetUser(r.Context(), r.Header.Get("Authorization"))
-	if err != nil {
-		commonviews.Unauthorized(w, nil, "unauthorized")
-		return
-	}
-
 	SosPostID, err := webutils.ParseIdFromPath(r, "id")
 	if err != nil || SosPostID <= 0 {
 		commonviews.NotFound(w, nil, "invalid sos_post ID")
@@ -181,7 +175,7 @@ func (h *SosPostHandler) UpdateSosPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uid, _ := strconv.Atoi(foundUser.FirebaseUID)
+	uid := foundUser.FirebaseUID
 
 	var updateSosPostRequest sos_post.UpdateSosPostRequest
 	if err := commonviews.ParseBody(w, r, &updateSosPostRequest); err != nil {

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -73,7 +73,6 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 // @Param page query int false "페이지 번호" default(1)
 // @Param size query int false "페이지 사이즈" default(20)
 // @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
-// @Security FirebaseAuth
 // @Success 200 {object} commonviews.PaginatedView[sos_post.FindSosPostResponse]
 // @Router /posts/sos [get]
 func (h *SosPostHandler) FindSosPosts(w http.ResponseWriter, r *http.Request) {
@@ -141,11 +140,16 @@ func (h *SosPostHandler) FindSosPosts(w http.ResponseWriter, r *http.Request) {
 // @Tags posts
 // @Accept  json
 // @Produce  json
-// @Security FirebaseAuth
 // @Param id path string true "게시글 ID"
 // @Success 200 {object} sos_post.FindSosPostResponse
 // @Router /posts/sos/{id} [get]
 func (h *SosPostHandler) FindSosPostByID(w http.ResponseWriter, r *http.Request) {
+	_, err := h.authService.VerifyAuthAndGetUser(r.Context(), r.Header.Get("Authorization"))
+	if err != nil {
+		commonviews.Unauthorized(w, nil, "unauthorized")
+		return
+	}
+
 	SosPostID, err := webutils.ParseIdFromPath(r, "id")
 	if err != nil || SosPostID <= 0 {
 		commonviews.NotFound(w, nil, "invalid sos_post ID")

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -41,8 +41,6 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uid := foundUser.FirebaseUID
-
 	var writeSosPostRequest sos_post.WriteSosPostRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&writeSosPostRequest); err != nil {
@@ -54,7 +52,7 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := h.sosPostService.WriteSosPost(uid, &writeSosPostRequest)
+	res, err := h.sosPostService.WriteSosPost(foundUser.FirebaseUID, &writeSosPostRequest)
 	if err != nil {
 		commonviews.InternalServerError(w, nil, err.Error())
 		return
@@ -175,14 +173,12 @@ func (h *SosPostHandler) UpdateSosPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uid := foundUser.FirebaseUID
-
 	var updateSosPostRequest sos_post.UpdateSosPostRequest
 	if err := commonviews.ParseBody(w, r, &updateSosPostRequest); err != nil {
 		return
 	}
 
-	permission := h.sosPostService.CheckUpdatePermission(uid, updateSosPostRequest.ID)
+	permission := h.sosPostService.CheckUpdatePermission(foundUser.FirebaseUID, updateSosPostRequest.ID)
 
 	if !permission {
 		commonviews.Forbidden(w, nil, "forbidden")

--- a/internal/domain/sos_post/service.go
+++ b/internal/domain/sos_post/service.go
@@ -21,8 +21,8 @@ func NewSosPostService(sosPostStore SosPostStore, resourceMediaStore media.Resou
 	}
 }
 
-func (service *SosPostService) WriteSosPost(uid string, request *WriteSosPostRequest) (*WriteSosPostResponse, error) {
-	userID, err := service.userStore.FindUserIDByUID(uid)
+func (service *SosPostService) WriteSosPost(fbUid string, request *WriteSosPostRequest) (*WriteSosPostResponse, error) {
+	userID, err := service.userStore.FindUserIDByFbUID(fbUid)
 	if err != nil {
 		return nil, err
 	}
@@ -445,8 +445,8 @@ func (service *SosPostService) UpdateSosPost(request *UpdateSosPostRequest) (*Up
 	}, nil
 }
 
-func (service *SosPostService) CheckUpdatePermission(uid string, sosPostID int) bool {
-	userID, _ := service.userStore.FindUserIDByUID(uid)
+func (service *SosPostService) CheckUpdatePermission(fbUid string, sosPostID int) bool {
+	userID, _ := service.userStore.FindUserIDByFbUID(fbUid)
 	sosPost, _ := service.sosPostStore.FindSosPostByID(sosPostID)
 	if sosPost.AuthorID != userID {
 		return false

--- a/internal/domain/sos_post/service.go
+++ b/internal/domain/sos_post/service.go
@@ -435,7 +435,8 @@ func (service *SosPostService) UpdateSosPost(request *UpdateSosPostRequest) (*Up
 	}, nil
 }
 
-func (service *SosPostService) CheckUpdatePermission(userID int, sosPostID int) bool {
+func (service *SosPostService) CheckUpdatePermission(uid int, sosPostID int) bool {
+	userID, _ := service.userStore.FindUserIDByUID(uid)
 	sosPost, _ := service.sosPostStore.FindSosPostByID(sosPostID)
 	if sosPost.AuthorID != userID {
 		return false

--- a/internal/domain/sos_post/service.go
+++ b/internal/domain/sos_post/service.go
@@ -21,7 +21,7 @@ func NewSosPostService(sosPostStore SosPostStore, resourceMediaStore media.Resou
 	}
 }
 
-func (service *SosPostService) WriteSosPost(uid int, request *WriteSosPostRequest) (*WriteSosPostResponse, error) {
+func (service *SosPostService) WriteSosPost(uid string, request *WriteSosPostRequest) (*WriteSosPostResponse, error) {
 	userID, err := service.userStore.FindUserIDByUID(uid)
 	if err != nil {
 		return nil, err
@@ -445,7 +445,7 @@ func (service *SosPostService) UpdateSosPost(request *UpdateSosPostRequest) (*Up
 	}, nil
 }
 
-func (service *SosPostService) CheckUpdatePermission(uid int, sosPostID int) bool {
+func (service *SosPostService) CheckUpdatePermission(uid string, sosPostID int) bool {
 	userID, _ := service.userStore.FindUserIDByUID(uid)
 	sosPost, _ := service.sosPostStore.FindSosPostByID(sosPostID)
 	if sosPost.AuthorID != userID {

--- a/internal/domain/sos_post/service.go
+++ b/internal/domain/sos_post/service.go
@@ -21,8 +21,8 @@ func NewSosPostService(sosPostStore SosPostStore, resourceMediaStore media.Resou
 	}
 }
 
-func (service *SosPostService) WriteSosPost(authorID int, request *WriteSosPostRequest) (*WriteSosPostResponse, error) {
-	userID, err := service.userStore.FindUserIDByUID(authorID)
+func (service *SosPostService) WriteSosPost(uid int, request *WriteSosPostRequest) (*WriteSosPostResponse, error) {
+	userID, err := service.userStore.FindUserIDByUID(uid)
 	if err != nil {
 		return nil, err
 	}
@@ -104,6 +104,8 @@ func (service *SosPostService) WriteSosPost(authorID int, request *WriteSosPostR
 		CarerGender:  sosPost.CarerGender,
 		RewardAmount: sosPost.RewardAmount,
 		ThumbnailID:  sosPost.ThumbnailID,
+		CreatedAt:    sosPost.CreatedAt,
+		UpdatedAt:    sosPost.UpdatedAt,
 	}, nil
 }
 
@@ -185,6 +187,8 @@ func (service *SosPostService) FindSosPosts(page int, size int, sortBy string) (
 			CarerGender:  sosPost.CarerGender,
 			RewardAmount: sosPost.RewardAmount,
 			ThumbnailID:  sosPost.ThumbnailID,
+			CreatedAt:    sosPost.CreatedAt,
+			UpdatedAt:    sosPost.UpdatedAt,
 		}
 
 		FindSosPostResponseList = append(FindSosPostResponseList, *findByAuthorSosPostResponse)
@@ -271,6 +275,8 @@ func (service *SosPostService) FindSosPostsByAuthorID(authorID int, page int, si
 			CarerGender:  sosPost.CarerGender,
 			RewardAmount: sosPost.RewardAmount,
 			ThumbnailID:  sosPost.ThumbnailID,
+			CreatedAt:    sosPost.CreatedAt,
+			UpdatedAt:    sosPost.UpdatedAt,
 		}
 
 		FindSosPostResponseList = append(FindSosPostResponseList, *findByAuthorSosPostResponse)
@@ -354,6 +360,8 @@ func (service *SosPostService) FindSosPostByID(id int) (*FindSosPostResponse, er
 		CarerGender:  sosPost.CarerGender,
 		RewardAmount: sosPost.RewardAmount,
 		ThumbnailID:  sosPost.ThumbnailID,
+		CreatedAt:    sosPost.CreatedAt,
+		UpdatedAt:    sosPost.UpdatedAt,
 	}, nil
 }
 
@@ -432,6 +440,8 @@ func (service *SosPostService) UpdateSosPost(request *UpdateSosPostRequest) (*Up
 		CarerGender:  updateSosPost.CarerGender,
 		RewardAmount: updateSosPost.RewardAmount,
 		ThumbnailID:  updateSosPost.ThumbnailID,
+		CreatedAt:    updateSosPost.CreatedAt,
+		UpdatedAt:    updateSosPost.UpdatedAt,
 	}, nil
 }
 

--- a/internal/domain/sos_post/view.go
+++ b/internal/domain/sos_post/view.go
@@ -39,6 +39,8 @@ type WriteSosPostResponse struct {
 	CarerGender  CarerGender       `json:"carer_gender"`
 	RewardAmount RewardAmount      `json:"reward_amount"`
 	ThumbnailID  int               `json:"thumbnail_id"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
 }
 
 type FindSosPostResponse struct {
@@ -58,6 +60,8 @@ type FindSosPostResponse struct {
 	CarerGender  CarerGender       `json:"carer_gender"`
 	RewardAmount RewardAmount      `json:"reward_amount"`
 	ThumbnailID  int               `json:"thumbnail_id"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
 }
 
 type UpdateSosPostRequest struct {
@@ -94,4 +98,6 @@ type UpdateSosPostResponse struct {
 	CarerGender  CarerGender       `json:"carer_gender"`
 	RewardAmount RewardAmount      `json:"reward_amount"`
 	ThumbnailID  int               `json:"thumbnail_id"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
 }

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -45,7 +45,7 @@ type UserStore interface {
 	CreateUser(request *RegisterUserRequest) (*User, error)
 	FindUserByEmail(email string) (*UserWithProfileImage, error)
 	FindUserByUID(uid string) (*UserWithProfileImage, error)
-	FindUserIDByUID(uid string) (int, error)
+	FindUserIDByFbUID(fbUid string) (int, error)
 	ExistsByNickname(nickname string) (bool, error)
 	FindUserStatusByEmail(email string) (*UserStatus, error)
 	UpdateUserByUID(uid string, nickname string, profileImageID int) (*User, error)

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -45,7 +45,7 @@ type UserStore interface {
 	CreateUser(request *RegisterUserRequest) (*User, error)
 	FindUserByEmail(email string) (*UserWithProfileImage, error)
 	FindUserByUID(uid string) (*UserWithProfileImage, error)
-	FindUserIDByUID(uid int) (int, error)
+	FindUserIDByUID(uid string) (int, error)
 	ExistsByNickname(nickname string) (bool, error)
 	FindUserStatusByEmail(email string) (*UserStatus, error)
 	UpdateUserByUID(uid string, nickname string, profileImageID int) (*User, error)

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -146,7 +146,7 @@ func (s *UserPostgresStore) FindUserByUID(uid string) (*user.UserWithProfileImag
 	return user, nil
 }
 
-func (s *UserPostgresStore) FindUserIDByUID(uid string) (int, error) {
+func (s *UserPostgresStore) FindUserIDByFbUID(fbUid string) (int, error) {
 	var UserID int
 
 	tx, _ := s.db.Begin()
@@ -159,7 +159,7 @@ func (s *UserPostgresStore) FindUserIDByUID(uid string) (int, error) {
 		fb_uid = $1 AND
 		deleted_at IS NULL
 	`,
-		uid,
+		fbUid,
 	).Scan(&UserID)
 	tx.Commit()
 

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -146,7 +146,7 @@ func (s *UserPostgresStore) FindUserByUID(uid string) (*user.UserWithProfileImag
 	return user, nil
 }
 
-func (s *UserPostgresStore) FindUserIDByUID(uid int) (int, error) {
+func (s *UserPostgresStore) FindUserIDByUID(uid string) (int, error) {
 	var UserID int
 
 	tx, _ := s.db.Begin()

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -809,6 +809,9 @@ const docTemplate = `{
                 "content": {
                     "type": "string"
                 },
+                "created_at": {
+                    "type": "string"
+                },
                 "date_end_at": {
                     "type": "string"
                 },
@@ -846,6 +849,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -1062,6 +1068,9 @@ const docTemplate = `{
                 "content": {
                     "type": "string"
                 },
+                "created_at": {
+                    "type": "string"
+                },
                 "date_end_at": {
                     "type": "string"
                 },
@@ -1099,6 +1108,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -162,11 +162,6 @@ const docTemplate = `{
         },
         "/posts/sos": {
             "get": {
-                "security": [
-                    {
-                        "FirebaseAuth": []
-                    }
-                ],
                 "consumes": [
                     "application/json"
                 ],
@@ -290,11 +285,6 @@ const docTemplate = `{
         },
         "/posts/sos/{id}": {
             "get": {
-                "security": [
-                    {
-                        "FirebaseAuth": []
-                    }
-                ],
                 "consumes": [
                     "application/json"
                 ],

--- a/pkg/docs/swagger.json
+++ b/pkg/docs/swagger.json
@@ -802,6 +802,9 @@
                 "content": {
                     "type": "string"
                 },
+                "created_at": {
+                    "type": "string"
+                },
                 "date_end_at": {
                     "type": "string"
                 },
@@ -839,6 +842,9 @@
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -1055,6 +1061,9 @@
                 "content": {
                     "type": "string"
                 },
+                "created_at": {
+                    "type": "string"
+                },
                 "date_end_at": {
                     "type": "string"
                 },
@@ -1092,6 +1101,9 @@
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }

--- a/pkg/docs/swagger.json
+++ b/pkg/docs/swagger.json
@@ -155,11 +155,6 @@
         },
         "/posts/sos": {
             "get": {
-                "security": [
-                    {
-                        "FirebaseAuth": []
-                    }
-                ],
                 "consumes": [
                     "application/json"
                 ],
@@ -283,11 +278,6 @@
         },
         "/posts/sos/{id}": {
             "get": {
-                "security": [
-                    {
-                        "FirebaseAuth": []
-                    }
-                ],
                 "consumes": [
                     "application/json"
                 ],

--- a/pkg/docs/swagger.yaml
+++ b/pkg/docs/swagger.yaml
@@ -635,8 +635,6 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/commonviews.PaginatedView-sos_post_FindSosPostResponse'
-      security:
-      - FirebaseAuth: []
       summary: 돌봄급구 게시글을 조회합니다.
       tags:
       - posts
@@ -699,8 +697,6 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/sos_post.FindSosPostResponse'
-      security:
-      - FirebaseAuth: []
       summary: 게시글 ID로 돌봄급구 게시글을 조회합니다.
       tags:
       - posts

--- a/pkg/docs/swagger.yaml
+++ b/pkg/docs/swagger.yaml
@@ -182,6 +182,8 @@ definitions:
         type: array
       content:
         type: string
+      created_at:
+        type: string
       date_end_at:
         type: string
       date_start_at:
@@ -207,6 +209,8 @@ definitions:
       time_start_at:
         type: string
       title:
+        type: string
+      updated_at:
         type: string
     type: object
   sos_post.RewardAmount:
@@ -348,6 +352,8 @@ definitions:
         type: array
       content:
         type: string
+      created_at:
+        type: string
       date_end_at:
         type: string
       date_start_at:
@@ -373,6 +379,8 @@ definitions:
       time_start_at:
         type: string
       title:
+        type: string
+      updated_at:
         type: string
     type: object
   user.CheckNicknameRequest:


### PR DESCRIPTION
## 작업내용

- 돌봄급구 수정 API에서 상황에 맞지 않게 403 에러가 반환되는 이슈를 수정하였습니다.
- 게시글 조회 Response 타입에 created_at, updated_at 를 추가하였습니다.
- Swagger 돌봄급구 API에서 불필요한 Security를 제거하였습니다.

## 테스트

_/posts/sos [PUT]_

Request (예시)
```
{
  "care_type": "foster",
  "carer_gender": "male",
  "condition_ids": [
    1, 2, 3
  ],
  "content": "content",
  "date_end_at": "2020-10-06T10:00:00+09:00",
  "date_start_at": "2020-10-16T18:00:00+09:00",
	"id": 1,
  "image_ids": [
    1
  ],
  "pet_ids": [
    1
  ],
  "reward": "string",
  "reward_amount": "hour",
  "time_end_at": "10:00",
  "time_start_at": "18:00",
  "title": "title"
}
```