### PR TITLE
돌봄급구 SQL Injection 문제를 해결합니다.

### DIFF
--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -86,7 +86,7 @@ func (h *SosPostHandler) FindSosPosts(w http.ResponseWriter, r *http.Request) {
 
 	var res *sos_post.FindSosPostListView
 	if authorID != nil {
-		res, err = h.sosPostService.FindSosPostsByAuthorID(*authorID, page, size)
+		res, err = h.sosPostService.FindSosPostsByAuthorID(*authorID, page, size, sortBy)
 		if err != nil {
 			render.Render(w, r, err)
 			return

--- a/internal/domain/sos_post/service.go
+++ b/internal/domain/sos_post/service.go
@@ -200,8 +200,8 @@ func (service *SosPostService) FindSosPosts(page int, size int, sortBy string) (
 	return findSosPostViews, nil
 }
 
-func (service *SosPostService) FindSosPostsByAuthorID(authorID int, page int, size int) (*FindSosPostListView, *pnd.AppError) {
-	sosPosts, err := service.sosPostStore.FindSosPostsByAuthorID(authorID, page, size)
+func (service *SosPostService) FindSosPostsByAuthorID(authorID int, page int, size int, sortBy string) (*FindSosPostListView, *pnd.AppError) {
+	sosPosts, err := service.sosPostStore.FindSosPostsByAuthorID(authorID, page, size, sortBy)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/sos_post/sos_post.go
+++ b/internal/domain/sos_post/sos_post.go
@@ -57,7 +57,7 @@ func NewSosPostList(page int, size int) *SosPostList {
 type SosPostStore interface {
 	WriteSosPost(authorID int, utcDateStart string, utcDateEnd string, request *WriteSosPostRequest) (*SosPost, *pnd.AppError)
 	FindSosPosts(page int, size int, sortBy string) (*SosPostList, *pnd.AppError)
-	FindSosPostsByAuthorID(authorID int, page int, size int) (*SosPostList, *pnd.AppError)
+	FindSosPostsByAuthorID(authorID int, page int, size int, sortBy string) (*SosPostList, *pnd.AppError)
 	FindSosPostByID(id int) (*SosPost, *pnd.AppError)
 	UpdateSosPost(request *UpdateSosPostRequest) (*SosPost, *pnd.AppError)
 	FindConditionByID(id int) ([]Condition, *pnd.AppError)

--- a/internal/domain/sos_post/tests/service_test.go
+++ b/internal/domain/sos_post/tests/service_test.go
@@ -414,44 +414,46 @@ func TestSosPostService(t *testing.T) {
 				sosPosts = append(sosPosts, *sosPost)
 			}
 
-			sosPostListByAuthorID, err := sosPostService.FindSosPostsByAuthorID(owner.ID, 1, 3)
+			sosPostListByAuthorID, err := sosPostService.FindSosPostsByAuthorID(owner.ID, 1, 3, "newest")
 			for i, sosPost := range sosPostListByAuthorID.Items {
 				assertConditionEquals(t, sosPost.Conditions, conditionIDs)
 				assertPetEquals(t, sosPost.Pets[0], addPets[0])
 				assertMediaEquals(t, sosPost.Media, sosPostMedia)
 
+				idx := len(sosPostListByAuthorID.Items) - i - 1
+
 				if err != nil {
 					t.Errorf("got %v want %v", err, nil)
 				}
-				if sosPost.Title != sosPosts[i].Title {
-					t.Errorf("got %v want %v", sosPost.Title, sosPosts[i].Title)
+				if sosPost.Title != sosPosts[idx].Title {
+					t.Errorf("got %v want %v", sosPost.Title, sosPosts[idx].Title)
 				}
-				if sosPost.Content != sosPosts[i].Content {
-					t.Errorf("got %v want %v", sosPost.Content, sosPosts[i].Content)
+				if sosPost.Content != sosPosts[idx].Content {
+					t.Errorf("got %v want %v", sosPost.Content, sosPosts[idx].Content)
 				}
-				if sosPost.Reward != sosPosts[i].Reward {
-					t.Errorf("got %v want %v", sosPost.Reward, sosPosts[i].Reward)
+				if sosPost.Reward != sosPosts[idx].Reward {
+					t.Errorf("got %v want %v", sosPost.Reward, sosPosts[idx].Reward)
 				}
-				if sosPost.DateStartAt != sosPosts[i].DateStartAt {
-					t.Errorf("got %v want %v", sosPost.DateStartAt, sosPosts[i].DateStartAt)
+				if sosPost.DateStartAt != sosPosts[idx].DateStartAt {
+					t.Errorf("got %v want %v", sosPost.DateStartAt, sosPosts[idx].DateStartAt)
 				}
-				if sosPost.DateEndAt != sosPosts[i].DateEndAt {
-					t.Errorf("got %v want %v", sosPost.DateEndAt, sosPosts[i].DateEndAt)
+				if sosPost.DateEndAt != sosPosts[idx].DateEndAt {
+					t.Errorf("got %v want %v", sosPost.DateEndAt, sosPosts[idx].DateEndAt)
 				}
-				if sosPost.TimeStartAt != sosPosts[i].TimeStartAt {
-					t.Errorf("got %v want %v", sosPost.TimeStartAt, sosPosts[i].TimeStartAt)
+				if sosPost.TimeStartAt != sosPosts[idx].TimeStartAt {
+					t.Errorf("got %v want %v", sosPost.TimeStartAt, sosPosts[idx].TimeStartAt)
 				}
-				if sosPost.TimeEndAt != sosPosts[i].TimeEndAt {
-					t.Errorf("got %v want %v", sosPost.TimeEndAt, sosPosts[i].TimeEndAt)
+				if sosPost.TimeEndAt != sosPosts[idx].TimeEndAt {
+					t.Errorf("got %v want %v", sosPost.TimeEndAt, sosPosts[idx].TimeEndAt)
 				}
-				if sosPost.CareType != sosPosts[i].CareType {
-					t.Errorf("got %v want %v", sosPost.CareType, sosPosts[i].CareType)
+				if sosPost.CareType != sosPosts[idx].CareType {
+					t.Errorf("got %v want %v", sosPost.CareType, sosPosts[idx].CareType)
 				}
-				if sosPost.CarerGender != sosPosts[i].CarerGender {
-					t.Errorf("got %v want %v", sosPost.CarerGender, sosPosts[i].CarerGender)
+				if sosPost.CarerGender != sosPosts[idx].CarerGender {
+					t.Errorf("got %v want %v", sosPost.CarerGender, sosPosts[idx].CarerGender)
 				}
-				if sosPost.RewardAmount != sosPosts[i].RewardAmount {
-					t.Errorf("got %v want %v", sosPost.RewardAmount, sosPosts[i].RewardAmount)
+				if sosPost.RewardAmount != sosPosts[idx].RewardAmount {
+					t.Errorf("got %v want %v", sosPost.RewardAmount, sosPosts[idx].RewardAmount)
 				}
 				if sosPost.ThumbnailID != sosPostImage.ID {
 					t.Errorf("got %v want %v", sosPost.ThumbnailID, sosPostImage.ID)


### PR DESCRIPTION
- 페이지네이션 파라미터를 `Prepared Statements`로 조회하도록 수정하였습니다.

부득히하게 ORDER BY 옵션의 경우, Prepared Statements로 파라미터를 삽입하지 못하기 때문에 switch문으로 체크하고 문자열로 대입하도록 구현하였습니다. 이 방법은 Injection 문제를 완전히 해결한게 아니다보니 `switch`문의 `default`를 제거하고 정해놓은 형식(newest, deadline)의 값만 삽입하도록 해야할 지 고민 중입니다.

- 작성자 ID로 돌봄 급구 게시글 조회 로직에 정렬 기준(newest, deadline)을 추가하였습니다.

정렬 기능은 전체 조회에만 구현되어 있어, 작성자 ID로 조회하는 경우에는 사용할 수 없었습니다. 
같은 엔드포인트에서 동작하기 때문에 혼란을 줄 수 있고 추후에 필터링 옵션이 추가될 가능성을 고려하여 추가하였습니다.