### PR TITLE
Transaction Rollback 함수 실행 간 이미 transaction이 commit 됐을 때 나오는 에러를 무시합니다.

### DIFF
--- a/internal/infra/database/transaction.go
+++ b/internal/infra/database/transaction.go
@@ -3,7 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
-
+	"errors"
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )
 
@@ -51,6 +51,9 @@ func (sct *Tx) EndTx(f func() *pnd.AppError) *pnd.AppError {
 
 func (sct *Tx) Rollback() *pnd.AppError {
 	if err := sct.Tx.Rollback(); err != nil {
+		if errors.Is(err, sql.ErrTxDone) {
+			return nil
+		}
 		return pnd.FromPostgresError(err)
 	}
 


### PR DESCRIPTION
Transaction Rollback 함수 실행 간 이미 transaction이 commit 됐을 때 나오는 에러를 무시합니다.

Transaction을 BeginTx로 시작하고 defer Rollback 함수를 넣는데 되는데, commit 여부와 상관 없이 rollback 함수는 무조건 실행되고, 이후 commit이 되더라도 에러가 나오기 때문에 에러 처리를 하지 않더라도 logger에 의해 에러가 로그에 찍히는 마이너한 이슈가 있습니다.

로그가 나오지 않도록 ErrTxDone 오류일 경우 무시합니다.

```
sql: transaction has already been committed or rolled back
```

(마이너한 이슈라 리뷰 안받고 머지할게요.)