### PR TITLE
사용자 목록 조회 API를 추가합니다.

### DIFF
--- a/cmd/server/handler/breed_handler.go
+++ b/cmd/server/handler/breed_handler.go
@@ -2,9 +2,9 @@ package handler
 
 import (
 	"github.com/pet-sitter/pets-next-door-api/api/commonviews"
+	webutils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"net/http"
-	"strconv"
 )
 
 type BreedHandler struct {
@@ -27,28 +27,12 @@ func NewBreedHandler(breedService *pet.BreedService) *BreedHandler {
 // @Success 200 {object} commonviews.PaginatedView[pet.BreedView]
 // @Router /breeds [get]
 func (h *BreedHandler) FindBreeds(w http.ResponseWriter, r *http.Request) {
-	pageQuery := r.URL.Query().Get("page")
-	sizeQuery := r.URL.Query().Get("size")
 	petTypeQuery := r.URL.Query().Get("pet_type")
 
-	page := 1
-	size := 20
-	var err error
-
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			commonviews.BadRequest(w, nil, err.Error())
-			return
-		}
-	}
-
-	if sizeQuery != "" {
-		size, err = strconv.Atoi(sizeQuery)
-		if err != nil {
-			commonviews.BadRequest(w, nil, err.Error())
-			return
-		}
+	page, size, err := webutils.ParsePaginationQueries(r, 1, 20)
+	if err != nil {
+		commonviews.BadRequest(w, nil, err.Error())
+		return
 	}
 
 	var petType *string

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -1,11 +1,9 @@
 package handler
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 
-	"github.com/go-playground/validator"
 	"github.com/pet-sitter/pets-next-door-api/api/commonviews"
 	webutils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/auth"
@@ -42,13 +40,7 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var writeSosPostRequest sos_post.WriteSosPostRequest
-
-	if err := json.NewDecoder(r.Body).Decode(&writeSosPostRequest); err != nil {
-		commonviews.BadRequest(w, nil, err.Error())
-		return
-	}
-	if err := validator.New().Struct(writeSosPostRequest); err != nil {
-		commonviews.BadRequest(w, nil, err.Error())
+	if err := commonviews.ParseBody(w, r, &writeSosPostRequest); err != nil {
 		return
 	}
 

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -24,7 +24,7 @@ func NewSosPostHandler(sosPostService sos_post.SosPostService, authService auth.
 	}
 }
 
-// writeSosPost godoc
+// WriteSosPost godoc
 // @Summary 돌봄급구 게시글을 업로드합니다.
 // @Description
 // @Tags posts
@@ -61,7 +61,7 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 	commonviews.Created(w, nil, res)
 }
 
-// findSosPosts godoc
+// FindSosPosts godoc
 // @Summary 돌봄급구 게시글을 조회합니다.
 // @Description
 // @Tags posts
@@ -116,7 +116,7 @@ func (h *SosPostHandler) FindSosPosts(w http.ResponseWriter, r *http.Request) {
 	commonviews.OK(w, nil, commonviews.NewPaginatedView(page, size, res))
 }
 
-// findSosPostsByID godoc
+// FindSosPostByID godoc
 // @Summary 게시글 ID로 돌봄급구 게시글을 조회합니다.
 // @Description
 // @Tags posts
@@ -140,7 +140,7 @@ func (h *SosPostHandler) FindSosPostByID(w http.ResponseWriter, r *http.Request)
 	commonviews.OK(w, nil, res)
 }
 
-// updateSosPost godoc
+// UpdateSosPost godoc
 // @Summary 돌봄급구 게시글을 수정합니다.
 // @Description
 // @Tags posts

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -75,28 +75,12 @@ func (h *SosPostHandler) WriteSosPost(w http.ResponseWriter, r *http.Request) {
 // @Router /posts/sos [get]
 func (h *SosPostHandler) FindSosPosts(w http.ResponseWriter, r *http.Request) {
 	authorIDQuery := r.URL.Query().Get("author_id")
-	pageQuery := r.URL.Query().Get("page")
-	sizeQuery := r.URL.Query().Get("size")
 	sortByQuery := r.URL.Query().Get("sort_by")
 
-	page := 1
-	size := 20
-
-	var err error
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			commonviews.BadRequest(w, nil, err.Error())
-			return
-		}
-	}
-
-	if sizeQuery != "" {
-		size, err = strconv.Atoi(sizeQuery)
-		if err != nil {
-			commonviews.BadRequest(w, nil, err.Error())
-			return
-		}
+	page, size, err := webutils.ParsePaginationQueries(r, 1, 20)
+	if err != nil {
+		commonviews.BadRequest(w, nil, err.Error())
+		return
 	}
 
 	var res []sos_post.FindSosPostResponse

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -2,14 +2,13 @@ package handler
 
 import (
 	"encoding/json"
-	"net/http"
-	"strconv"
-
 	"github.com/go-playground/validator"
 	"github.com/pet-sitter/pets-next-door-api/api/commonviews"
+	webutils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/auth"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
+	"net/http"
 )
 
 type UserHandler struct {
@@ -124,27 +123,12 @@ func (h *UserHandler) FindUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pageQuery := r.URL.Query().Get("page")
-	sizeQuery := r.URL.Query().Get("size")
 	nicknameQuery := r.URL.Query().Get("nickname")
 
-	page := 1
-	size := 10
-
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			commonviews.BadRequest(w, nil, err.Error())
-			return
-		}
-	}
-
-	if sizeQuery != "" {
-		size, err = strconv.Atoi(sizeQuery)
-		if err != nil {
-			commonviews.BadRequest(w, nil, err.Error())
-			return
-		}
+	page, size, err := webutils.ParsePaginationQueries(r, 1, 10)
+	if err != nil {
+		commonviews.BadRequest(w, nil, err.Error())
+		return
 	}
 
 	var res []*user.UserWithoutPrivateInfo

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"encoding/json"
-	"github.com/go-playground/validator"
 	"github.com/pet-sitter/pets-next-door-api/api/commonviews"
 	webutils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/auth"
@@ -34,12 +32,7 @@ func NewUserHandler(userService user.UserServicer, authService auth.AuthService)
 // @Router /users [post]
 func (h *UserHandler) RegisterUser(w http.ResponseWriter, r *http.Request) {
 	var registerUserRequest user.RegisterUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&registerUserRequest); err != nil {
-		commonviews.BadRequest(w, nil, err.Error())
-		return
-	}
-	if err := validator.New().Struct(registerUserRequest); err != nil {
-		commonviews.BadRequest(w, nil, err.Error())
+	if err := commonviews.ParseBody(w, r, &registerUserRequest); err != nil {
 		return
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 // @title 이웃집멍냥 API 문서
-// @version 0.6.0
+// @version 0.7.0
 // @description 이웃집멍냥 백엔드 API 문서입니다.
 // @termsOfService http://swagger.io/terms/
 

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -102,6 +102,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) *chi.Mux {
 			r.Post("/", userHandler.RegisterUser)
 			r.Post("/check/nickname", userHandler.CheckUserNickname)
 			r.Post("/status", userHandler.FindUserStatusByEmail)
+			r.Get("/", userHandler.FindUsers)
 			r.Get("/me", userHandler.FindMyProfile)
 			r.Put("/me", userHandler.UpdateMyProfile)
 			r.Get("/me/pets", userHandler.FindMyPets)

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db_test:
-    image: postgres:11.5-alpine
+    image: postgres:15-alpine
     ports:
       - "5455:5432"
     environment:
@@ -20,7 +20,7 @@ services:
       retries: 5
 
   migrate:
-    image: migrate/migrate:v4.7.0
+    image: migrate/migrate:v4.17.0
     depends_on:
       db_test:
         condition: service_healthy

--- a/internal/common/web.go
+++ b/internal/common/web.go
@@ -10,3 +10,28 @@ import (
 func ParseIdFromPath(r *http.Request, path string) (int, error) {
 	return strconv.Atoi(chi.URLParam(r, path))
 }
+
+// ParsePaginationQueries parses pagination parameters from query string: page, size.
+func ParsePaginationQueries(r *http.Request, defaultPage int, defaultLimit int) (page int, size int, err error) {
+	pageQuery := r.URL.Query().Get("page")
+	sizeQuery := r.URL.Query().Get("size")
+
+	page = defaultPage
+	size = defaultLimit
+
+	if pageQuery != "" {
+		page, err = strconv.Atoi(pageQuery)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	if sizeQuery != "" {
+		size, err = strconv.Atoi(sizeQuery)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	return page, size, nil
+}

--- a/internal/domain/pet/breed_service.go
+++ b/internal/domain/pet/breed_service.go
@@ -16,7 +16,7 @@ func (service *BreedService) FindBreeds(page int, size int, petType *string) ([]
 		return nil, err
 	}
 
-	var breedViews []*BreedView
+	breedViews := make([]*BreedView, 0)
 	for _, breed := range breeds {
 		breedViews = append(breedViews, &BreedView{
 			ID:      breed.ID,

--- a/internal/domain/user/service.go
+++ b/internal/domain/user/service.go
@@ -21,6 +21,7 @@ func NewUserService(userStore UserStore, petStore pet.PetStore, mediaService med
 
 type UserServicer interface {
 	RegisterUser(registerUserRequest *RegisterUserRequest) (*RegisterUserResponse, error)
+	FindUsers(page int, size int, nickname *string) ([]*UserWithoutPrivateInfo, error)
 	FindUserByEmail(email string) (*UserWithProfileImage, error)
 	FindUserByUID(uid string) (*FindUserResponse, error)
 	ExistsByNickname(nickname string) (bool, error)
@@ -54,6 +55,15 @@ func (service *UserService) RegisterUser(registerUserRequest *RegisterUserReques
 		FirebaseProviderType: created.FirebaseProviderType,
 		FirebaseUID:          created.FirebaseUID,
 	}, nil
+}
+
+func (service *UserService) FindUsers(page int, size int, nickname *string) ([]*UserWithoutPrivateInfo, error) {
+	usersData, err := service.userStore.FindUsers(page, size, nickname)
+	if err != nil {
+		return nil, err
+	}
+
+	return usersData, nil
 }
 
 func (service *UserService) FindUserByEmail(email string) (*UserWithProfileImage, error) {

--- a/internal/domain/user/tests/service_test.go
+++ b/internal/domain/user/tests/service_test.go
@@ -1,6 +1,7 @@
 package user_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
@@ -107,12 +108,12 @@ func TestUserService(t *testing.T) {
 			service.RegisterUser(targetUserRequest)
 			for i := 0; i < 2; i++ {
 				service.RegisterUser(&user.RegisterUserRequest{
-					Email:                "test" + string(rune(i)) + "@example.com",
-					Nickname:             "nickname" + string(rune(i)),
-					Fullname:             "fullname" + string(rune(i)),
+					Email:                fmt.Sprintf("test%d@example.com", i),
+					Nickname:             fmt.Sprintf("nickname%d", i),
+					Fullname:             fmt.Sprintf("fullname%d", i),
 					ProfileImageID:       profile_image.ID,
 					FirebaseProviderType: "kakao",
-					FirebaseUID:          "uid" + string(rune(i)),
+					FirebaseUID:          fmt.Sprintf("uid%d", i),
 				})
 			}
 

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -37,12 +37,19 @@ type UserWithProfileImage struct {
 	DeletedAt            string               `field:"deleted_at"`
 }
 
+type UserWithoutPrivateInfo struct {
+	ID              int    `field:"id" json:"id"`
+	Nickname        string `field:"nickname" json:"nickname"`
+	ProfileImageURL string `field:"profile_image_url" json:"profileImageUrl"`
+}
+
 type UserStatus struct {
 	FirebaseProviderType FirebaseProviderType `field:"fb_provider_type"`
 }
 
 type UserStore interface {
 	CreateUser(request *RegisterUserRequest) (*User, error)
+	FindUsers(page int, size int, nickname *string) ([]*UserWithoutPrivateInfo, error)
 	FindUserByEmail(email string) (*UserWithProfileImage, error)
 	FindUserByUID(uid string) (*UserWithProfileImage, error)
 	FindUserIDByFbUID(fbUid string) (int, error)

--- a/internal/postgres/breed_store.go
+++ b/internal/postgres/breed_store.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"fmt"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
@@ -32,21 +31,14 @@ func (s *BreedPostgresStore) FindBreeds(page int, size int, petType *string) ([]
 	FROM
 		breeds
 	WHERE
+	    (pet_type = $1 OR $1 IS NULL) AND
 		deleted_at IS NULL
+	ORDER BY id ASC
+	LIMIT $2
+	OFFSET $3
 	`
 
-	if petType != nil {
-		query += fmt.Sprintf(" AND pet_type = '%s'", *petType)
-	}
-
-	query += `
-		ORDER BY id ASC
-	`
-
-	query += fmt.Sprintf(" LIMIT %d", size)
-	query += fmt.Sprintf(" OFFSET %d", (page-1)*size)
-
-	rows, err := tx.Query(query)
+	rows, err := tx.Query(query, petType, size, (page-1)*size)
 
 	if err != nil {
 		return nil, err

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -316,6 +316,50 @@ const docTemplate = `{
             }
         },
         "/users": {
+            "get": {
+                "security": [
+                    {
+                        "FirebaseAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "사용자 목록을 조회합니다.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "페이지 번호",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "페이지 사이즈",
+                        "name": "size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "닉네임 (완전 일치)",
+                        "name": "nickname",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/commonviews.PaginatedView-user_UserWithoutPrivateInfo"
+                        }
+                    }
+                }
+            },
             "post": {
                 "consumes": [
                     "application/json"
@@ -579,6 +623,23 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/sos_post.FindSosPostResponse"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "commonviews.PaginatedView-user_UserWithoutPrivateInfo": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.UserWithoutPrivateInfo"
                     }
                 },
                 "page": {
@@ -1296,6 +1357,20 @@ const docTemplate = `{
                     "$ref": "#/definitions/user.UserRegistrationStatus"
                 }
             }
+        },
+        "user.UserWithoutPrivateInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "profileImageUrl": {
+                    "type": "string"
+                }
+            }
         }
     },
     "securityDefinitions": {
@@ -1309,7 +1384,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.6.0",
+	Version:          "0.7.0",
 	Host:             "",
 	BasePath:         "/api",
 	Schemes:          []string{},

--- a/pkg/docs/swagger.json
+++ b/pkg/docs/swagger.json
@@ -12,7 +12,7 @@
             "name": "Apache 2.0",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "0.6.0"
+        "version": "0.7.0"
     },
     "basePath": "/api",
     "paths": {
@@ -308,6 +308,50 @@
             }
         },
         "/users": {
+            "get": {
+                "security": [
+                    {
+                        "FirebaseAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "사용자 목록을 조회합니다.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "페이지 번호",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "페이지 사이즈",
+                        "name": "size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "닉네임 (완전 일치)",
+                        "name": "nickname",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/commonviews.PaginatedView-user_UserWithoutPrivateInfo"
+                        }
+                    }
+                }
+            },
             "post": {
                 "consumes": [
                     "application/json"
@@ -571,6 +615,23 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/sos_post.FindSosPostResponse"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "commonviews.PaginatedView-user_UserWithoutPrivateInfo": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.UserWithoutPrivateInfo"
                     }
                 },
                 "page": {
@@ -1286,6 +1347,20 @@
                 },
                 "status": {
                     "$ref": "#/definitions/user.UserRegistrationStatus"
+                }
+            }
+        },
+        "user.UserWithoutPrivateInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "profileImageUrl": {
+                    "type": "string"
                 }
             }
         }

--- a/pkg/docs/swagger.yaml
+++ b/pkg/docs/swagger.yaml
@@ -35,6 +35,17 @@ definitions:
       size:
         type: integer
     type: object
+  commonviews.PaginatedView-user_UserWithoutPrivateInfo:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/user.UserWithoutPrivateInfo'
+        type: array
+      page:
+        type: integer
+      size:
+        type: integer
+    type: object
   media.MediaType:
     enum:
     - image
@@ -505,6 +516,15 @@ definitions:
       status:
         $ref: '#/definitions/user.UserRegistrationStatus'
     type: object
+  user.UserWithoutPrivateInfo:
+    properties:
+      id:
+        type: integer
+      nickname:
+        type: string
+      profileImageUrl:
+        type: string
+    type: object
 info:
   contact:
     email: petsnextdoordev@gmail.com
@@ -515,7 +535,7 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: http://swagger.io/terms/
   title: 이웃집멍냥 API 문서
-  version: 0.6.0
+  version: 0.7.0
 paths:
   /auth/callback/kakao:
     get:
@@ -705,6 +725,34 @@ paths:
       tags:
       - posts
   /users:
+    get:
+      parameters:
+      - default: 1
+        description: 페이지 번호
+        in: query
+        name: page
+        type: integer
+      - default: 10
+        description: 페이지 사이즈
+        in: query
+        name: size
+        type: integer
+      - description: 닉네임 (완전 일치)
+        in: query
+        name: nickname
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/commonviews.PaginatedView-user_UserWithoutPrivateInfo'
+      security:
+      - FirebaseAuth: []
+      summary: 사용자 목록을 조회합니다.
+      tags:
+      - users
     post:
       consumes:
       - application/json


### PR DESCRIPTION
## About

사용자 목록 조회 API를 추가합니다.

`GET /api/users`로 접근 가능하며, nickname 쿼리를 받아 일치하는 유저를 조회합니다. 아무것도 안넣으면 전체 검색으로 진행됩니다.

- 응답에서 민감 정보는 모두 제외했지만, 일단 인증을 필요로 하도록 했습니다.

- 추가로 기존 견/묘종 목록 조회 API에서 SQL injection 가능성이 있어 해당 부분을 수정하고, 아무 견/묘종이 없을 경우 빈 배열 대신 null이 나가고 있어서 해당 부분을 수정합니다.

- API 버전은 0.7.0으로 올립니다.

- Test DB docker-compose의 pg, migrate 버전도 로컬 개발 DB에 맞게 올립니다.