### PR TITLE
날짜 컬럼을 `timestampz`(timetamp with timezone) 타입으로 변경합니다.

### DIFF
--- a/db/migrations/000012_timestamp_with_timezone.down.sql
+++ b/db/migrations/000012_timestamp_with_timezone.down.sql
@@ -1,0 +1,44 @@
+ALTER TABLE users
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE media
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE pets
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE breeds
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE base_posts
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE resource_media
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE sos_conditions
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE sos_posts_conditions
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE sos_posts_pets
+    ALTER created_at TYPE timestamp USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamp USING deleted_at AT TIME ZONE 'UTC';

--- a/db/migrations/000012_timestamp_with_timezone.up.sql
+++ b/db/migrations/000012_timestamp_with_timezone.up.sql
@@ -1,0 +1,44 @@
+ALTER TABLE users
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE media
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE pets
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE breeds
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE base_posts
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE resource_media
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE sos_conditions
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE sos_posts_conditions
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';
+
+ALTER TABLE sos_posts_pets
+    ALTER created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC',
+    ALTER deleted_at TYPE timestamptz USING deleted_at AT TIME ZONE 'UTC';


### PR DESCRIPTION
## About

기존 created_at, updated_at, deleted_at 컬럼의 타입이 `timestamp`(timestamp without timezone)로 설정되어 있어 timezone 정보가 누락되어 있었습니다.

`timestampz`(timestamp with timezone) 필드로 설정하여 timezone을 저장합니다. timezone은 UTC를 사용합니다.

## Note

배포 후 `migrate` 명령어 실행이 필요합니다.