### PR TITLE
SQL 문법 오류 및 코드 중복 정의를 제거합니다.

### DIFF
--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -2,6 +2,8 @@ package user
 
 import (
 	"context"
+	"database/sql"
+	"time"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )
@@ -24,9 +26,9 @@ type User struct {
 	ProfileImageID       *int                 `field:"profile_image_id"`
 	FirebaseProviderType FirebaseProviderType `field:"fb_provider_type"`
 	FirebaseUID          string               `field:"fb_uid"`
-	CreatedAt            string               `field:"created_at"`
-	UpdatedAt            string               `field:"updated_at"`
-	DeletedAt            string               `field:"deleted_at"`
+	CreatedAt            time.Time            `field:"created_at"`
+	UpdatedAt            time.Time            `field:"updated_at"`
+	DeletedAt            sql.NullTime         `field:"deleted_at"`
 }
 
 type UserWithProfileImage struct {
@@ -38,13 +40,13 @@ type UserWithProfileImage struct {
 	ProfileImageURL      *string              `field:"profile_image_url"`
 	FirebaseProviderType FirebaseProviderType `field:"fb_provider_type"`
 	FirebaseUID          string               `field:"fb_uid"`
-	CreatedAt            string               `field:"created_at"`
-	UpdatedAt            string               `field:"updated_at"`
-	DeletedAt            string               `field:"deleted_at"`
+	CreatedAt            time.Time            `field:"created_at"`
+	UpdatedAt            time.Time            `field:"updated_at"`
+	DeletedAt            sql.NullTime         `field:"deleted_at"`
 }
 
 func (u *UserWithProfileImage) ToUserWithoutPrivateInfo() *UserWithoutPrivateInfo {
-	if u.DeletedAt != "" {
+	if u.DeletedAt.Valid {
 		return &UserWithoutPrivateInfo{
 			ID:              u.ID,
 			Nickname:        "탈퇴한 사용자",

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -86,7 +86,6 @@ type UserStore interface {
 	FindUserByEmail(ctx context.Context, email string) (*UserWithProfileImage, *pnd.AppError)
 	FindUserByUID(ctx context.Context, uid string) (*UserWithProfileImage, *pnd.AppError)
 	FindUserIDByFbUID(ctx context.Context, fbUid string) (int, *pnd.AppError)
-	FindUserByID(ctx context.Context, id int) (*UserWithoutPrivateInfo, *pnd.AppError)
 	ExistsByNickname(ctx context.Context, nickname string) (bool, *pnd.AppError)
 	FindUserStatusByEmail(ctx context.Context, email string) (*UserStatus, *pnd.AppError)
 	UpdateUserByUID(ctx context.Context, uid string, nickname string, profileImageID *int) (*User, *pnd.AppError)

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -164,7 +164,7 @@ func (s *userQueries) FindUserByID(ctx context.Context, id int, includeDeleted b
 		users.fb_provider_type,
 		users.fb_uid,
 		users.created_at,
-		users.updated_at
+		users.updated_at,
 		users.deleted_at
 	FROM
 		users

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
@@ -39,10 +40,6 @@ func (s *UserPostgresStore) FindUserByUID(ctx context.Context, uid string) (*use
 
 func (s *UserPostgresStore) FindUserIDByFbUID(ctx context.Context, fbUid string) (int, *pnd.AppError) {
 	return (&userQueries{conn: s.conn}).FindUserIDByFbUID(ctx, fbUid)
-}
-
-func (s *UserPostgresStore) FindUserByID(ctx context.Context, id int) (*user.UserWithoutPrivateInfo, *pnd.AppError) {
-	return (&userQueries{conn: s.conn}).FindUserByID(ctx, id)
 }
 
 func (s *UserPostgresStore) ExistsByNickname(ctx context.Context, nickname string) (bool, *pnd.AppError) {
@@ -298,36 +295,6 @@ func (s *userQueries) FindUserIDByFbUID(ctx context.Context, fbUid string) (int,
 	}
 
 	return userID, nil
-}
-
-func (s *userQueries) FindUserByID(ctx context.Context, id int) (*user.UserWithoutPrivateInfo, *pnd.AppError) {
-	const sql = `
-	SELECT
-		users.id,
-		users.nickname,
-		media.url AS profile_image_url
-	FROM
-		users
-	LEFT JOIN
-		media
-	ON
-		users.profile_image_id = media.id
-	WHERE
-		users.id = $1 AND
-		users.deleted_at IS NULL
-	`
-
-	var user user.UserWithoutPrivateInfo
-
-	if err := s.conn.QueryRowContext(ctx, sql, id).Scan(
-		&user.ID,
-		&user.Nickname,
-		&user.ProfileImageURL,
-	); err != nil {
-		return nil, pnd.FromPostgresError(err)
-	}
-
-	return &user, nil
 }
 
 func (s *userQueries) ExistsByNickname(ctx context.Context, nickname string) (bool, *pnd.AppError) {

--- a/internal/service/sos_post_service.go
+++ b/internal/service/sos_post_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	"time"
 
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
@@ -192,17 +191,14 @@ func (service *SosPostService) FindSosPosts(ctx context.Context, page int, size 
 				petsView = append(petsView, p)
 			}
 
-			author, err := userStore.FindUserByID(ctx, sosPost.AuthorID)
-
-			userView := &user.UserWithoutPrivateInfo{
-				ID:              author.ID,
-				ProfileImageURL: author.ProfileImageURL,
-				Nickname:        author.Nickname,
+			author, err := userStore.FindUserByID(ctx, sosPost.AuthorID, true)
+			if err != nil {
+				return err
 			}
 
 			findByAuthorSosPostView := &sos_post.FindSosPostView{
 				ID:           sosPost.ID,
-				Author:       userView,
+				Author:       author.ToUserWithoutPrivateInfo(),
 				Title:        sosPost.Title,
 				Content:      sosPost.Content,
 				Media:        mediaView,
@@ -298,17 +294,14 @@ func (service *SosPostService) FindSosPostsByAuthorID(ctx context.Context, autho
 				petsView = append(petsView, p)
 			}
 
-			author, err := userStore.FindUserByID(ctx, sosPost.AuthorID)
-
-			userView := &user.UserWithoutPrivateInfo{
-				ID:              author.ID,
-				ProfileImageURL: author.ProfileImageURL,
-				Nickname:        author.Nickname,
+			author, err := userStore.FindUserByID(ctx, sosPost.AuthorID, true)
+			if err != nil {
+				return err
 			}
 
 			findByAuthorSosPostView := &sos_post.FindSosPostView{
 				ID:           sosPost.ID,
-				Author:       userView,
+				Author:       author.ToUserWithoutPrivateInfo(),
 				Title:        sosPost.Title,
 				Content:      sosPost.Content,
 				Media:        mediaView,
@@ -402,17 +395,14 @@ func (service *SosPostService) FindSosPostByID(ctx context.Context, id int) (*so
 			petsView = append(petsView, p)
 		}
 
-		author, err := userStore.FindUserByID(ctx, sosPost.AuthorID)
-
-		userView := &user.UserWithoutPrivateInfo{
-			ID:              author.ID,
-			ProfileImageURL: author.ProfileImageURL,
-			Nickname:        author.Nickname,
+		author, err := userStore.FindUserByID(ctx, sosPost.AuthorID, true)
+		if err != nil {
+			return err
 		}
 
 		sosPostView = &sos_post.FindSosPostView{
 			ID:           sosPost.ID,
-			Author:       userView,
+			Author:       author.ToUserWithoutPrivateInfo(),
 			Title:        sosPost.Title,
 			Content:      sosPost.Content,
 			Media:        mediaView,


### PR DESCRIPTION
## About

버그픽스

- #46 #47 Rebase 과정에서 `FindUserByID` 중복 정의 제거
- `users.deleted_at`이 nullable함으로 `sql.NullTime` 사용 (Go 1.13+)
- sql 문법 오류 제거
- `UserWithoutPrivateInfo`를 빌드할 때 `ToUserWithoutPrivateInfo` 메서드를 사용합니다.

리베이스 과정에 유입된 것도 있고 바로 픽스해야돼서 바로 머지할게요. @barabobBOB 

## REF

https://stackoverflow.com/questions/24564619/nullable-time-time