### PR TITLE
golangci-lint를 CI에 추가하고 Lint 오류를 수정합니다.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
     tags-ignore:
       - '**'
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,9 +25,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21.6'
+          cache: false
 
       - name: Generate Swagger
         run: go install github.com/swaggo/swag/cmd/swag@latest && source ./scripts/swagger-gen.sh
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          skip-pkg-cache: true
 
       - name: Build
         run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,7 +127,7 @@ linters-settings:
     # Run `go tool vet help` to see all analyzers.
     # Default: []
     disable:
-    # - fieldalignment # too strict
+     - fieldalignment # too strict
     # Settings per analyzer.
     settings:
       shadow:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,619 @@
+# Based on: https://github.com/neilotoole/sq/blob/a3cd01f36a59e4c6417b09e37081b07de192e11e/.golangci.yml
+
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m
+
+  tests: true
+
+output:
+  sort-results: true
+
+# This file contains only configs which differ from defaults.
+# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 50
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 10.0
+
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true
+
+  exhaustive:
+    # Program elements to check for exhaustiveness.
+    # Default: [ switch ]
+    check:
+      - switch
+      - map
+
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 150
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 100
+
+    # Ignore comments when counting lines.
+    # Default false
+    ignore-comments: true
+
+  gocognit:
+    # Minimal code complexity to report
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 50
+
+  gocritic:
+    # Settings passed to gocritic.
+    # The settings key is the name of a supported gocritic checker.
+    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    settings:
+      captLocal:
+        # Whether to restrict checker to params only.
+        # Default: true
+        paramsOnly: false
+      underef:
+        # Whether to skip (*x).method() calls where x is a pointer receiver.
+        # Default: true
+        skipRecvDeref: false
+
+  gocyclo:
+    # Minimal code complexity to report.
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 50
+
+  gofumpt:
+    # Module path which contains the source code being formatted.
+    # Default: ""
+    module-path: github.com/neilotoole/sq
+    # Choose whether to use the extra rules.
+    # Default: false
+    extra-rules: true
+
+  gomnd:
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Date`,
+    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+    # Default: []
+    ignored-functions:
+      - make
+      - os.Chmod
+      - os.Mkdir
+      - os.MkdirAll
+      - os.OpenFile
+      - os.WriteFile
+      - prometheus.ExponentialBuckets
+      - prometheus.ExponentialBucketsRange
+      - prometheus.LinearBuckets
+    ignored-numbers:
+      - "2"
+      - "3"
+
+  gomodguard:
+    blocked:
+      # List of blocked modules.
+      # Default: []
+      modules:
+        - github.com/golang/protobuf:
+            recommendations:
+              - google.golang.org/protobuf
+            reason: "see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
+        - github.com/satori/go.uuid:
+            recommendations:
+              - github.com/google/uuid
+            reason: "satori's package is not maintained"
+        - github.com/gofrs/uuid:
+            recommendations:
+              - github.com/google/uuid
+            reason: "gofrs' package is not go module"
+
+  govet:
+    # Enable all analyzers.
+    # Default: false
+    enable-all: true
+    # Disable analyzers by name.
+    # Run `go tool vet help` to see all analyzers.
+    # Default: []
+    disable:
+    # - fieldalignment # too strict
+    # Settings per analyzer.
+    settings:
+      shadow:
+        # Whether to be strict about shadowing; can be noisy.
+        # Default: false
+        strict: false
+
+  lll:
+    # Max line length, lines longer will be reported.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
+    # Default: 120.
+    line-length: 120
+    # Tab width in spaces.
+    # Default: 1
+    tab-width: 1
+
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 0
+
+  nestif:
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 20
+
+  nolintlint:
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [ funlen, gocognit, lll ]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
+  revive:
+    # https://golangci-lint.run/usage/linters/#revive
+    rules:
+
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      - name: add-constant
+        disabled: true
+        arguments:
+          - maxLitCount: "3"
+            allowStrs: '""'
+            allowInts: "0,1,2"
+            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#argument-limit
+      - name: argument-limit
+        disabled: false
+        arguments: [ 7 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
+      - name: atomic
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
+      - name: banned-characters
+        disabled: true
+        arguments: [ "Ω", "Σ", "σ", "7" ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
+      - name: bare-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
+      - name: blank-imports
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      - name: bool-literal-in-expr
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#call-to-gc
+      - name: call-to-gc
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
+      - name: cognitive-complexity
+        disabled: true
+        arguments: [ 7 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
+      - name: comment-spacings
+        disabled: true
+        arguments:
+          - mypragma
+          - otherpragma
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
+      - name: confusing-naming
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-results
+      - name: confusing-results
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
+      - name: constant-logical-expr
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        disabled: false
+        arguments:
+          - allowTypesBefore: "*testing.T,*github.com/user/repo/testing.Harness"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
+      - name: context-keys-type
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
+      - name: cyclomatic
+        disabled: true
+        arguments: [ 3 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#datarace
+      - name: datarace
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
+      - name: deep-exit
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
+      - name: defer
+        disabled: false
+        arguments:
+          - [ "call-chain", "loop" ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
+      - name: dot-imports
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      - name: duplicated-imports
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        disabled: false
+        arguments:
+          - "preserveScope"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
+      - name: empty-block
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+      - name: empty-lines
+        disabled: true # Covered by "whitespace" linter.
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        disabled: true
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
+      - name: error-naming
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
+      - name: error-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      - name: error-strings
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
+      - name: errorf
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-header
+      - name: file-header
+        disabled: true
+      #        arguments:
+      #          - This is the text that must appear at the top of source files.
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
+      - name: flag-parameter
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
+      - name: function-result-limit
+        disabled: false
+        arguments: [ 4 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
+      - name: function-length
+        disabled: true
+        arguments: [ 10, 0 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#get-return
+      - name: get-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
+      - name: identical-branches
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      - name: if-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
+      - name: increment-decrement
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+      - name: indent-error-flow
+        disabled: false
+        arguments:
+          - "preserveScope"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-alias-naming
+      - name: import-alias-naming
+        disabled: false
+        arguments:
+          - "^[a-z][a-z0-9]{0,}$"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blacklist
+      - name: imports-blacklist
+        disabled: false
+        arguments:
+          - "crypto/md5"
+          - "crypto/sha1"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      - name: import-shadowing
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
+      - name: line-length-limit
+        disabled: true
+        arguments: [ 80 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
+      - name: max-public-structs
+        disabled: true
+        arguments: [ 3 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-parameter
+      - name: modifies-parameter
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-value-receiver
+      - name: modifies-value-receiver
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#nested-structs
+      - name: nested-structs
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
+      - name: package-comments
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
+      - name: range
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
+      - name: range-val-in-closure
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
+      - name: range-val-address
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#receiver-naming
+      - name: receiver-naming
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
+      - name: redundant-import-alias
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
+      - name: redefines-builtin-id
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-of-int
+      - name: string-of-int
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
+      - name: string-format
+        disabled: false
+        arguments:
+          - - 'core.WriteError[1].Message'
+            - '/^([^A-Z]|$)/'
+            - must not start with a capital letter
+          - - 'fmt.Errorf[0]'
+            - '/(^|[^\.!?])$/'
+            - must not end in punctuation
+          - - panic
+            - '/^[^\n]*$/'
+            - must not contain line breaks
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      - name: struct-tag
+        arguments:
+          - "json,inline"
+          - "bson,outline,gnu"
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+      - name: superfluous-else
+        disabled: false
+        arguments:
+          - "preserveScope"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
+      - name: time-equal
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-naming
+      - name: time-naming
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      - name: var-naming
+        disabled: false
+        arguments:
+          - [ "ID" ] # AllowList
+          - [ "VM" ] # DenyList
+          - - upperCaseConst: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
+      - name: var-declaration
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
+      - name: unconditional-recursion
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
+      - name: unexported-naming
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+      - name: unexported-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      - name: unhandled-error
+        disabled: false
+        arguments:
+          - "fmt.Printf"
+          - "fmt.Fprintf"
+          - "fmt.Fprint"
+          - "fmt.Fprintln"
+          - "bytes.Buffer.Write"
+          - "bytes.Buffer.WriteByte"
+          - "bytes.Buffer.WriteString"
+          - "bytes.Buffer.WriteRune"
+          - "strings.Builder.WriteString"
+          - "strings.Builder.WriteRune"
+          - "strings.Builder.Write"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt
+      - name: unnecessary-stmt
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code
+      - name: unreachable-code
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        disabled: false
+        arguments:
+          - allowRegex: "^_"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      - name: unused-receiver
+        disabled: true
+        arguments:
+          - allowRegex: "^_"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      - name: useless-break
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
+      - name: waitgroup-by-value
+        disabled: false
+
+  rowserrcheck:
+    # database/sql is always checked
+    # Default: []
+    packages:
+      - github.com/jmoiron/sqlx
+
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
+
+
+linters:
+  disable-all: true
+
+  enable:
+    ## enabled by default
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # checks for unused constants, variables, functions and types
+
+
+    #    ## disabled by default
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - cyclop # checks function and package cyclomatic complexity
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exportloopref # checks for pointers to enclosing loop variables
+    - forbidigo # forbids identifiers
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    # - godot # checks if comments end in a period
+    - gofumpt
+    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - grouper # analyzes expression groups
+    - lll # reports long lines
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks for performance issues with fmt.Sprintf
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - reassign # checks that package variables are not reassigned
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - sloglint # ensure consistent code style when using log/slog.
+    - stylecheck # is a replacement for golint
+    # - tagalign # check that struct tags are well aligned.
+    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - testableexamples # checks if examples are testable (have an expected output)
+    - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - wastedassign # finds wasted assignment statements.
+    - whitespace # detects leading and trailing whitespace
+
+    ## These three linters are disabled for now due to generics: https://github.com/golangci/golangci-lint/issues/2649
+    #- rowserrcheck # checks whether Err of rows is checked successfully  # Disabled because:  https://github.com/golangci/golangci-lint/issues/2649
+    #- sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    #- wastedassign # finds wasted assignment statements
+
+
+    ## you may want to enable
+    #- decorder # checks declaration order and count of types, constants, variables and functions
+    #- exhaustruct # checks if all structure fields are initialized
+    #    - gochecknoglobals # checks that no global variables exist
+    #- godox # detects FIXME, TODO and other comment keywords
+    #- goheader # checks is file header matches to pattern
+    #- gomnd # detects magic numbers
+    #- interfacebloat # checks the number of methods inside an interface
+    #- ireturn # accept interfaces, return concrete types
+    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
+
+    ## disabled
+    #- containedctx # detects struct contained context.Context field
+    # - contextcheck # [too many false positives] checks the function whether use a non-inherited context
+    #- depguard # [replaced by gomodguard] checks if package imports are in a list of acceptable packages
+    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    #- dupword # [useless without config] checks for duplicate words in the source code
+    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
+    #- goerr113 # [too strict] checks the errors handling expressions
+    #- gofmt # [replaced by goimports] checks whether code was gofmt-ed
+    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
+    #- grouper # analyzes expression groups
+    #- importas # enforces consistent import aliases
+    #- maintidx # measures the maintainability index of each function
+    #- misspell # [useless] finds commonly misspelled English words in comments
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- tagliatelle # checks the struct tags
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+
+    ## deprecated
+    #- deadcode # [deprecated, replaced by unused] finds unused code
+    #- exhaustivestruct # [deprecated, replaced by exhaustruct] checks if all struct's fields are initialized
+    #- golint # [deprecated, replaced by revive] golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    #- ifshort # [deprecated] checks that your code uses short syntax for if-statements whenever possible
+    #- interfacer # [deprecated] suggests narrower interface types
+    #- maligned # [deprecated, replaced by govet fieldalignment] detects Go structs that would take less memory if their fields were sorted
+    #- nosnakecase # [deprecated, replaced by revive var-naming] detects snake case of variable naming and function name
+    #- scopelint # [deprecated, replaced by exportloopref] checks for unpinned variables in go programs
+    #- structcheck # [deprecated, replaced by unused] finds unused struct fields
+    #- varcheck # [deprecated, replaced by unused] finds unused global variables and constants
+
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 3
+
+  exclude-rules:
+    - source: "^//\\s*go:generate\\s"
+      linters: [ lll ]
+    - source: "(noinspection|TODO)"
+      linters: [ godot ]
+    - source: "//noinspection"
+      linters: [ gocritic ]
+    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
+      linters: [ errorlint ]
+    - path: "_test\\.go"
+      linters:
+        - govet
+        - bodyclose
+        - dupl
+        - funlen
+        - goconst
+        - gosec
+        - noctx
+        - wrapcheck

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint\:install:
 	# https://golangci-lint.run/welcome/install/#local-installation
 	brew install golangci-lint
 lint:
-	golangci-lint run --enable-all
+	golangci-lint run
 
 ## Version ##
 version:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ lint\:install:
 	brew install golangci-lint
 lint:
 	golangci-lint run
+lint\:fix:
+	golangci-lint run --fix
 
 ## Version ##
 version:

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,12 @@ deps:
 	go mod tidy
 
 ## Code ##
+format\:install:
+	# gofumpt
+	# https://github.com/mvdan/gofumpt
+	go install mvdan.cc/gofumpt@latest
 format:
-	go fmt ./...
+	gofumpt -l -w .
 
 lint\:install:
 	# golangci-lint

--- a/api/common.go
+++ b/api/common.go
@@ -12,7 +12,7 @@ type PaginatedView[T interface{}] struct {
 	Items      []T  `json:"items"`
 }
 
-func NewPaginatedView[T interface{}](page int, size int, isLastPage bool, items []T) *PaginatedView[T] {
+func NewPaginatedView[T interface{}](page, size int, isLastPage bool, items []T) *PaginatedView[T] {
 	return &PaginatedView[T]{
 		Page:       page,
 		Size:       size,

--- a/api/errors.go
+++ b/api/errors.go
@@ -19,8 +19,8 @@ const (
 	ErrCodeMultipartForm     AppErrorCode = "ERR_MULTIPART_FORM"
 
 	// Common errors - Auth
-	ErrCodeInvalidFBToken     AppErrorCode = "ERR_INVALID_FB_TOKEN"
-	ErrCodeInvalidBearerToken AppErrorCode = "ERR_INVALID_BEARER_TOKEN"
+	ErrCodeInvalidFBToken     AppErrorCode = "ERR_INVALID_FB_TOKEN"     //nolint:gosec
+	ErrCodeInvalidBearerToken AppErrorCode = "ERR_INVALID_BEARER_TOKEN" //nolint:gosec
 	ErrCodeUserNotRegistered  AppErrorCode = "ERR_USER_NOT_REGISTERED"
 	ErrCodeForbidden          AppErrorCode = "ERR_FORBIDDEN"
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -107,17 +107,18 @@ func ErrUnknown(err error) *AppError {
 
 func FromPostgresError(err error) *AppError {
 	errStr := err.Error()
-	if strings.Contains(errStr, "no rows in result set") {
+	switch {
+	case strings.Contains(errStr, "no rows in result set"):
 		return NewAppError(err, http.StatusNotFound, ErrCodeNotFound, "해당하는 자원이 없습니다")
-	} else if strings.Contains(errStr, "violates foreign key constraint") {
+	case strings.Contains(errStr, "violates foreign key constraint"):
 		return NewAppError(err, http.StatusNotFound, ErrCodeNotFound, "해당하는 자원이 없습니다")
-	} else if strings.Contains(errStr, "violates not-null constraint") {
+	case strings.Contains(errStr, "violates not-null constraint"):
 		return NewAppError(err, http.StatusBadRequest, ErrCodeBadRequest, "필수 값이 누락되었습니다")
-	} else if strings.Contains(errStr, "violates check constraint") {
+	case strings.Contains(errStr, "violates check constraint"):
 		return NewAppError(err, http.StatusBadRequest, ErrCodeBadRequest, "잘못된 값입니다")
-	} else if strings.Contains(errStr, "violates unique constraint") {
+	case strings.Contains(errStr, "violates unique constraint"):
 		return NewAppError(err, http.StatusConflict, ErrCodeConflict, "중복된 값입니다")
-	} else {
+	default:
 		return NewAppError(err, http.StatusInternalServerError, ErrCodeUnknown, "알 수 없는 오류가 발생했습니다")
 	}
 }

--- a/api/web.go
+++ b/api/web.go
@@ -2,9 +2,10 @@ package pnd
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/go-playground/validator"
 	"github.com/labstack/echo/v4"
-	"strconv"
 )
 
 func ParseBody(c echo.Context, payload interface{}) *AppError {

--- a/api/web.go
+++ b/api/web.go
@@ -1,6 +1,7 @@
 package pnd
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -75,7 +76,7 @@ func ParsePaginationQueries(c echo.Context, defaultPage, defaultLimit int) (page
 		var atoiError error
 		page, atoiError = strconv.Atoi(pageQuery)
 		if atoiError != nil || page <= 0 {
-			return 0, 0, ErrInvalidPagination(fmt.Errorf("expected integer value bigger than 0 for query: page"))
+			return 0, 0, ErrInvalidPagination(errors.New("expected integer value bigger than 0 for query: page"))
 		}
 	}
 
@@ -83,7 +84,7 @@ func ParsePaginationQueries(c echo.Context, defaultPage, defaultLimit int) (page
 		var atoiError error
 		size, atoiError = strconv.Atoi(sizeQuery)
 		if atoiError != nil || size <= 0 {
-			return 0, 0, ErrInvalidPagination(fmt.Errorf("expected integer value bigger than 0 for query: size"))
+			return 0, 0, ErrInvalidPagination(errors.New("expected integer value bigger than 0 for query: size"))
 		}
 	}
 

--- a/api/web.go
+++ b/api/web.go
@@ -64,7 +64,7 @@ func ParseOptionalStringQuery(c echo.Context, query string) *string {
 }
 
 // ParsePaginationQueries parses pagination parameters from query string: page, size.
-func ParsePaginationQueries(c echo.Context, defaultPage int, defaultLimit int) (page int, size int, err *AppError) {
+func ParsePaginationQueries(c echo.Context, defaultPage, defaultLimit int) (page, size int, err *AppError) {
 	pageQuery := c.QueryParam("page")
 	sizeQuery := c.QueryParam("size")
 

--- a/cmd/import_breeds/breeds_importer_service/breeds_importer_service.go
+++ b/cmd/import_breeds/breeds_importer_service/breeds_importer_service.go
@@ -2,12 +2,15 @@ package breeds_importer_service
 
 import (
 	"context"
+
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )
 
-const catSheetIndex = 0
-const dogSheetIndex = 1
+const (
+	catSheetIndex = 0
+	dogSheetIndex = 1
+)
 
 type BreedsImporterService struct {
 	client *sheets.Service
@@ -26,7 +29,6 @@ func (c *BreedsImporterService) GetSpreadsheet(spreadsheetId string) (*sheets.Sp
 	resp := c.client.Spreadsheets.Get(spreadsheetId)
 	resp.IncludeGridData(true)
 	spreadsheet, err := resp.Do()
-
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/import_breeds/breedsimporterservice/breedsimporterservice.go
+++ b/cmd/import_breeds/breedsimporterservice/breedsimporterservice.go
@@ -1,4 +1,4 @@
-package breeds_importer_service
+package breedsimporterservice
 
 import (
 	"context"

--- a/cmd/import_breeds/breedsimporterservice/breedsimporterservice.go
+++ b/cmd/import_breeds/breedsimporterservice/breedsimporterservice.go
@@ -25,8 +25,8 @@ func NewBreedsImporterService(ctx context.Context, apiKey string) (*BreedsImport
 	return &BreedsImporterService{client: client}, nil
 }
 
-func (c *BreedsImporterService) GetSpreadsheet(spreadsheetId string) (*sheets.Spreadsheet, error) {
-	resp := c.client.Spreadsheets.Get(spreadsheetId)
+func (c *BreedsImporterService) GetSpreadsheet(spreadsheetID string) (*sheets.Spreadsheet, error) {
+	resp := c.client.Spreadsheets.Get(spreadsheetID)
 	resp.IncludeGridData(true)
 	spreadsheet, err := resp.Do()
 	if err != nil {
@@ -39,7 +39,7 @@ func (c *BreedsImporterService) GetSpreadsheet(spreadsheetId string) (*sheets.Sp
 func (c *BreedsImporterService) GetCatNames(spreadsheet *sheets.Spreadsheet) []Row {
 	var catRows []Row
 
-	var catsSheet *sheets.Sheet = spreadsheet.Sheets[catSheetIndex]
+	catsSheet := spreadsheet.Sheets[catSheetIndex]
 	for _, row := range catsSheet.Data[0].RowData[1:] {
 		if len(row.Values) == 0 {
 			continue
@@ -54,7 +54,7 @@ func (c *BreedsImporterService) GetCatNames(spreadsheet *sheets.Spreadsheet) []R
 func (c *BreedsImporterService) GetDogNames(spreadsheet *sheets.Spreadsheet) []Row {
 	var dogRows []Row
 
-	var dogsSheet *sheets.Sheet = spreadsheet.Sheets[dogSheetIndex]
+	dogsSheet := spreadsheet.Sheets[dogSheetIndex]
 	for _, row := range dogsSheet.Data[0].RowData[1:] {
 		if len(row.Values) == 0 {
 			continue

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -21,7 +21,6 @@ func main() {
 	log.Printf("Starting to import pet types: %s to database\n", flags.petTypeToImport)
 
 	db, err := database.Open(configs.DatabaseURL)
-
 	if err != nil {
 		log.Fatalf("error opening database: %v\n", err)
 	}
@@ -39,14 +38,14 @@ func main() {
 
 	switch flags.petTypeToImport {
 	case Cat:
-		var catRows = client.GetCatNames(spreadsheet)
+		catRows := client.GetCatNames(spreadsheet)
 		importBreeds(ctx, db, pet.PetTypeCat, &catRows)
 	case Dog:
-		var dogRows = client.GetDogNames(spreadsheet)
+		dogRows := client.GetDogNames(spreadsheet)
 		importBreeds(ctx, db, pet.PetTypeDog, &dogRows)
 	case All:
-		var catRows = client.GetCatNames(spreadsheet)
-		var dogRows = client.GetDogNames(spreadsheet)
+		catRows := client.GetCatNames(spreadsheet)
+		dogRows := client.GetDogNames(spreadsheet)
 
 		importBreeds(ctx, db, pet.PetTypeCat, &catRows)
 		importBreeds(ctx, db, pet.PetTypeDog, &dogRows)

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -5,8 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"flag"
-	"github.com/pet-sitter/pets-next-door-api/cmd/import_breeds/breedsimporterservice"
 	"log"
+
+	"github.com/pet-sitter/pets-next-door-api/cmd/import_breeds/breedsimporterservice"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"flag"
+	"github.com/pet-sitter/pets-next-door-api/cmd/import_breeds/breedsimporterservice"
 	"log"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
-	"github.com/pet-sitter/pets-next-door-api/cmd/import_breeds/breeds_importer_service"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	client, err := breeds_importer_service.NewBreedsImporterService(ctx, configs.GoogleSheetsAPIKey)
+	client, err := breedsimporterservice.NewBreedsImporterService(ctx, configs.GoogleSheetsAPIKey)
 	if err != nil {
 		log.Fatalf("error initializing google sheets client: %v\n", err)
 	}
@@ -89,7 +89,7 @@ func parseFlags() Flags {
 }
 
 func importBreed(
-	ctx context.Context, conn *database.DB, petType pet.PetType, row breeds_importer_service.Row,
+	ctx context.Context, conn *database.DB, petType pet.PetType, row breedsimporterservice.Row,
 ) (*pet.Breed, *pnd.AppError) {
 	log.Printf("Importing breed with pet_type: %s, name: %s to database", petType, row.Breed)
 
@@ -131,7 +131,7 @@ func importBreed(
 	return breed, nil
 }
 
-func importBreeds(ctx context.Context, conn *database.DB, petType pet.PetType, rows *[]breeds_importer_service.Row) {
+func importBreeds(ctx context.Context, conn *database.DB, petType pet.PetType, rows *[]breedsimporterservice.Row) {
 	for _, row := range *rows {
 		breed, err := importBreed(ctx, conn, petType, row)
 		if err != nil {

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -88,7 +88,9 @@ func parseFlags() Flags {
 	return Flags{petTypeToImport: petTypeToImport}
 }
 
-func importBreed(ctx context.Context, conn *database.DB, petType pet.PetType, row breeds_importer_service.Row) (*pet.Breed, *pnd.AppError) {
+func importBreed(
+	ctx context.Context, conn *database.DB, petType pet.PetType, row breeds_importer_service.Row,
+) (*pet.Breed, *pnd.AppError) {
 	log.Printf("Importing breed with pet_type: %s, name: %s to database", petType, row.Breed)
 
 	var breed *pet.Breed
@@ -99,7 +101,12 @@ func importBreed(ctx context.Context, conn *database.DB, petType pet.PetType, ro
 		}
 
 		if existing != nil {
-			log.Printf("Breed with id: %d, pet_type: %s, name: %s already exists in database", existing.ID, existing.PetType, existing.Name)
+			log.Printf(
+				"Breed with id: %d, pet_type: %s, name: %s already exists in database",
+				existing.ID,
+				existing.PetType,
+				existing.Name,
+			)
 			breed = existing
 			return nil
 		}
@@ -109,7 +116,12 @@ func importBreed(ctx context.Context, conn *database.DB, petType pet.PetType, ro
 			return err
 		}
 
-		log.Printf("Succeeded to import breed with id: %d, pet_type: %s, name: %s to database", breed.ID, breed.PetType, breed.Name)
+		log.Printf(
+			"Succeeded to import breed with id: %d, pet_type: %s, name: %s to database",
+			breed.ID,
+			breed.PetType,
+			breed.Name,
+		)
 		return nil
 	})
 	if err != nil {

--- a/cmd/import_conditions/main.go
+++ b/cmd/import_conditions/main.go
@@ -6,7 +6,7 @@ import (
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 	"github.com/pet-sitter/pets-next-door-api/internal/postgres"
 )
@@ -24,7 +24,7 @@ func main() {
 
 	ctx := context.Background()
 	err2 = database.WithTransaction(ctx, db, func(tx *database.Tx) *pnd.AppError {
-		result, err2 = postgres.InitConditions(ctx, tx, sos_post.ConditionName)
+		result, err2 = postgres.InitConditions(ctx, tx, sospost.ConditionName)
 		if err2 != nil {
 			return err2
 		}

--- a/cmd/server/handler/auth_handler.go
+++ b/cmd/server/handler/auth_handler.go
@@ -1,8 +1,9 @@
 package handler
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 
@@ -62,7 +63,7 @@ func (h *AuthHandler) KakaoCallback(c echo.Context) error {
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
-	customToken, err2 := h.authService.CustomToken(c.Request().Context(), fmt.Sprintf("%d", userProfile.ID))
+	customToken, err2 := h.authService.CustomToken(c.Request().Context(), strconv.FormatInt(userProfile.ID, 10))
 	if err2 != nil {
 		return c.JSON(err2.StatusCode, err2)
 	}
@@ -88,11 +89,11 @@ func (h *AuthHandler) GenerateFBCustomTokenFromKakao(c echo.Context) error {
 
 	userProfile, err2 := h.kakaoClient.FetchUserProfile(tokenRequest.OAuthToken)
 	if err2 != nil {
-		pndErr := pnd.ErrBadRequest(fmt.Errorf("유효하지 않은 Kakao 인증 정보입니다"))
+		pndErr := pnd.ErrBadRequest(errors.New("유효하지 않은 Kakao 인증 정보입니다"))
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
-	customToken, err := h.authService.CustomToken(c.Request().Context(), fmt.Sprintf("%d", userProfile.ID))
+	customToken, err := h.authService.CustomToken(c.Request().Context(), strconv.FormatInt(userProfile.ID, 10))
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}

--- a/cmd/server/handler/auth_handler.go
+++ b/cmd/server/handler/auth_handler.go
@@ -51,13 +51,13 @@ func (h *AuthHandler) KakaoLogin(c echo.Context) error {
 // @Router /auth/callback/kakao [get]
 func (h *AuthHandler) KakaoCallback(c echo.Context) error {
 	code := pnd.ParseOptionalStringQuery(c, "code")
-	tokenView, err := h.kakaoClient.FetchAccessToken(*code)
+	tokenView, err := h.kakaoClient.FetchAccessToken(c.Request().Context(), *code)
 	if err != nil {
 		pndErr := pnd.ErrUnknown(err)
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
-	userProfile, err := h.kakaoClient.FetchUserProfile(tokenView.AccessToken)
+	userProfile, err := h.kakaoClient.FetchUserProfile(c.Request().Context(), tokenView.AccessToken)
 	if err != nil {
 		pndErr := pnd.ErrUnknown(err)
 		return c.JSON(pndErr.StatusCode, pndErr)
@@ -87,7 +87,7 @@ func (h *AuthHandler) GenerateFBCustomTokenFromKakao(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	userProfile, err2 := h.kakaoClient.FetchUserProfile(tokenRequest.OAuthToken)
+	userProfile, err2 := h.kakaoClient.FetchUserProfile(c.Request().Context(), tokenRequest.OAuthToken)
 	if err2 != nil {
 		pndErr := pnd.ErrBadRequest(errors.New("유효하지 않은 Kakao 인증 정보입니다"))
 		return c.JSON(pndErr.StatusCode, pndErr)

--- a/cmd/server/handler/auth_handler.go
+++ b/cmd/server/handler/auth_handler.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/labstack/echo/v4"
 	"net/http"
+
+	"github.com/labstack/echo/v4"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"

--- a/cmd/server/handler/auth_handler.go
+++ b/cmd/server/handler/auth_handler.go
@@ -13,13 +13,13 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 )
 
-type authHandler struct {
+type AuthHandler struct {
 	authService service.AuthService
 	kakaoClient kakaoinfra.KakaoClient
 }
 
-func NewAuthHandler(authService service.AuthService, kakaoClient kakaoinfra.KakaoClient) *authHandler {
-	return &authHandler{
+func NewAuthHandler(authService service.AuthService, kakaoClient kakaoinfra.KakaoClient) *AuthHandler {
+	return &AuthHandler{
 		authService: authService,
 		kakaoClient: kakaoClient,
 	}
@@ -31,7 +31,7 @@ func NewAuthHandler(authService service.AuthService, kakaoClient kakaoinfra.Kaka
 // @Tags auth
 // @Success 302
 // @Router /auth/login/kakao [get]
-func (h *authHandler) KakaoLogin(c echo.Context) error {
+func (h *AuthHandler) KakaoLogin(c echo.Context) error {
 	return c.Redirect(
 		http.StatusTemporaryRedirect,
 		"https://kauth.kakao.com/oauth/authorize?"+
@@ -48,7 +48,7 @@ func (h *authHandler) KakaoLogin(c echo.Context) error {
 // @Tags auth
 // @Success 200 {object} auth.KakaoCallbackView
 // @Router /auth/callback/kakao [get]
-func (h *authHandler) KakaoCallback(c echo.Context) error {
+func (h *AuthHandler) KakaoCallback(c echo.Context) error {
 	code := pnd.ParseOptionalStringQuery(c, "code")
 	tokenView, err := h.kakaoClient.FetchAccessToken(*code)
 	if err != nil {
@@ -80,7 +80,7 @@ func (h *authHandler) KakaoCallback(c echo.Context) error {
 // @Success 201 {object} auth.GenerateFBCustomTokenResponse
 // @Failure 400 {object} pnd.AppError
 // @Router /auth/custom-tokens/kakao [post]
-func (h *authHandler) GenerateFBCustomTokenFromKakao(c echo.Context) error {
+func (h *AuthHandler) GenerateFBCustomTokenFromKakao(c echo.Context) error {
 	var tokenRequest auth.GenerateFBCustomTokenRequest
 	if err := pnd.ParseBody(c, &tokenRequest); err != nil {
 		return c.JSON(err.StatusCode, err)

--- a/cmd/server/handler/breed_handler.go
+++ b/cmd/server/handler/breed_handler.go
@@ -1,10 +1,11 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
-	"net/http"
 )
 
 type BreedHandler struct {

--- a/cmd/server/handler/condition_handler.go
+++ b/cmd/server/handler/condition_handler.go
@@ -1,8 +1,9 @@
 package handler
 
 import (
-	"github.com/labstack/echo/v4"
 	"net/http"
+
+	"github.com/labstack/echo/v4"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 )

--- a/cmd/server/handler/condition_handler.go
+++ b/cmd/server/handler/condition_handler.go
@@ -22,7 +22,7 @@ func NewConditionHandler(conditionService service.ConditionService) *ConditionHa
 // @Tags posts
 // @Accept  json
 // @Produce  json
-// @Success 200 {object} []sos_post.ConditionView
+// @Success 200 {object} []sospost.ConditionView
 // @Router /posts/sos/conditions [get]
 func (h *ConditionHandler) FindConditions(c echo.Context) error {
 	res, err := h.conditionService.FindConditions(c.Request().Context())

--- a/cmd/server/handler/media_handler.go
+++ b/cmd/server/handler/media_handler.go
@@ -79,7 +79,7 @@ func (h *MediaHandler) UploadImage(c echo.Context) error {
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
-	res, err2 := h.mediaService.UploadMedia(c.Request().Context(), file, media.IMAGE_MEDIA_TYPE, fileHeader.Filename)
+	res, err2 := h.mediaService.UploadMedia(c.Request().Context(), file, media.MediaTypeImage, fileHeader.Filename)
 	if err2 != nil {
 		return c.JSON(err2.StatusCode, err2)
 	}

--- a/cmd/server/handler/media_handler.go
+++ b/cmd/server/handler/media_handler.go
@@ -73,7 +73,9 @@ func (h *mediaHandler) UploadImage(c echo.Context) error {
 	defer file.Close()
 
 	if !isValidMimeType(fileHeader.Header.Get("Content-Type")) {
-		pndErr := pnd.ErrMultipartFormError(fmt.Errorf("invalid MIME type; supported MIME types are: [" + supportedMimeTypeString() + "]"))
+		pndErr := pnd.ErrMultipartFormError(
+			fmt.Errorf("invalid MIME type; supported MIME types are: [" + supportedMimeTypeString() + "]"),
+		)
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 

--- a/cmd/server/handler/media_handler.go
+++ b/cmd/server/handler/media_handler.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -56,25 +56,25 @@ func (h *MediaHandler) FindMediaByID(c echo.Context) error {
 func (h *MediaHandler) UploadImage(c echo.Context) error {
 	fileHeader, err := c.FormFile("file")
 	if err != nil {
-		pndErr := pnd.ErrMultipartFormError(fmt.Errorf("file must be provided"))
+		pndErr := pnd.ErrMultipartFormError(errors.New("file must be provided"))
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
 	if fileHeader.Size > 10<<20 {
-		pndErr := pnd.ErrMultipartFormError(fmt.Errorf("file size must be less than 10MB"))
+		pndErr := pnd.ErrMultipartFormError(errors.New("file size must be less than 10MB"))
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
 	file, err := fileHeader.Open()
 	if err != nil {
-		pndErr := pnd.ErrMultipartFormError(fmt.Errorf("failed to open file"))
+		pndErr := pnd.ErrMultipartFormError(errors.New("failed to open file"))
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 	defer file.Close()
 
 	if !isValidMimeType(fileHeader.Header.Get("Content-Type")) {
 		pndErr := pnd.ErrMultipartFormError(
-			fmt.Errorf("invalid MIME type; supported MIME types are: [" + supportedMimeTypeString() + "]"),
+			errors.New("invalid MIME type; supported MIME types are: [" + supportedMimeTypeString() + "]"),
 		)
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}

--- a/cmd/server/handler/media_handler.go
+++ b/cmd/server/handler/media_handler.go
@@ -2,9 +2,10 @@ package handler
 
 import (
 	"fmt"
-	"github.com/labstack/echo/v4"
 	"net/http"
 	"strings"
+
+	"github.com/labstack/echo/v4"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"

--- a/cmd/server/handler/media_handler.go
+++ b/cmd/server/handler/media_handler.go
@@ -12,12 +12,12 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 )
 
-type mediaHandler struct {
+type MediaHandler struct {
 	mediaService service.MediaService
 }
 
-func NewMediaHandler(mediaService service.MediaService) *mediaHandler {
-	return &mediaHandler{
+func NewMediaHandler(mediaService service.MediaService) *MediaHandler {
+	return &MediaHandler{
 		mediaService: mediaService,
 	}
 }
@@ -30,7 +30,7 @@ func NewMediaHandler(mediaService service.MediaService) *mediaHandler {
 // @Param id path int true "미디어 ID"
 // @Success 200 {object} media.MediaView
 // @Router /media/{id} [get]
-func (h *mediaHandler) FindMediaByID(c echo.Context) error {
+func (h *MediaHandler) FindMediaByID(c echo.Context) error {
 	id, err := pnd.ParseIDFromPath(c, "id")
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
@@ -53,7 +53,7 @@ func (h *mediaHandler) FindMediaByID(c echo.Context) error {
 // @Param file formData file true "이미지 파일"
 // @Success 201 {object} media.MediaView
 // @Router /media/images [post]
-func (h *mediaHandler) UploadImage(c echo.Context) error {
+func (h *MediaHandler) UploadImage(c echo.Context) error {
 	fileHeader, err := c.FormFile("file")
 	if err != nil {
 		pndErr := pnd.ErrMultipartFormError(fmt.Errorf("file must be provided"))

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -11,40 +11,40 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 )
 
-type SosPostHandler struct {
-	sosPostService service.SosPostService
+type SOSPostHandler struct {
+	sosPostService service.SOSPostService
 	authService    service.AuthService
 }
 
-func NewSosPostHandler(sosPostService service.SosPostService, authService service.AuthService) *SosPostHandler {
-	return &SosPostHandler{
+func NewSOSPostHandler(sosPostService service.SOSPostService, authService service.AuthService) *SOSPostHandler {
+	return &SOSPostHandler{
 		sosPostService: sosPostService,
 		authService:    authService,
 	}
 }
 
-// WriteSosPost godoc
+// WriteSOSPost godoc
 // @Summary 돌봄급구 게시글을 업로드합니다.
 // @Description
 // @Tags posts
 // @Accept  json
 // @Produce  json
-// @Param request body sospost.WriteSosPostRequest true "돌봄급구 게시글 업로드 요청"
+// @Param request body sospost.WriteSOSPostRequest true "돌봄급구 게시글 업로드 요청"
 // @Security FirebaseAuth
-// @Success 201 {object} sospost.WriteSosPostView
+// @Success 201 {object} sospost.WriteSOSPostView
 // @Router /posts/sos [post]
-func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
+func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	var writeSosPostRequest sospost.WriteSosPostRequest
-	if err = pnd.ParseBody(c, &writeSosPostRequest); err != nil {
+	var writeSOSPostRequest sospost.WriteSOSPostRequest
+	if err = pnd.ParseBody(c, &writeSOSPostRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	res, err := h.sosPostService.WriteSosPost(c.Request().Context(), foundUser.FirebaseUID, &writeSosPostRequest)
+	res, err := h.sosPostService.WriteSOSPost(c.Request().Context(), foundUser.FirebaseUID, &writeSOSPostRequest)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
@@ -52,7 +52,7 @@ func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
 	return c.JSON(http.StatusCreated, res)
 }
 
-// FindSosPosts godoc
+// FindSOSPosts godoc
 // @Summary 돌봄급구 게시글을 조회합니다.
 // @Description
 // @Tags posts
@@ -63,9 +63,9 @@ func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
 // @Param size query int false "페이지 사이즈" default(20)
 // @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
 // @Param filter_type query string false "필터링 기준" Enums(dog, cat, all)
-// @Success 200 {object} sospost.FindSosPostListView
+// @Success 200 {object} sospost.FindSOSPostListView
 // @Router /posts/sos [get]
-func (h *SosPostHandler) FindSosPosts(c echo.Context) error {
+func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
 	authorID, err := pnd.ParseOptionalIntQuery(c, "author_id")
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
@@ -85,14 +85,14 @@ func (h *SosPostHandler) FindSosPosts(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	var res *sospost.FindSosPostListView
+	var res *sospost.FindSOSPostListView
 	if authorID != nil {
-		res, err = h.sosPostService.FindSosPostsByAuthorID(c.Request().Context(), *authorID, page, size, sortBy, filterType)
+		res, err = h.sosPostService.FindSOSPostsByAuthorID(c.Request().Context(), *authorID, page, size, sortBy, filterType)
 		if err != nil {
 			return c.JSON(err.StatusCode, err)
 		}
 	} else {
-		res, err = h.sosPostService.FindSosPosts(c.Request().Context(), page, size, sortBy, filterType)
+		res, err = h.sosPostService.FindSOSPosts(c.Request().Context(), page, size, sortBy, filterType)
 		if err != nil {
 			return c.JSON(err.StatusCode, err)
 		}
@@ -101,20 +101,20 @@ func (h *SosPostHandler) FindSosPosts(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-// FindSosPostByID godoc
+// FindSOSPostByID godoc
 // @Summary 게시글 ID로 돌봄급구 게시글을 조회합니다.
 // @Description
 // @Tags posts
 // @Produce  json
 // @Param id path int true "게시글 ID"
-// @Success 200 {object} sospost.FindSosPostView
+// @Success 200 {object} sospost.FindSOSPostView
 // @Router /posts/sos/{id} [get]
-func (h *SosPostHandler) FindSosPostByID(c echo.Context) error {
+func (h *SOSPostHandler) FindSOSPostByID(c echo.Context) error {
 	id, err := pnd.ParseIDFromPath(c, "id")
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
-	res, err := h.sosPostService.FindSosPostByID(c.Request().Context(), *id)
+	res, err := h.sosPostService.FindSOSPostByID(c.Request().Context(), *id)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
@@ -122,31 +122,31 @@ func (h *SosPostHandler) FindSosPostByID(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-// UpdateSosPost godoc
+// UpdateSOSPost godoc
 // @Summary 돌봄급구 게시글을 수정합니다.
 // @Description
 // @Tags posts
 // @Accept  json
 // @Produce  json
 // @Security FirebaseAuth
-// @Param request body sospost.UpdateSosPostRequest true "돌봄급구 수정 요청"
+// @Param request body sospost.UpdateSOSPostRequest true "돌봄급구 수정 요청"
 // @Success 200
 // @Router /posts/sos [put]
-func (h *SosPostHandler) UpdateSosPost(c echo.Context) error {
+func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	var updateSosPostRequest sospost.UpdateSosPostRequest
-	if err = pnd.ParseBody(c, &updateSosPostRequest); err != nil {
+	var updateSOSPostRequest sospost.UpdateSOSPostRequest
+	if err = pnd.ParseBody(c, &updateSOSPostRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
 	permission, err := h.sosPostService.CheckUpdatePermission(
 		c.Request().Context(),
 		foundUser.FirebaseUID,
-		updateSosPostRequest.ID,
+		updateSOSPostRequest.ID,
 	)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
@@ -156,7 +156,7 @@ func (h *SosPostHandler) UpdateSosPost(c echo.Context) error {
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
-	res, err := h.sosPostService.UpdateSosPost(c.Request().Context(), &updateSosPostRequest)
+	res, err := h.sosPostService.UpdateSOSPost(c.Request().Context(), &updateSOSPostRequest)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -143,7 +143,11 @@ func (h *SosPostHandler) UpdateSosPost(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	permission, err := h.sosPostService.CheckUpdatePermission(c.Request().Context(), foundUser.FirebaseUID, updateSosPostRequest.ID)
+	permission, err := h.sosPostService.CheckUpdatePermission(
+		c.Request().Context(),
+		foundUser.FirebaseUID,
+		updateSosPostRequest.ID,
+	)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -152,7 +152,7 @@ func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 	if !permission {
-		pndErr := pnd.ErrForbidden(fmt.Errorf("해당 게시글에 대한 수정 권한이 없습니다"))
+		pndErr := pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -40,7 +40,7 @@ func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
 	}
 
 	var writeSosPostRequest sospost.WriteSosPostRequest
-	if err := pnd.ParseBody(c, &writeSosPostRequest); err != nil {
+	if err = pnd.ParseBody(c, &writeSosPostRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
@@ -139,7 +139,7 @@ func (h *SosPostHandler) UpdateSosPost(c echo.Context) error {
 	}
 
 	var updateSosPostRequest sospost.UpdateSosPostRequest
-	if err := pnd.ParseBody(c, &updateSosPostRequest); err != nil {
+	if err = pnd.ParseBody(c, &updateSosPostRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/labstack/echo/v4"
 	"net/http"
+
+	"github.com/labstack/echo/v4"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 )
 
@@ -29,9 +29,9 @@ func NewSosPostHandler(sosPostService service.SosPostService, authService servic
 // @Tags posts
 // @Accept  json
 // @Produce  json
-// @Param request body sos_post.WriteSosPostRequest true "돌봄급구 게시글 업로드 요청"
+// @Param request body sospost.WriteSosPostRequest true "돌봄급구 게시글 업로드 요청"
 // @Security FirebaseAuth
-// @Success 201 {object} sos_post.WriteSosPostView
+// @Success 201 {object} sospost.WriteSosPostView
 // @Router /posts/sos [post]
 func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
@@ -39,7 +39,7 @@ func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	var writeSosPostRequest sos_post.WriteSosPostRequest
+	var writeSosPostRequest sospost.WriteSosPostRequest
 	if err := pnd.ParseBody(c, &writeSosPostRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
@@ -63,7 +63,7 @@ func (h *SosPostHandler) WriteSosPost(c echo.Context) error {
 // @Param size query int false "페이지 사이즈" default(20)
 // @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
 // @Param filter_type query string false "필터링 기준" Enums(dog, cat, all)
-// @Success 200 {object} sos_post.FindSosPostListView
+// @Success 200 {object} sospost.FindSosPostListView
 // @Router /posts/sos [get]
 func (h *SosPostHandler) FindSosPosts(c echo.Context) error {
 	authorID, err := pnd.ParseOptionalIntQuery(c, "author_id")
@@ -85,7 +85,7 @@ func (h *SosPostHandler) FindSosPosts(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	var res *sos_post.FindSosPostListView
+	var res *sospost.FindSosPostListView
 	if authorID != nil {
 		res, err = h.sosPostService.FindSosPostsByAuthorID(c.Request().Context(), *authorID, page, size, sortBy, filterType)
 		if err != nil {
@@ -107,7 +107,7 @@ func (h *SosPostHandler) FindSosPosts(c echo.Context) error {
 // @Tags posts
 // @Produce  json
 // @Param id path int true "게시글 ID"
-// @Success 200 {object} sos_post.FindSosPostView
+// @Success 200 {object} sospost.FindSosPostView
 // @Router /posts/sos/{id} [get]
 func (h *SosPostHandler) FindSosPostByID(c echo.Context) error {
 	id, err := pnd.ParseIDFromPath(c, "id")
@@ -129,7 +129,7 @@ func (h *SosPostHandler) FindSosPostByID(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Security FirebaseAuth
-// @Param request body sos_post.UpdateSosPostRequest true "돌봄급구 수정 요청"
+// @Param request body sospost.UpdateSosPostRequest true "돌봄급구 수정 요청"
 // @Success 200
 // @Router /posts/sos [put]
 func (h *SosPostHandler) UpdateSosPost(c echo.Context) error {
@@ -138,7 +138,7 @@ func (h *SosPostHandler) UpdateSosPost(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	var updateSosPostRequest sos_post.UpdateSosPostRequest
+	var updateSosPostRequest sospost.UpdateSosPostRequest
 	if err := pnd.ParseBody(c, &updateSosPostRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -163,7 +163,7 @@ func (h *UserHandler) UpdateMyProfile(c echo.Context) error {
 	uid := foundUser.FirebaseUID
 
 	var updateUserRequest user.UpdateUserRequest
-	if err := pnd.ParseBody(c, &updateUserRequest); err != nil {
+	if err = pnd.ParseBody(c, &updateUserRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
@@ -278,7 +278,7 @@ func (h *UserHandler) UpdateMyPet(c echo.Context) error {
 	}
 
 	var updatePetRequest pet.UpdatePetRequest
-	if err := pnd.ParseBody(c, &updatePetRequest); err != nil {
+	if err = pnd.ParseBody(c, &updatePetRequest); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -167,7 +167,12 @@ func (h *UserHandler) UpdateMyProfile(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	userModel, err := h.userService.UpdateUserByUID(c.Request().Context(), uid, updateUserRequest.Nickname, updateUserRequest.ProfileImageID)
+	userModel, err := h.userService.UpdateUserByUID(
+		c.Request().Context(),
+		uid,
+		updateUserRequest.Nickname,
+		updateUserRequest.ProfileImageID,
+	)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -188,12 +188,12 @@ func (h *UserHandler) UpdateMyProfile(c echo.Context) error {
 // @Success 204
 // @Router /users/me [delete]
 func (h *UserHandler) DeleteMyAccount(c echo.Context) error {
-	user, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
+	loggedInUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	if err := h.userService.DeleteUserByUID(c.Request().Context(), user.FirebaseUID); err != nil {
+	if err := h.userService.DeleteUserByUID(c.Request().Context(), loggedInUser.FirebaseUID); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -1,8 +1,9 @@
 package handler
 
 import (
-	"github.com/labstack/echo/v4"
 	"net/http"
+
+	"github.com/labstack/echo/v4"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,7 +46,10 @@ func main() {
 		}
 	}
 
-	r := NewRouter(app)
+	r, err := NewRouter(app)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	log.Printf("Starting server on port %s", configs.Port)
 	log.Fatal(http.ListenAndServe(":"+configs.Port, r))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -51,6 +52,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	server := &http.Server{
+		Addr:              ":" + configs.Port,
+		Handler:           r,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+
 	log.Printf("Starting server on port %s", configs.Port)
-	log.Fatal(http.ListenAndServe(":"+configs.Port, r))
+	log.Fatal(server.ListenAndServe())
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,10 +33,17 @@ func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 
 	var app *firebaseinfra.FirebaseApp
+	var err error
 	if configs.GetFirebaseCredentialsJSON() != (configs.FirebaseCredentialsJSONType{}) {
-		app = firebaseinfra.NewFirebaseAppFromCredentialsJSON(configs.GetFirebaseCredentialsJSON())
+		app, err = firebaseinfra.NewFirebaseAppFromCredentialsJSON(configs.GetFirebaseCredentialsJSON())
+		if err != nil {
+			log.Fatal(err)
+		}
 	} else {
-		app = firebaseinfra.NewFirebaseAppFromCredentialsPath(configs.FirebaseCredentialsPath)
+		app, err = firebaseinfra.NewFirebaseAppFromCredentialsPath(configs.FirebaseCredentialsPath)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	r := NewRouter(app)

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -52,7 +52,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) *echo.Echo {
 	userService := service.NewUserService(db, mediaService)
 	authService := service.NewFirebaseBearerAuthService(authClient, userService)
 	breedService := service.NewBreedService(db)
-	sosPostService := service.NewSosPostService(db)
+	sosPostService := service.NewSOSPostService(db)
 	conditionService := service.NewConditionService(db)
 
 	// Initialize handlers
@@ -60,7 +60,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) *echo.Echo {
 	userHandler := handler.NewUserHandler(*userService, authService)
 	mediaHandler := handler.NewMediaHandler(*mediaService)
 	breedHandler := handler.NewBreedHandler(*breedService)
-	sosPostHandler := handler.NewSosPostHandler(*sosPostService, authService)
+	sosPostHandler := handler.NewSOSPostHandler(*sosPostService, authService)
 	conditionHandler := handler.NewConditionHandler(*conditionService)
 
 	// Register middlewares
@@ -123,10 +123,10 @@ func NewRouter(app *firebaseinfra.FirebaseApp) *echo.Echo {
 
 	postAPIGroup := apiRouteGroup.Group("/posts")
 	{
-		postAPIGroup.POST("/sos", sosPostHandler.WriteSosPost)
-		postAPIGroup.GET("/sos/:id", sosPostHandler.FindSosPostByID)
-		postAPIGroup.GET("/sos", sosPostHandler.FindSosPosts)
-		postAPIGroup.PUT("/sos", sosPostHandler.UpdateSosPost)
+		postAPIGroup.POST("/sos", sosPostHandler.WriteSOSPost)
+		postAPIGroup.GET("/sos/:id", sosPostHandler.FindSOSPostByID)
+		postAPIGroup.GET("/sos", sosPostHandler.FindSOSPosts)
+		postAPIGroup.PUT("/sos", sosPostHandler.UpdateSOSPost)
 		postAPIGroup.GET("/sos/conditions", conditionHandler.FindConditions)
 	}
 

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -28,12 +28,12 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 
 	db, err := database.Open(configs.DatabaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("error opening database: %v", err)
+		return nil, fmt.Errorf("error opening database: %w", err)
 	}
 
 	authClient, err := app.Auth(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing app: %v", err)
+		return nil, fmt.Errorf("error initializing app: %w", err)
 	}
 
 	// Initialize services
@@ -45,7 +45,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 		configs.B2BucketName,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing s3 client: %v", err)
+		return nil, fmt.Errorf("error initializing s3 client: %w", err)
 	}
 
 	mediaService := service.NewMediaService(db, s3Client)

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -22,18 +22,18 @@ import (
 	firebaseinfra "github.com/pet-sitter/pets-next-door-api/internal/infra/firebase"
 )
 
-func NewRouter(app *firebaseinfra.FirebaseApp) *echo.Echo {
+func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 	e := echo.New()
 	ctx := context.Background()
 
 	db, err := database.Open(configs.DatabaseURL)
 	if err != nil {
-		log.Fatalf("error opening database: %v\n", err)
+		return nil, fmt.Errorf("error opening database: %v", err)
 	}
 
 	authClient, err := app.Auth(ctx)
 	if err != nil {
-		log.Fatalf("error initializing app: %v\n", err)
+		return nil, fmt.Errorf("error initializing app: %v", err)
 	}
 
 	// Initialize services
@@ -45,7 +45,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) *echo.Echo {
 		configs.B2BucketName,
 	)
 	if err != nil {
-		log.Fatalf("error initializing s3 client: %v\n", err)
+		return nil, fmt.Errorf("error initializing s3 client: %v", err)
 	}
 
 	mediaService := service.NewMediaService(db, s3Client)
@@ -130,5 +130,5 @@ func NewRouter(app *firebaseinfra.FirebaseApp) *echo.Echo {
 		postAPIGroup.GET("/sos/conditions", conditionHandler.FindConditions)
 	}
 
-	return e
+	return e, nil
 }

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"log"
+	"net/http"
+	"os"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/pet-sitter/pets-next-door-api/cmd/server/handler"
@@ -14,9 +18,6 @@ import (
 	pndMiddleware "github.com/pet-sitter/pets-next-door-api/lib/middleware"
 	"github.com/rs/zerolog"
 	echoSwagger "github.com/swaggo/echo-swagger"
-	"log"
-	"net/http"
-	"os"
 
 	firebaseinfra "github.com/pet-sitter/pets-next-door-api/internal/infra/firebase"
 )

--- a/internal/configs/server.go
+++ b/internal/configs/server.go
@@ -9,11 +9,15 @@ import (
 
 var Port = os.Getenv("PORT")
 
-var DatabaseURL = os.Getenv("DATABASE_URL")
-var MigrationPath = os.Getenv("MIGRATION_PATH")
+var (
+	DatabaseURL   = os.Getenv("DATABASE_URL")
+	MigrationPath = os.Getenv("MIGRATION_PATH")
+)
 
-var KakaoRestAPIKey = os.Getenv("KAKAO_REST_API_KEY")
-var KakaoRedirectURI = os.Getenv("KAKAO_REDIRECT_URI")
+var (
+	KakaoRestAPIKey  = os.Getenv("KAKAO_REST_API_KEY")
+	KakaoRedirectURI = os.Getenv("KAKAO_REDIRECT_URI")
+)
 
 var FirebaseCredentialsPath = os.Getenv("FIREBASE_CREDENTIALS_PATH")
 
@@ -47,14 +51,18 @@ func GetFirebaseCredentialsJSON() FirebaseCredentialsJSONType {
 	}
 }
 
-var B2KeyID = os.Getenv("B2_APPLICATION_KEY_ID")
-var B2Key = os.Getenv("B2_APPLICATION_KEY")
-var B2BucketName = os.Getenv("B2_BUCKET_NAME")
-var B2Endpoint = os.Getenv("B2_ENDPOINT")
-var B2Region = os.Getenv("B2_REGION")
+var (
+	B2KeyID      = os.Getenv("B2_APPLICATION_KEY_ID")
+	B2Key        = os.Getenv("B2_APPLICATION_KEY")
+	B2BucketName = os.Getenv("B2_BUCKET_NAME")
+	B2Endpoint   = os.Getenv("B2_ENDPOINT")
+	B2Region     = os.Getenv("B2_REGION")
+)
 
-var GoogleSheetsAPIKey = os.Getenv("GOOGLE_SHEETS_API_KEY")
-var BreedsGoogleSheetsID = os.Getenv("BREEDS_GOOGLE_SHEETS_ID")
+var (
+	GoogleSheetsAPIKey   = os.Getenv("GOOGLE_SHEETS_API_KEY")
+	BreedsGoogleSheetsID = os.Getenv("BREEDS_GOOGLE_SHEETS_ID")
+)
 
 func init() {
 	if Port == "" {

--- a/internal/configs/server.go
+++ b/internal/configs/server.go
@@ -65,6 +65,7 @@ var (
 	BreedsGoogleSheetsID = os.Getenv("BREEDS_GOOGLE_SHEETS_ID")
 )
 
+//nolint:gochecknoinits
 func init() {
 	if Port == "" {
 		Port = "8080"

--- a/internal/configs/server.go
+++ b/internal/configs/server.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	// Load environment variables from .env file
 	_ "github.com/joho/godotenv/autoload"
 )
 

--- a/internal/domain/auth/view.go
+++ b/internal/domain/auth/view.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	kakaoinfra "github.com/pet-sitter/pets-next-door-api/internal/infra/kakao"
@@ -19,7 +19,7 @@ func NewKakaoCallbackView(authToken string, kakaoUserProfile *kakaoinfra.KakaoUs
 	return KakaoCallbackView{
 		AuthToken:            authToken,
 		FirebaseProviderType: user.FirebaseProviderTypeKakao,
-		FirebaseUID:          fmt.Sprintf("%d", kakaoUserProfile.ID),
+		FirebaseUID:          strconv.FormatInt(kakaoUserProfile.ID, 10),
 		Email:                kakaoUserProfile.KakaoAccount.Email,
 		PhotoURL:             kakaoUserProfile.Properties.ProfileImage,
 	}
@@ -45,7 +45,7 @@ func NewGenerateFBCustomTokenResponse(
 	return GenerateFBCustomTokenResponse{
 		AuthToken:            authToken,
 		FirebaseProviderType: user.FirebaseProviderTypeKakao,
-		FirebaseUID:          fmt.Sprintf("%d", kakaoUserProfile.ID),
+		FirebaseUID:          strconv.FormatInt(kakaoUserProfile.ID, 10),
 		Email:                kakaoUserProfile.KakaoAccount.Email,
 		PhotoURL:             kakaoUserProfile.Properties.ProfileImage,
 	}

--- a/internal/domain/auth/view.go
+++ b/internal/domain/auth/view.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	kakaoinfra "github.com/pet-sitter/pets-next-door-api/internal/infra/kakao"
 )

--- a/internal/domain/auth/view.go
+++ b/internal/domain/auth/view.go
@@ -39,7 +39,9 @@ type GenerateFBCustomTokenResponse struct {
 	PhotoURL             string                    `json:"photoURL"`
 }
 
-func NewGenerateFBCustomTokenResponse(authToken string, kakaoUserProfile *kakaoinfra.KakaoUserProfile) GenerateFBCustomTokenResponse {
+func NewGenerateFBCustomTokenResponse(
+	authToken string, kakaoUserProfile *kakaoinfra.KakaoUserProfile,
+) GenerateFBCustomTokenResponse {
 	return GenerateFBCustomTokenResponse{
 		AuthToken:            authToken,
 		FirebaseProviderType: user.FirebaseProviderTypeKakao,

--- a/internal/domain/media/media.go
+++ b/internal/domain/media/media.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"context"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"

--- a/internal/domain/media/media.go
+++ b/internal/domain/media/media.go
@@ -11,7 +11,7 @@ import (
 type MediaType string
 
 const (
-	IMAGE_MEDIA_TYPE MediaType = "image"
+	MediaTypeImage MediaType = "image"
 )
 
 type Media struct {

--- a/internal/domain/media/resource_media.go
+++ b/internal/domain/media/resource_media.go
@@ -2,8 +2,9 @@ package media
 
 import (
 	"context"
-	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 	"time"
+
+	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )

--- a/internal/domain/media/resource_media.go
+++ b/internal/domain/media/resource_media.go
@@ -26,6 +26,10 @@ type ResourceMedia struct {
 }
 
 type ResourceMediaStore interface {
-	CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID int, mediaID int, resourceType string) (*ResourceMedia, *pnd.AppError)
-	FindResourceMediaByResourceID(ctx context.Context, tx *database.Tx, resourceID int, resourceType string) (*MediaList, *pnd.AppError)
+	CreateResourceMedia(
+		ctx context.Context, tx *database.Tx, resourceID int, mediaID int, resourceType string,
+	) (*ResourceMedia, *pnd.AppError)
+	FindResourceMediaByResourceID(
+		ctx context.Context, tx *database.Tx, resourceID int, resourceType string,
+	) (*MediaList, *pnd.AppError)
 }

--- a/internal/domain/media/resource_media.go
+++ b/internal/domain/media/resource_media.go
@@ -27,7 +27,7 @@ type ResourceMedia struct {
 
 type ResourceMediaStore interface {
 	CreateResourceMedia(
-		ctx context.Context, tx *database.Tx, resourceID int, mediaID int, resourceType string,
+		ctx context.Context, tx *database.Tx, resourceID, mediaID int, resourceType string,
 	) (*ResourceMedia, *pnd.AppError)
 	FindResourceMediaByResourceID(
 		ctx context.Context, tx *database.Tx, resourceID int, resourceType string,

--- a/internal/domain/media/resource_media.go
+++ b/internal/domain/media/resource_media.go
@@ -12,7 +12,7 @@ import (
 type ResourceType string
 
 const (
-	SosResourceType ResourceType = "sos_posts"
+	SOSResourceType ResourceType = "sos_posts"
 )
 
 type ResourceMedia struct {

--- a/internal/domain/pet/breed.go
+++ b/internal/domain/pet/breed.go
@@ -21,14 +21,14 @@ type BreedList struct {
 	*pnd.PaginatedView[Breed]
 }
 
-func NewBreedList(page int, size int) *BreedList {
+func NewBreedList(page, size int) *BreedList {
 	return &BreedList{PaginatedView: pnd.NewPaginatedView(
 		page, size, false, make([]Breed, 0),
 	)}
 }
 
 type BreedStore interface {
-	FindBreeds(ctx context.Context, tx *database.Tx, page int, size int, petType *string) (*BreedList, *pnd.AppError)
+	FindBreeds(ctx context.Context, tx *database.Tx, page, size int, petType *string) (*BreedList, *pnd.AppError)
 	FindBreedByPetTypeAndName(ctx context.Context, tx *database.Tx, petType PetType, name string) (*Breed, *pnd.AppError)
 	CreateBreed(ctx context.Context, tx *database.Tx, breed *Breed) (*Breed, *pnd.AppError)
 }

--- a/internal/domain/pet/breed.go
+++ b/internal/domain/pet/breed.go
@@ -2,6 +2,7 @@ package pet
 
 import (
 	"context"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"

--- a/internal/domain/pet/pet.go
+++ b/internal/domain/pet/pet.go
@@ -2,6 +2,7 @@ package pet
 
 import (
 	"context"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"

--- a/internal/domain/sos_post/condition.go
+++ b/internal/domain/sos_post/condition.go
@@ -2,6 +2,7 @@ package sos_post
 
 import (
 	"context"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"

--- a/internal/domain/sos_post/sos_post.go
+++ b/internal/domain/sos_post/sos_post.go
@@ -2,16 +2,19 @@ package sos_post
 
 import (
 	"context"
+	"time"
+
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
-	"time"
 )
 
-type CareType string
-type CarerGender string
-type RewardType string
+type (
+	CareType    string
+	CarerGender string
+	RewardType  string
+)
 
 const (
 	CareTypeFoster   CareType = "foster"

--- a/internal/domain/sos_post/sos_post.go
+++ b/internal/domain/sos_post/sos_post.go
@@ -99,9 +99,29 @@ type SosDates struct {
 type SosDatesList []*SosDates
 
 type SosPostStore interface {
-	WriteSosPost(ctx context.Context, tx *database.Tx, authorID int, utcDateStart string, utcDateEnd string, request *WriteSosPostRequest) (*SosPost, *pnd.AppError)
-	FindSosPosts(ctx context.Context, tx *database.Tx, page int, size int, sortBy string) (*SosPostInfoList, *pnd.AppError)
-	FindSosPostsByAuthorID(ctx context.Context, tx *database.Tx, authorID int, page int, size int, sortBy string) (*SosPostInfoList, *pnd.AppError)
+	WriteSosPost(
+		ctx context.Context,
+		tx *database.Tx,
+		authorID int,
+		utcDateStart string,
+		utcDateEnd string,
+		request *WriteSosPostRequest,
+	) (*SosPost, *pnd.AppError)
+	FindSosPosts(
+		ctx context.Context,
+		tx *database.Tx,
+		page int,
+		size int,
+		sortBy string,
+	) (*SosPostInfoList, *pnd.AppError)
+	FindSosPostsByAuthorID(
+		ctx context.Context,
+		tx *database.Tx,
+		authorID int,
+		page int,
+		size int,
+		sortBy string,
+	) (*SosPostInfoList, *pnd.AppError)
 	FindSosPostByID(ctx context.Context, tx *database.Tx, id int) (*SosPost, *pnd.AppError)
 	UpdateSosPost(ctx context.Context, tx *database.Tx, request *UpdateSosPostRequest) (*SosPost, *pnd.AppError)
 	FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*ConditionList, *pnd.AppError)

--- a/internal/domain/sospost/condition.go
+++ b/internal/domain/sospost/condition.go
@@ -1,4 +1,4 @@
-package sos_post
+package sospost
 
 import (
 	"context"

--- a/internal/domain/sospost/condition.go
+++ b/internal/domain/sospost/condition.go
@@ -18,17 +18,17 @@ type Condition struct {
 
 type ConditionList []*Condition
 
-type SosCondition string
+type SOSCondition string
 
 const (
-	CCTVPermission  SosCondition = "CCTV, 펫캠 촬영 동의"
-	IDVerification  SosCondition = "신분증 인증"
-	PhonePermission SosCondition = "사전 통화 가능 여부"
+	CCTVPermission  SOSCondition = "CCTV, 펫캠 촬영 동의"
+	IDVerification  SOSCondition = "신분증 인증"
+	PhonePermission SOSCondition = "사전 통화 가능 여부"
 )
 
-var ConditionName = []SosCondition{CCTVPermission, IDVerification, PhonePermission}
+var ConditionName = []SOSCondition{CCTVPermission, IDVerification, PhonePermission}
 
 type ConditionStore interface {
-	InitConditions(ctx context.Context, tx *database.Tx, conditions []SosCondition) (string, *pnd.AppError)
+	InitConditions(ctx context.Context, tx *database.Tx, conditions []SOSCondition) (string, *pnd.AppError)
 	FindConditions(ctx context.Context, tx *database.Tx) (*ConditionList, *pnd.AppError)
 }

--- a/internal/domain/sospost/sos_post.go
+++ b/internal/domain/sospost/sos_post.go
@@ -33,7 +33,7 @@ const (
 	RewardTypeNegotiable RewardType = "negotiable"
 )
 
-type SosPost struct {
+type SOSPost struct {
 	ID          int         `field:"id"`
 	AuthorID    int         `field:"author_id"`
 	Title       string      `field:"title"`
@@ -48,11 +48,11 @@ type SosPost struct {
 	DeletedAt   time.Time   `field:"deleted_at"`
 }
 
-type SosPostList struct {
-	*pnd.PaginatedView[SosPost]
+type SOSPostList struct {
+	*pnd.PaginatedView[SOSPost]
 }
 
-type SosPostInfo struct {
+type SOSPostInfo struct {
 	ID          int                    `field:"id" json:"id"`
 	AuthorID    int                    `field:"author" json:"author"`
 	Title       string                 `field:"title" json:"title"`
@@ -61,7 +61,7 @@ type SosPostInfo struct {
 	Conditions  ConditionList          `field:"conditions" json:"conditions"`
 	Pets        pet.PetWithProfileList `field:"pets" json:"pets"`
 	Reward      string                 `field:"reward" json:"reward"`
-	Dates       SosDatesList           `field:"dates" json:"dates"`
+	Dates       SOSDatesList           `field:"dates" json:"dates"`
 	CareType    CareType               `field:"careType" json:"careType"`
 	CarerGender CarerGender            `field:"carerGender" json:"carerGender"`
 	RewardType  RewardType             `field:"rewardType" json:"rewardType"`
@@ -71,23 +71,23 @@ type SosPostInfo struct {
 	DeletedAt   time.Time              `field:"deletedAt" json:"deletedAt"`
 }
 
-type SosPostInfoList struct {
-	*pnd.PaginatedView[SosPostInfo]
+type SOSPostInfoList struct {
+	*pnd.PaginatedView[SOSPostInfo]
 }
 
-func NewSosPostList(page, size int) *SosPostList {
-	return &SosPostList{PaginatedView: pnd.NewPaginatedView(
-		page, size, false, make([]SosPost, 0),
+func NewSOSPostList(page, size int) *SOSPostList {
+	return &SOSPostList{PaginatedView: pnd.NewPaginatedView(
+		page, size, false, make([]SOSPost, 0),
 	)}
 }
 
-func NewSosPostInfoList(page, size int) *SosPostInfoList {
-	return &SosPostInfoList{PaginatedView: pnd.NewPaginatedView(
-		page, size, false, make([]SosPostInfo, 0),
+func NewSOSPostInfoList(page, size int) *SOSPostInfoList {
+	return &SOSPostInfoList{PaginatedView: pnd.NewPaginatedView(
+		page, size, false, make([]SOSPostInfo, 0),
 	)}
 }
 
-type SosDates struct {
+type SOSDates struct {
 	ID          int       `field:"id" json:"id"`
 	DateStartAt string    `field:"date_start_at" json:"date_start_at"`
 	DateEndAt   string    `field:"date_end_at" json:"date_end_at"`
@@ -96,36 +96,36 @@ type SosDates struct {
 	DeletedAt   time.Time `field:"deleted_at" json:"deleted_at"`
 }
 
-type SosDatesList []*SosDates
+type SOSDatesList []*SOSDates
 
-type SosPostStore interface {
-	WriteSosPost(
+type SOSPostStore interface {
+	WriteSOSPost(
 		ctx context.Context,
 		tx *database.Tx,
 		authorID int,
 		utcDateStart string,
 		utcDateEnd string,
-		request *WriteSosPostRequest,
-	) (*SosPost, *pnd.AppError)
-	FindSosPosts(
+		request *WriteSOSPostRequest,
+	) (*SOSPost, *pnd.AppError)
+	FindSOSPosts(
 		ctx context.Context,
 		tx *database.Tx,
 		page int,
 		size int,
 		sortBy string,
-	) (*SosPostInfoList, *pnd.AppError)
-	FindSosPostsByAuthorID(
+	) (*SOSPostInfoList, *pnd.AppError)
+	FindSOSPostsByAuthorID(
 		ctx context.Context,
 		tx *database.Tx,
 		authorID int,
 		page int,
 		size int,
 		sortBy string,
-	) (*SosPostInfoList, *pnd.AppError)
-	FindSosPostByID(ctx context.Context, tx *database.Tx, id int) (*SosPost, *pnd.AppError)
-	UpdateSosPost(ctx context.Context, tx *database.Tx, request *UpdateSosPostRequest) (*SosPost, *pnd.AppError)
+	) (*SOSPostInfoList, *pnd.AppError)
+	FindSOSPostByID(ctx context.Context, tx *database.Tx, id int) (*SOSPost, *pnd.AppError)
+	UpdateSOSPost(ctx context.Context, tx *database.Tx, request *UpdateSOSPostRequest) (*SOSPost, *pnd.AppError)
 	FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*ConditionList, *pnd.AppError)
 	FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.PetList, *pnd.AppError)
-	WriteDates(ctx context.Context, tx *database.Tx, dates []string, sosPostID int) (*SosDatesList, *pnd.AppError)
-	FindDatesBySosPostID(ctx context.Context, tx *database.Tx, sosPostID int) (*SosDatesList, *pnd.AppError)
+	WriteDates(ctx context.Context, tx *database.Tx, dates []string, sosPostID int) (*SOSDatesList, *pnd.AppError)
+	FindDatesBySOSPostID(ctx context.Context, tx *database.Tx, sosPostID int) (*SOSDatesList, *pnd.AppError)
 }

--- a/internal/domain/sospost/sos_post.go
+++ b/internal/domain/sospost/sos_post.go
@@ -1,4 +1,4 @@
-package sos_post
+package sospost
 
 import (
 	"context"
@@ -75,13 +75,13 @@ type SosPostInfoList struct {
 	*pnd.PaginatedView[SosPostInfo]
 }
 
-func NewSosPostList(page int, size int) *SosPostList {
+func NewSosPostList(page, size int) *SosPostList {
 	return &SosPostList{PaginatedView: pnd.NewPaginatedView(
 		page, size, false, make([]SosPost, 0),
 	)}
 }
 
-func NewSosPostInfoList(page int, size int) *SosPostInfoList {
+func NewSosPostInfoList(page, size int) *SosPostInfoList {
 	return &SosPostInfoList{PaginatedView: pnd.NewPaginatedView(
 		page, size, false, make([]SosPostInfo, 0),
 	)}

--- a/internal/domain/sospost/view.go
+++ b/internal/domain/sospost/view.go
@@ -30,12 +30,12 @@ func (cl *ConditionList) ToConditionViewList() []ConditionView {
 	return conditionViews
 }
 
-type WriteSosPostRequest struct {
+type WriteSOSPostRequest struct {
 	Title        string        `json:"title" validate:"required"`
 	Content      string        `json:"content" validate:"required"`
 	ImageIDs     []int         `json:"imageIds" validate:"required"`
 	Reward       string        `json:"reward"`
-	Dates        []SosDateView `json:"dates" validate:"required"`
+	Dates        []SOSDateView `json:"dates" validate:"required"`
 	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
 	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
 	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
@@ -43,7 +43,7 @@ type WriteSosPostRequest struct {
 	PetIDs       []int         `json:"petIds"`
 }
 
-type WriteSosPostView struct {
+type WriteSOSPostView struct {
 	ID          int                 `json:"id"`
 	AuthorID    int                 `json:"authorId"`
 	Title       string              `json:"title"`
@@ -52,7 +52,7 @@ type WriteSosPostView struct {
 	Conditions  []ConditionView     `json:"conditions"`
 	Pets        []pet.PetView       `json:"pets"`
 	Reward      string              `json:"reward"`
-	Dates       []SosDateView       `json:"dates"`
+	Dates       []SOSDateView       `json:"dates"`
 	CareType    CareType            `json:"careType"`
 	CarerGender CarerGender         `json:"carerGender"`
 	RewardType  RewardType          `json:"rewardType"`
@@ -61,13 +61,13 @@ type WriteSosPostView struct {
 	UpdatedAt   string              `json:"updatedAt"`
 }
 
-func (p *SosPost) ToWriteSosPostView(
+func (p *SOSPost) ToWriteSOSPostView(
 	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
-	sosDates []SosDateView,
-) *WriteSosPostView {
-	return &WriteSosPostView{
+	sosDates []SOSDateView,
+) *WriteSOSPostView {
+	return &WriteSOSPostView{
 		ID:          p.ID,
 		AuthorID:    p.AuthorID,
 		Title:       p.Title,
@@ -86,7 +86,7 @@ func (p *SosPost) ToWriteSosPostView(
 	}
 }
 
-type FindSosPostView struct {
+type FindSOSPostView struct {
 	ID          int                          `json:"id"`
 	Author      *user.UserWithoutPrivateInfo `json:"author"`
 	Title       string                       `json:"title"`
@@ -95,7 +95,7 @@ type FindSosPostView struct {
 	Conditions  []ConditionView              `json:"conditions"`
 	Pets        []pet.PetView                `json:"pets"`
 	Reward      string                       `json:"reward"`
-	Dates       []SosDateView                `json:"dates"`
+	Dates       []SOSDateView                `json:"dates"`
 	CareType    CareType                     `json:"careType"`
 	CarerGender CarerGender                  `json:"carerGender"`
 	RewardType  RewardType                   `json:"rewardType"`
@@ -104,14 +104,14 @@ type FindSosPostView struct {
 	UpdatedAt   string                       `json:"updatedAt"`
 }
 
-func (p *SosPost) ToFindSosPostView(
+func (p *SOSPost) ToFindSOSPostView(
 	author *user.UserWithoutPrivateInfo,
 	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
-	sosDates []SosDateView,
-) *FindSosPostView {
-	return &FindSosPostView{
+	sosDates []SOSDateView,
+) *FindSOSPostView {
+	return &FindSOSPostView{
 		ID:          p.ID,
 		Author:      author,
 		Title:       p.Title,
@@ -130,34 +130,34 @@ func (p *SosPost) ToFindSosPostView(
 	}
 }
 
-type FindSosPostListView struct {
-	*pnd.PaginatedView[FindSosPostView]
+type FindSOSPostListView struct {
+	*pnd.PaginatedView[FindSOSPostView]
 }
 
-func FromEmptySosPostList(sosPosts *SosPostList) *FindSosPostListView {
-	return &FindSosPostListView{
+func FromEmptySOSPostList(sosPosts *SOSPostList) *FindSOSPostListView {
+	return &FindSOSPostListView{
 		PaginatedView: pnd.NewPaginatedView(
-			sosPosts.Page, sosPosts.Size, sosPosts.IsLastPage, make([]FindSosPostView, 0),
+			sosPosts.Page, sosPosts.Size, sosPosts.IsLastPage, make([]FindSOSPostView, 0),
 		),
 	}
 }
 
-func FromEmptySosPostInfoList(sosPosts *SosPostInfoList) *FindSosPostListView {
-	return &FindSosPostListView{
+func FromEmptySOSPostInfoList(sosPosts *SOSPostInfoList) *FindSOSPostListView {
+	return &FindSOSPostListView{
 		PaginatedView: pnd.NewPaginatedView(
-			sosPosts.Page, sosPosts.Size, sosPosts.IsLastPage, make([]FindSosPostView, 0),
+			sosPosts.Page, sosPosts.Size, sosPosts.IsLastPage, make([]FindSOSPostView, 0),
 		),
 	}
 }
 
-func (p *SosPostInfo) ToFindSosPostInfoView(
+func (p *SOSPostInfo) ToFindSOSPostInfoView(
 	author *user.UserWithoutPrivateInfo,
 	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
-	sosDates []SosDateView,
-) *FindSosPostView {
-	return &FindSosPostView{
+	sosDates []SOSDateView,
+) *FindSOSPostView {
+	return &FindSOSPostView{
 		ID:          p.ID,
 		Author:      author,
 		Title:       p.Title,
@@ -176,12 +176,12 @@ func (p *SosPostInfo) ToFindSosPostInfoView(
 	}
 }
 
-type UpdateSosPostRequest struct {
+type UpdateSOSPostRequest struct {
 	ID           int           `json:"id" validate:"required"`
 	Title        string        `json:"title" validate:"required"`
 	Content      string        `json:"content" validate:"required"`
 	ImageIDs     []int         `json:"imageIds" validate:"required"`
-	Dates        []SosDateView `json:"dates" validate:"required"`
+	Dates        []SOSDateView `json:"dates" validate:"required"`
 	Reward       string        `json:"reward"`
 	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
 	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
@@ -190,7 +190,7 @@ type UpdateSosPostRequest struct {
 	PetIDs       []int         `json:"petIds"`
 }
 
-type UpdateSosPostView struct {
+type UpdateSOSPostView struct {
 	ID          int                 `json:"id"`
 	AuthorID    int                 `json:"authorId"`
 	Title       string              `json:"title"`
@@ -199,7 +199,7 @@ type UpdateSosPostView struct {
 	Conditions  []ConditionView     `json:"conditions"`
 	Pets        []pet.PetView       `json:"pets"`
 	Reward      string              `json:"reward"`
-	Dates       []SosDateView       `json:"dates"`
+	Dates       []SOSDateView       `json:"dates"`
 	CareType    CareType            `json:"careType"`
 	CarerGender CarerGender         `json:"carerGender"`
 	RewardType  RewardType          `json:"rewardType"`
@@ -208,13 +208,13 @@ type UpdateSosPostView struct {
 	UpdatedAt   string              `json:"updatedAt"`
 }
 
-func (p *SosPost) ToUpdateSosPostView(
+func (p *SOSPost) ToUpdateSOSPostView(
 	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
-	sosDates []SosDateView,
-) *UpdateSosPostView {
-	return &UpdateSosPostView{
+	sosDates []SOSDateView,
+) *UpdateSOSPostView {
+	return &UpdateSOSPostView{
 		ID:          p.ID,
 		AuthorID:    p.AuthorID,
 		Title:       p.Title,
@@ -233,22 +233,22 @@ func (p *SosPost) ToUpdateSosPostView(
 	}
 }
 
-type SosDateView struct {
+type SOSDateView struct {
 	DateStartAt string `json:"dateStartAt"`
 	DateEndAt   string `json:"dateEndAt"`
 }
 
-func (d *SosDates) ToSosDateView() SosDateView {
-	return SosDateView{
+func (d *SOSDates) ToSOSDateView() SOSDateView {
+	return SOSDateView{
 		DateStartAt: utils.FormatDate(d.DateStartAt),
 		DateEndAt:   utils.FormatDate(d.DateEndAt),
 	}
 }
 
-func (dl *SosDatesList) ToSosDateViewList() []SosDateView {
-	sosDateViews := make([]SosDateView, len(*dl))
+func (dl *SOSDatesList) ToSOSDateViewList() []SOSDateView {
+	sosDateViews := make([]SOSDateView, len(*dl))
 	for i, d := range *dl {
-		sosDateViews[i] = d.ToSosDateView()
+		sosDateViews[i] = d.ToSOSDateView()
 	}
 	return sosDateViews
 }

--- a/internal/domain/sospost/view.go
+++ b/internal/domain/sospost/view.go
@@ -1,4 +1,4 @@
-package sos_post
+package sospost
 
 import (
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
@@ -62,7 +62,7 @@ type WriteSosPostView struct {
 }
 
 func (p *SosPost) ToWriteSosPostView(
-	media media.MediaViewList,
+	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
 	sosDates []SosDateView,
@@ -72,7 +72,7 @@ func (p *SosPost) ToWriteSosPostView(
 		AuthorID:    p.AuthorID,
 		Title:       p.Title,
 		Content:     p.Content,
-		Media:       media,
+		Media:       mediaList,
 		Conditions:  conditions,
 		Pets:        pets,
 		Reward:      p.Reward,
@@ -106,7 +106,7 @@ type FindSosPostView struct {
 
 func (p *SosPost) ToFindSosPostView(
 	author *user.UserWithoutPrivateInfo,
-	media media.MediaViewList,
+	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
 	sosDates []SosDateView,
@@ -116,7 +116,7 @@ func (p *SosPost) ToFindSosPostView(
 		Author:      author,
 		Title:       p.Title,
 		Content:     p.Content,
-		Media:       media,
+		Media:       mediaList,
 		Conditions:  conditions,
 		Pets:        pets,
 		Reward:      p.Reward,
@@ -152,7 +152,7 @@ func FromEmptySosPostInfoList(sosPosts *SosPostInfoList) *FindSosPostListView {
 
 func (p *SosPostInfo) ToFindSosPostInfoView(
 	author *user.UserWithoutPrivateInfo,
-	media media.MediaViewList,
+	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
 	sosDates []SosDateView,
@@ -162,7 +162,7 @@ func (p *SosPostInfo) ToFindSosPostInfoView(
 		Author:      author,
 		Title:       p.Title,
 		Content:     p.Content,
-		Media:       media,
+		Media:       mediaList,
 		Conditions:  conditions,
 		Pets:        pets,
 		Reward:      p.Reward,
@@ -209,7 +209,7 @@ type UpdateSosPostView struct {
 }
 
 func (p *SosPost) ToUpdateSosPostView(
-	media media.MediaViewList,
+	mediaList media.MediaViewList,
 	conditions []ConditionView,
 	pets []pet.PetView,
 	sosDates []SosDateView,
@@ -219,7 +219,7 @@ func (p *SosPost) ToUpdateSosPostView(
 		AuthorID:    p.AuthorID,
 		Title:       p.Title,
 		Content:     p.Content,
-		Media:       media,
+		Media:       mediaList,
 		Conditions:  conditions,
 		Pets:        pets,
 		Reward:      p.Reward,

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -89,7 +89,7 @@ type UserWithoutPrivateInfoList struct {
 	*pnd.PaginatedView[UserWithoutPrivateInfo]
 }
 
-func NewUserWithoutPrivateInfoList(page int, size int) *UserWithoutPrivateInfoList {
+func NewUserWithoutPrivateInfoList(page, size int) *UserWithoutPrivateInfoList {
 	return &UserWithoutPrivateInfoList{PaginatedView: pnd.NewPaginatedView(
 		page, size, false, make([]UserWithoutPrivateInfo, 0),
 	)}
@@ -101,13 +101,13 @@ type UserStatus struct {
 
 type UserStore interface {
 	CreateUser(ctx context.Context, tx *database.Tx, request *RegisterUserRequest) (*User, *pnd.AppError)
-	FindUsers(ctx context.Context, tx *database.Tx, page int, size int, nickname *string) (*UserWithoutPrivateInfoList, *pnd.AppError)
+	FindUsers(ctx context.Context, tx *database.Tx, page, size int, nickname *string) (*UserWithoutPrivateInfoList, *pnd.AppError)
 	FindUserByID(ctx context.Context, tx *database.Tx, id int, includeDeleted bool) (*UserWithProfileImage, *pnd.AppError)
 	FindUserByEmail(ctx context.Context, tx *database.Tx, email string) (*UserWithProfileImage, *pnd.AppError)
 	FindUserByUID(ctx context.Context, tx *database.Tx, uid string) (*UserWithProfileImage, *pnd.AppError)
-	FindUserIDByFbUID(ctx context.Context, tx *database.Tx, fbUid string) (int, *pnd.AppError)
+	FindUserIDByFbUID(ctx context.Context, tx *database.Tx, fbUID string) (int, *pnd.AppError)
 	ExistsUserByNickname(ctx context.Context, tx *database.Tx, nickname string) (bool, *pnd.AppError)
 	FindUserStatusByEmail(ctx context.Context, tx *database.Tx, email string) (*UserStatus, *pnd.AppError)
-	UpdateUserByUID(ctx context.Context, tx *database.Tx, uid string, nickname string, profileImageID *int) (*User, *pnd.AppError)
+	UpdateUserByUID(ctx context.Context, tx *database.Tx, uid, nickname string, profileImageID *int) (*User, *pnd.AppError)
 	DeleteUserByUID(ctx context.Context, tx *database.Tx, uid string) *pnd.AppError
 }

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -3,8 +3,9 @@ package user
 import (
 	"context"
 	"database/sql"
-	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 	"time"
+
+	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -101,7 +101,13 @@ type UserStatus struct {
 
 type UserStore interface {
 	CreateUser(ctx context.Context, tx *database.Tx, request *RegisterUserRequest) (*User, *pnd.AppError)
-	FindUsers(ctx context.Context, tx *database.Tx, page, size int, nickname *string) (*UserWithoutPrivateInfoList, *pnd.AppError)
+	FindUsers(
+		ctx context.Context,
+		tx *database.Tx,
+		page int,
+		size int,
+		nickname *string,
+	) (*UserWithoutPrivateInfoList, *pnd.AppError)
 	FindUserByID(ctx context.Context, tx *database.Tx, id int, includeDeleted bool) (*UserWithProfileImage, *pnd.AppError)
 	FindUserByEmail(ctx context.Context, tx *database.Tx, email string) (*UserWithProfileImage, *pnd.AppError)
 	FindUserByUID(ctx context.Context, tx *database.Tx, uid string) (*UserWithProfileImage, *pnd.AppError)

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/golang-migrate/migrate/v4"
 
@@ -67,7 +68,7 @@ func (db *DB) Migrate(migrationPath string) error {
 		return err
 	}
 
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return err
 	}
 

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -61,7 +61,6 @@ func (db *DB) Migrate(migrationPath string) error {
 		"file://"+migrationPath,
 		db.databaseURL,
 	)
-
 	if err != nil {
 		return err
 	}

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -2,10 +2,10 @@ package database
 
 import (
 	"database/sql"
-	"log"
-
 	"github.com/golang-migrate/migrate/v4"
+	// To use Postgres driver
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	// To use file source
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
@@ -31,7 +31,7 @@ func (db *DB) Close() error {
 }
 
 func (db *DB) Flush() error {
-	var tableNames []string = []string{
+	tableNames := []string{
 		"users",
 		"breeds",
 		"resource_media",
@@ -49,7 +49,7 @@ func (db *DB) Flush() error {
 	for _, tableName := range tableNames {
 		_, err := db.DB.Exec("DELETE FROM " + tableName)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 	}
 

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"database/sql"
+
 	"github.com/golang-migrate/migrate/v4"
+
 	// To use Postgres driver
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	// To use file source

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -50,7 +50,7 @@ func (db *DB) Flush() error {
 	}
 
 	for _, tableName := range tableNames {
-		_, err := db.DB.Exec("DELETE FROM " + tableName)
+		_, err := db.DB.Exec("DELETE FROM " + tableName) //nolint:gosec
 		if err != nil {
 			return err
 		}

--- a/internal/infra/database/transaction.go
+++ b/internal/infra/database/transaction.go
@@ -22,8 +22,8 @@ type Transactioner interface {
 	BeginTx() (*DB, *pnd.AppError)
 }
 
-func (sdt *DB) BeginTx(ctx context.Context) (*Tx, *pnd.AppError) {
-	tx, err := sdt.DB.BeginTx(ctx, nil)
+func (db *DB) BeginTx(ctx context.Context) (*Tx, *pnd.AppError) {
+	tx, err := db.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}

--- a/internal/infra/database/transaction.go
+++ b/internal/infra/database/transaction.go
@@ -9,10 +9,10 @@ import (
 )
 
 type DBTx interface {
-	ExecContext(context context.Context, query string, args ...any) (sql.Result, error)
-	QueryContext(context context.Context, query string, args ...any) (*sql.Rows, error)
-	QueryRowContext(context context.Context, query string, args ...any) *sql.Row
-	PrepareContext(context context.Context, query string) (*sql.Stmt, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
 }
 
 type Transactioner interface {
@@ -83,9 +83,5 @@ func WithTransaction(ctx context.Context, conn *DB, f func(tx *Tx) *pnd.AppError
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Commit()
 }

--- a/internal/infra/database/transaction.go
+++ b/internal/infra/database/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )
 

--- a/internal/infra/database/transaction.go
+++ b/internal/infra/database/transaction.go
@@ -39,7 +39,7 @@ func (sct *Tx) EndTx(f func() *pnd.AppError) *pnd.AppError {
 		if p := recover(); p != nil {
 			tx.Rollback()
 			panic(p)
-		} else if err := f(); err != nil {
+		} else if err = f(); err != nil {
 			tx.Rollback()
 		} else if err := tx.Commit(); err != nil {
 			tx.Rollback()
@@ -76,7 +76,7 @@ func WithTransaction(ctx context.Context, conn *DB, f func(tx *Tx) *pnd.AppError
 	}
 
 	if err := f(tx); err != nil {
-		if err := tx.Rollback(); err != nil {
+		if err = tx.Rollback(); err != nil {
 			return err
 		}
 

--- a/internal/infra/firebase/app.go
+++ b/internal/infra/firebase/app.go
@@ -3,9 +3,11 @@ package firebaseinfra
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"fmt"
 
 	firebase "firebase.google.com/go"
+
+	// Firebase Auth initialization
 	_ "firebase.google.com/go/auth"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"
 	"golang.org/x/oauth2/google"
@@ -17,20 +19,20 @@ type FirebaseApp struct {
 	*firebase.App
 }
 
-func NewFirebaseAppFromCredentialsPath(firebaseCredentialsPath string) *FirebaseApp {
+func NewFirebaseAppFromCredentialsPath(firebaseCredentialsPath string) (*FirebaseApp, error) {
 	opt := option.WithCredentialsFile(firebaseCredentialsPath)
 	app, err := firebase.NewApp(context.Background(), nil, opt)
 	if err != nil {
-		log.Fatalf("error initializing app: %v\n", err)
+		return nil, fmt.Errorf("error initializing app: %v", err)
 	}
 
-	return &FirebaseApp{app}
+	return &FirebaseApp{app}, nil
 }
 
-func NewFirebaseAppFromCredentialsJSON(firebaseCredentialsJSON configs.FirebaseCredentialsJSONType) *FirebaseApp {
+func NewFirebaseAppFromCredentialsJSON(firebaseCredentialsJSON configs.FirebaseCredentialsJSONType) (*FirebaseApp, error) {
 	firebaseCredentialsJSONBytes, err := json.Marshal(firebaseCredentialsJSON)
 	if err != nil {
-		log.Fatalf("error marshalling firebase credentials json: %v\n", err)
+		return nil, fmt.Errorf("error marshalling firebase credentials json: %v", err)
 	}
 
 	opt := option.WithCredentials(
@@ -41,8 +43,8 @@ func NewFirebaseAppFromCredentialsJSON(firebaseCredentialsJSON configs.FirebaseC
 	)
 	app, err := firebase.NewApp(context.Background(), nil, opt)
 	if err != nil {
-		log.Fatalf("error initializing app: %v\n", err)
+		return nil, fmt.Errorf("error initializing app: %v", err)
 	}
 
-	return &FirebaseApp{app}
+	return &FirebaseApp{app}, nil
 }

--- a/internal/infra/firebase/app.go
+++ b/internal/infra/firebase/app.go
@@ -23,7 +23,7 @@ func NewFirebaseAppFromCredentialsPath(firebaseCredentialsPath string) (*Firebas
 	opt := option.WithCredentialsFile(firebaseCredentialsPath)
 	app, err := firebase.NewApp(context.Background(), nil, opt)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing app: %v", err)
+		return nil, fmt.Errorf("error initializing app: %w", err)
 	}
 
 	return &FirebaseApp{app}, nil
@@ -32,7 +32,7 @@ func NewFirebaseAppFromCredentialsPath(firebaseCredentialsPath string) (*Firebas
 func NewFirebaseAppFromCredentialsJSON(firebaseCredentialsJSON configs.FirebaseCredentialsJSONType) (*FirebaseApp, error) {
 	firebaseCredentialsJSONBytes, err := json.Marshal(firebaseCredentialsJSON)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling firebase credentials json: %v", err)
+		return nil, fmt.Errorf("error marshalling firebase credentials json: %w", err)
 	}
 
 	opt := option.WithCredentials(
@@ -43,7 +43,7 @@ func NewFirebaseAppFromCredentialsJSON(firebaseCredentialsJSON configs.FirebaseC
 	)
 	app, err := firebase.NewApp(context.Background(), nil, opt)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing app: %v", err)
+		return nil, fmt.Errorf("error initializing app: %w", err)
 	}
 
 	return &FirebaseApp{app}, nil

--- a/internal/infra/firebase/app.go
+++ b/internal/infra/firebase/app.go
@@ -29,7 +29,9 @@ func NewFirebaseAppFromCredentialsPath(firebaseCredentialsPath string) (*Firebas
 	return &FirebaseApp{app}, nil
 }
 
-func NewFirebaseAppFromCredentialsJSON(firebaseCredentialsJSON configs.FirebaseCredentialsJSONType) (*FirebaseApp, error) {
+func NewFirebaseAppFromCredentialsJSON(
+	firebaseCredentialsJSON configs.FirebaseCredentialsJSONType,
+) (*FirebaseApp, error) {
 	firebaseCredentialsJSONBytes, err := json.Marshal(firebaseCredentialsJSON)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling firebase credentials json: %w", err)

--- a/internal/infra/kakao/client.go
+++ b/internal/infra/kakao/client.go
@@ -31,7 +31,7 @@ func (kakaoClient *KakaoDefaultClient) FetchAccessToken(ctx context.Context, cod
 
 	req, _ := http.NewRequestWithContext(
 		ctx,
-		"POST",
+		http.MethodPost,
 		"https://kauth.kakao.com/oauth/token",
 		strings.NewReader(kakaoTokenRequest.ToURLValues().Encode()),
 	)
@@ -65,8 +65,7 @@ func (kakaoClient *KakaoDefaultClient) FetchAccessToken(ctx context.Context, cod
 
 func (kakaoClient *KakaoDefaultClient) FetchUserProfile(ctx context.Context, code string) (*KakaoUserProfile, error) {
 	client := &http.Client{}
-	req, _ := http.NewRequestWithContext(ctx,
-		"GET", "https://kapi.kakao.com/v2/user/me", nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://kapi.kakao.com/v2/user/me", nil)
 	req.Header.Add("Authorization", "Bearer "+code)
 	res, err := client.Do(req)
 	if err != nil {

--- a/internal/infra/kakao/client.go
+++ b/internal/infra/kakao/client.go
@@ -2,7 +2,7 @@ package kakaoinfra
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -71,7 +71,7 @@ func (kakaoClient *KakaoDefaultClient) FetchUserProfile(code string) (*KakaoUser
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch user profile from Kakao server")
+		return nil, errors.New("failed to fetch user profile from Kakao server")
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/internal/infra/kakao/view.go
+++ b/internal/infra/kakao/view.go
@@ -38,30 +38,36 @@ type KakaoTokenResponse struct {
 }
 
 type KakaoUserProfile struct {
-	ID          int64  `json:"id"`
-	ConnectedAt string `json:"connected_at"`
-	Properties  struct {
-		Nickname       string `json:"nickname"`
-		ProfileImage   string `json:"profile_image"`
-		ThumbnailImage string `json:"thumbnail_image"`
-	} `json:"properties"`
-	KakaoAccount struct {
-		ProfileNeedsAgreement bool `json:"profile_needs_agreement"`
-		Profile               struct {
-			Nickname          string `json:"nickname"`
-			ProfileImageURL   string `json:"profile_image_url"`
-			ThumbnailImageURL string `json:"thumbnail_image_url"`
-		} `json:"profile"`
-		HasEmail               bool   `json:"has_email"`
-		EmailNeedsAgreement    bool   `json:"email_needs_agreement"`
-		IsEmailValid           bool   `json:"is_email_valid"`
-		IsEmailVerified        bool   `json:"is_email_verified"`
-		Email                  string `json:"email"`
-		HasAgeRange            bool   `json:"has_age_range"`
-		AgeRangeNeedsAgreement bool   `json:"age_range_needs_agreement"`
-		AgeRange               string `json:"age_range"`
-		HasGender              bool   `json:"has_gender"`
-		GenderNeedsAgreement   bool   `json:"gender_needs_agreement"`
-		Gender                 string `json:"gender"`
-	} `json:"kakao_account"`
+	ID           int64        `json:"id"`
+	ConnectedAt  string       `json:"connected_at"`
+	Properties   properties   `json:"properties"`
+	KakaoAccount kakaoAccount `json:"kakao_account"`
+}
+
+type properties struct {
+	Nickname       string `json:"nickname"`
+	ProfileImage   string `json:"profile_image"`
+	ThumbnailImage string `json:"thumbnail_image"`
+}
+
+type kakaoProfile struct {
+	Nickname          string `json:"nickname"`
+	ProfileImageURL   string `json:"profile_image_url"`
+	ThumbnailImageURL string `json:"thumbnail_image_url"`
+}
+
+type kakaoAccount struct {
+	ProfileNeedsAgreement  bool         `json:"profile_needs_agreement"`
+	Profile                kakaoProfile `json:"profile"`
+	HasEmail               bool         `json:"has_email"`
+	EmailNeedsAgreement    bool         `json:"email_needs_agreement"`
+	IsEmailValid           bool         `json:"is_email_valid"`
+	IsEmailVerified        bool         `json:"is_email_verified"`
+	Email                  string       `json:"email"`
+	HasAgeRange            bool         `json:"has_age_range"`
+	AgeRangeNeedsAgreement bool         `json:"age_range_needs_agreement"`
+	AgeRange               string       `json:"age_range"`
+	HasGender              bool         `json:"has_gender"`
+	GenderNeedsAgreement   bool         `json:"gender_needs_agreement"`
+	Gender                 string       `json:"gender"`
 }

--- a/internal/infra/s3/client.go
+++ b/internal/infra/s3/client.go
@@ -16,9 +16,9 @@ type S3Client struct {
 	bucketName string
 }
 
-func NewS3Client(keyId, key, endpoint, region, bucketName string) (*S3Client, error) {
+func NewS3Client(keyID, key, endpoint, region, bucketName string) (*S3Client, error) {
 	s3Config := &aws.Config{
-		Credentials:      credentials.NewStaticCredentials(keyId, key, ""),
+		Credentials:      credentials.NewStaticCredentials(keyID, key, ""),
 		Endpoint:         aws.String(endpoint),
 		Region:           aws.String(region),
 		S3ForcePathStyle: aws.Bool(true),

--- a/internal/postgres/breed_store.go
+++ b/internal/postgres/breed_store.go
@@ -100,7 +100,7 @@ func CreateBreed(ctx context.Context, tx *database.Tx, breed *pet.Breed) (*pet.B
 		id, pet_type, name, created_at, updated_at
 	`
 
-	if err := tx.QueryRowContext(ctx, sql,
+	if err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		breed.Name,
 		breed.PetType,
 	).Scan(

--- a/internal/postgres/breed_store.go
+++ b/internal/postgres/breed_store.go
@@ -48,7 +48,9 @@ func FindBreeds(ctx context.Context, tx *database.Tx, page int, size int, petTyp
 	return breedList, nil
 }
 
-func FindBreedByPetTypeAndName(ctx context.Context, tx *database.Tx, petType pet.PetType, name string) (*pet.Breed, *pnd.AppError) {
+func FindBreedByPetTypeAndName(
+	ctx context.Context, tx *database.Tx, petType pet.PetType, name string,
+) (*pet.Breed, *pnd.AppError) {
 	const sql = `
 	SELECT
 		id,
@@ -65,8 +67,16 @@ func FindBreedByPetTypeAndName(ctx context.Context, tx *database.Tx, petType pet
 	`
 
 	breed := &pet.Breed{}
-	err := tx.QueryRowContext(ctx, sql, petType, name).Scan(&breed.ID, &breed.Name, &breed.PetType, &breed.CreatedAt, &breed.UpdatedAt)
-	if err != nil {
+	if err := tx.QueryRowContext(ctx, sql,
+		petType,
+		name,
+	).Scan(
+		&breed.ID,
+		&breed.Name,
+		&breed.PetType,
+		&breed.CreatedAt,
+		&breed.UpdatedAt,
+	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
@@ -90,8 +100,16 @@ func CreateBreed(ctx context.Context, tx *database.Tx, breed *pet.Breed) (*pet.B
 		id, pet_type, name, created_at, updated_at
 	`
 
-	err := tx.QueryRowContext(ctx, sql, breed.Name, breed.PetType).Scan(&breed.ID, &breed.PetType, &breed.Name, &breed.CreatedAt, &breed.UpdatedAt)
-	if err != nil {
+	if err := tx.QueryRowContext(ctx, sql,
+		breed.Name,
+		breed.PetType,
+	).Scan(
+		&breed.ID,
+		&breed.PetType,
+		&breed.Name,
+		&breed.CreatedAt,
+		&breed.UpdatedAt,
+	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 

--- a/internal/postgres/breed_store.go
+++ b/internal/postgres/breed_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func FindBreeds(ctx context.Context, tx *database.Tx, page int, size int, petType *string) (*pet.BreedList, *pnd.AppError) {
+func FindBreeds(ctx context.Context, tx *database.Tx, page, size int, petType *string) (*pet.BreedList, *pnd.AppError) {
 	const sql = `
 	SELECT
 		id,

--- a/internal/postgres/condition_store.go
+++ b/internal/postgres/condition_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func InitConditions(ctx context.Context, tx *database.Tx, conditions []sospost.SosCondition) (string, *pnd.AppError) {
+func InitConditions(ctx context.Context, tx *database.Tx, conditions []sospost.SOSCondition) (string, *pnd.AppError) {
 	const sql = `
 	INSERT INTO sos_conditions
 		(

--- a/internal/postgres/condition_store.go
+++ b/internal/postgres/condition_store.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func InitConditions(ctx context.Context, tx *database.Tx, conditions []sos_post.SosCondition) (string, *pnd.AppError) {
+func InitConditions(ctx context.Context, tx *database.Tx, conditions []sospost.SosCondition) (string, *pnd.AppError) {
 	const sql = `
 	INSERT INTO sos_conditions
 		(
@@ -38,7 +38,7 @@ func InitConditions(ctx context.Context, tx *database.Tx, conditions []sos_post.
 	return "condition init success", nil
 }
 
-func FindConditions(ctx context.Context, tx *database.Tx) (*sos_post.ConditionList, *pnd.AppError) {
+func FindConditions(ctx context.Context, tx *database.Tx) (*sospost.ConditionList, *pnd.AppError) {
 	const sql = `
 	SELECT
 		id,
@@ -47,13 +47,13 @@ func FindConditions(ctx context.Context, tx *database.Tx) (*sos_post.ConditionLi
 		sos_conditions
 	`
 
-	conditions := make(sos_post.ConditionList, 0)
+	conditions := make(sospost.ConditionList, 0)
 	rows, err := tx.QueryContext(ctx, sql)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 	for rows.Next() {
-		condition := sos_post.Condition{}
+		condition := sospost.Condition{}
 		if err := rows.Scan(&condition.ID, &condition.Name); err != nil {
 			return nil, pnd.FromPostgresError(err)
 		}

--- a/internal/postgres/media_store.go
+++ b/internal/postgres/media_store.go
@@ -22,7 +22,7 @@ func CreateMedia(ctx context.Context, tx *database.Tx, mediaData *media.Media) (
 	RETURNING id, created_at, updated_at
 	`
 
-	if err := tx.QueryRowContext(ctx, sql,
+	if err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		mediaData.MediaType,
 		mediaData.URL,
 	).Scan(&mediaData.ID, &mediaData.CreatedAt, &mediaData.UpdatedAt); err != nil {

--- a/internal/postgres/media_store.go
+++ b/internal/postgres/media_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func CreateMedia(ctx context.Context, tx *database.Tx, media *media.Media) (*media.Media, *pnd.AppError) {
+func CreateMedia(ctx context.Context, tx *database.Tx, mediaData *media.Media) (*media.Media, *pnd.AppError) {
 	const sql = `
 	INSERT INTO
 		media
@@ -23,13 +23,13 @@ func CreateMedia(ctx context.Context, tx *database.Tx, media *media.Media) (*med
 	`
 
 	if err := tx.QueryRowContext(ctx, sql,
-		media.MediaType,
-		media.URL,
-	).Scan(&media.ID, &media.CreatedAt, &media.UpdatedAt); err != nil {
+		mediaData.MediaType,
+		mediaData.URL,
+	).Scan(&mediaData.ID, &mediaData.CreatedAt, &mediaData.UpdatedAt); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return media, nil
+	return mediaData, nil
 }
 
 func FindMediaByID(ctx context.Context, tx *database.Tx, id int) (*media.Media, *pnd.AppError) {
@@ -47,18 +47,18 @@ func FindMediaByID(ctx context.Context, tx *database.Tx, id int) (*media.Media, 
 		deleted_at IS NULL
 	`
 
-	media := &media.Media{}
+	mediaData := &media.Media{}
 	if err := tx.QueryRowContext(ctx, sql,
 		id,
 	).Scan(
-		&media.ID,
-		&media.MediaType,
-		&media.URL,
-		&media.CreatedAt,
-		&media.UpdatedAt,
+		&mediaData.ID,
+		&mediaData.MediaType,
+		&mediaData.URL,
+		&mediaData.CreatedAt,
+		&mediaData.UpdatedAt,
 	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return media, nil
+	return mediaData, nil
 }

--- a/internal/postgres/pet_store.go
+++ b/internal/postgres/pet_store.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"

--- a/internal/postgres/pet_store.go
+++ b/internal/postgres/pet_store.go
@@ -31,7 +31,7 @@ func CreatePet(ctx context.Context, tx *database.Tx, petData *pet.Pet) (*pet.Pet
 	RETURNING id, created_at, updated_at
 	`
 
-	if err := tx.QueryRowContext(ctx, sql,
+	if err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		petData.OwnerID,
 		petData.Name,
 		petData.PetType,

--- a/internal/postgres/pet_store.go
+++ b/internal/postgres/pet_store.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func CreatePet(ctx context.Context, tx *database.Tx, pet *pet.Pet) (*pet.PetWithProfileImage, *pnd.AppError) {
+func CreatePet(ctx context.Context, tx *database.Tx, petData *pet.Pet) (*pet.PetWithProfileImage, *pnd.AppError) {
 	const sql = `
 	INSERT INTO
 		pets
@@ -32,21 +32,21 @@ func CreatePet(ctx context.Context, tx *database.Tx, pet *pet.Pet) (*pet.PetWith
 	`
 
 	if err := tx.QueryRowContext(ctx, sql,
-		pet.OwnerID,
-		pet.Name,
-		pet.PetType,
-		pet.Sex,
-		pet.Neutered,
-		pet.Breed,
-		pet.BirthDate,
-		pet.WeightInKg,
-		pet.Remarks,
-		pet.ProfileImageID,
-	).Scan(&pet.ID, &pet.CreatedAt, &pet.UpdatedAt); err != nil {
+		petData.OwnerID,
+		petData.Name,
+		petData.PetType,
+		petData.Sex,
+		petData.Neutered,
+		petData.Breed,
+		petData.BirthDate,
+		petData.WeightInKg,
+		petData.Remarks,
+		petData.ProfileImageID,
+	).Scan(&petData.ID, &petData.CreatedAt, &petData.UpdatedAt); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return FindPetByID(ctx, tx, pet.ID)
+	return FindPetByID(ctx, tx, petData.ID)
 }
 
 func FindPetByID(ctx context.Context, tx *database.Tx, id int) (*pet.PetWithProfileImage, *pnd.AppError) {
@@ -76,30 +76,30 @@ func FindPetByID(ctx context.Context, tx *database.Tx, id int) (*pet.PetWithProf
 		pets.deleted_at IS NULL
 	`
 
-	var pet pet.PetWithProfileImage
+	var petData pet.PetWithProfileImage
 	if err := tx.QueryRowContext(ctx, sql,
 		id,
 	).Scan(
-		&pet.ID,
-		&pet.OwnerID,
-		&pet.Name,
-		&pet.PetType,
-		&pet.Sex,
-		&pet.Neutered,
-		&pet.Breed,
-		&pet.BirthDate,
-		&pet.WeightInKg,
-		&pet.Remarks,
-		&pet.ProfileImageURL,
-		&pet.CreatedAt,
-		&pet.UpdatedAt,
+		&petData.ID,
+		&petData.OwnerID,
+		&petData.Name,
+		&petData.PetType,
+		&petData.Sex,
+		&petData.Neutered,
+		&petData.Breed,
+		&petData.BirthDate,
+		&petData.WeightInKg,
+		&petData.Remarks,
+		&petData.ProfileImageURL,
+		&petData.CreatedAt,
+		&petData.UpdatedAt,
 	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	pet.BirthDate = utils.FormatDate(pet.BirthDate)
+	petData.BirthDate = utils.FormatDate(petData.BirthDate)
 
-	return &pet, nil
+	return &petData, nil
 }
 
 func FindPetsByOwnerID(ctx context.Context, tx *database.Tx, ownerID int) (*pet.PetWithProfileList, *pnd.AppError) {
@@ -139,26 +139,26 @@ func FindPetsByOwnerID(ctx context.Context, tx *database.Tx, ownerID int) (*pet.
 	defer rows.Close()
 
 	for rows.Next() {
-		var pet pet.PetWithProfileImage
+		var petData pet.PetWithProfileImage
 		if err := rows.Scan(
-			&pet.ID,
-			&pet.OwnerID,
-			&pet.Name,
-			&pet.PetType,
-			&pet.Sex,
-			&pet.Neutered,
-			&pet.Breed,
-			&pet.BirthDate,
-			&pet.WeightInKg,
-			&pet.Remarks,
-			&pet.ProfileImageURL,
-			&pet.CreatedAt,
-			&pet.UpdatedAt,
+			&petData.ID,
+			&petData.OwnerID,
+			&petData.Name,
+			&petData.PetType,
+			&petData.Sex,
+			&petData.Neutered,
+			&petData.Breed,
+			&petData.BirthDate,
+			&petData.WeightInKg,
+			&petData.Remarks,
+			&petData.ProfileImageURL,
+			&petData.CreatedAt,
+			&petData.UpdatedAt,
 		); err != nil {
 			return nil, pnd.FromPostgresError(err)
 		}
-		pet.BirthDate = utils.FormatDate(pet.BirthDate)
-		pets = append(pets, &pet)
+		petData.BirthDate = utils.FormatDate(petData.BirthDate)
+		pets = append(pets, &petData)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, pnd.FromPostgresError(err)

--- a/internal/postgres/resource_media_store.go
+++ b/internal/postgres/resource_media_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID int, mediaID int, resourceType string) (*media.ResourceMedia, *pnd.AppError) {
+func CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID, mediaID int, resourceType string) (*media.ResourceMedia, *pnd.AppError) {
 	const sql = `
 	INSERT INTO
 		resource_media

--- a/internal/postgres/resource_media_store.go
+++ b/internal/postgres/resource_media_store.go
@@ -8,7 +8,9 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
-func CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID, mediaID int, resourceType string) (*media.ResourceMedia, *pnd.AppError) {
+func CreateResourceMedia(
+	ctx context.Context, tx *database.Tx, resourceID, mediaID int, resourceType string,
+) (*media.ResourceMedia, *pnd.AppError) {
 	const sql = `
 	INSERT INTO
 		resource_media

--- a/internal/postgres/resource_media_store.go
+++ b/internal/postgres/resource_media_store.go
@@ -24,7 +24,7 @@ func CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID, media
 	`
 
 	resourceMedia := &media.ResourceMedia{}
-	err := tx.QueryRowContext(ctx, sql,
+	err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		resourceID,
 		mediaID,
 		resourceType,

--- a/internal/postgres/resource_media_store.go
+++ b/internal/postgres/resource_media_store.go
@@ -28,7 +28,13 @@ func CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID int, m
 		resourceID,
 		mediaID,
 		resourceType,
-	).Scan(&resourceMedia.ID, &resourceMedia.ResourceID, &resourceMedia.MediaID, &resourceMedia.CreatedAt, &resourceMedia.UpdatedAt)
+	).Scan(
+		&resourceMedia.ID,
+		&resourceMedia.ResourceID,
+		&resourceMedia.MediaID,
+		&resourceMedia.CreatedAt,
+		&resourceMedia.UpdatedAt,
+	)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
@@ -36,7 +42,9 @@ func CreateResourceMedia(ctx context.Context, tx *database.Tx, resourceID int, m
 	return resourceMedia, nil
 }
 
-func FindResourceMediaByResourceID(ctx context.Context, tx *database.Tx, resourceID int, resourceType string) (*media.MediaList, *pnd.AppError) {
+func FindResourceMediaByResourceID(
+	ctx context.Context, tx *database.Tx, resourceID int, resourceType string,
+) (*media.MediaList, *pnd.AppError) {
 	const sql = `
 	SELECT
 		m.id,
@@ -68,7 +76,13 @@ func FindResourceMediaByResourceID(ctx context.Context, tx *database.Tx, resourc
 
 	for rows.Next() {
 		mediaItem := media.Media{}
-		if err := rows.Scan(&mediaItem.ID, &mediaItem.MediaType, &mediaItem.URL, &mediaItem.CreatedAt, &mediaItem.UpdatedAt); err != nil {
+		if err := rows.Scan(
+			&mediaItem.ID,
+			&mediaItem.MediaType,
+			&mediaItem.URL,
+			&mediaItem.CreatedAt,
+			&mediaItem.UpdatedAt,
+		); err != nil {
 			return nil, pnd.FromPostgresError(err)
 		}
 		mediaList = append(mediaList, &mediaItem)

--- a/internal/postgres/sos_post_store.go
+++ b/internal/postgres/sos_post_store.go
@@ -413,33 +413,31 @@ func FindSOSPostsByAuthorID(
 }
 
 func FindSOSPostByID(ctx context.Context, tx *database.Tx, id int) (*sospost.SOSPostInfo, *pnd.AppError) {
-	query := fmt.Sprintf(`
-		SELECT
-			v_sos_posts.id,
-			v_sos_posts.title,
-			v_sos_posts.content,
-			v_sos_posts.reward,
-			v_sos_posts.reward_type,
-			v_sos_posts.care_type,
-			v_sos_posts.carer_gender,
-			v_sos_posts.thumbnail_id,
-			v_sos_posts.author_id,
-			v_sos_posts.created_at,
-			v_sos_posts.updated_at,
-			v_sos_posts.dates,
-			v_pets_for_sos_posts.pets_info,
-			v_media_for_sos_posts.media_info,
-			v_conditions.conditions_info
-		FROM
-			v_sos_posts
-				LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-				LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-				LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-		WHERE
-			v_sos_posts.id = $1;
-
-	`,
-	)
+	query := `
+			SELECT
+				v_sos_posts.id,
+				v_sos_posts.title,
+				v_sos_posts.content,
+				v_sos_posts.reward,
+				v_sos_posts.reward_type,
+				v_sos_posts.care_type,
+				v_sos_posts.carer_gender,
+				v_sos_posts.thumbnail_id,
+				v_sos_posts.author_id,
+				v_sos_posts.created_at,
+				v_sos_posts.updated_at,
+				v_sos_posts.dates,
+				v_pets_for_sos_posts.pets_info,
+				v_media_for_sos_posts.media_info,
+				v_conditions.conditions_info
+			FROM
+				v_sos_posts
+					LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+					LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+					LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+			WHERE
+				v_sos_posts.id = $1;
+		`
 
 	row := tx.QueryRowContext(ctx, query, id)
 

--- a/internal/postgres/sos_post_store.go
+++ b/internal/postgres/sos_post_store.go
@@ -17,7 +17,7 @@ import (
 )
 
 func WriteSOSPost(ctx context.Context, tx *database.Tx, authorID int, request *sospost.WriteSOSPostRequest) (*sospost.SOSPost, *pnd.AppError) {
-	const sql = `
+	const query = `
 	INSERT INTO
 		sos_posts
 		(
@@ -46,7 +46,7 @@ func WriteSOSPost(ctx context.Context, tx *database.Tx, authorID int, request *s
 	`
 
 	sosPost := &sospost.SOSPost{}
-	err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
+	err := tx.QueryRowContext(ctx, query, //nolint:execinquery
 		authorID,
 		request.Title,
 		request.Content,
@@ -479,7 +479,7 @@ func UpdateSOSPost(ctx context.Context, tx *database.Tx, request *sospost.Update
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	const sql = `
+	const query = `
 		INSERT INTO
 		sos_dates
 		(
@@ -496,7 +496,7 @@ func UpdateSOSPost(ctx context.Context, tx *database.Tx, request *sospost.Update
 
 	for _, date := range request.Dates {
 		sosDate := sospost.SOSDates{}
-		if err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
+		if err := tx.QueryRowContext(ctx, query, //nolint:execinquery
 			date.DateStartAt,
 			date.DateEndAt,
 		).Scan(
@@ -664,7 +664,7 @@ func UpdateSOSPost(ctx context.Context, tx *database.Tx, request *sospost.Update
 }
 
 func FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*sospost.ConditionList, *pnd.AppError) {
-	const sql = `
+	const query = `
 	SELECT
 		sos_conditions.id,
 		sos_conditions.name,
@@ -682,7 +682,7 @@ func FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*sospost.C
 	`
 
 	conditions := sospost.ConditionList{}
-	rows, err := tx.QueryContext(ctx, sql, id)
+	rows, err := tx.QueryContext(ctx, query, id)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
@@ -708,7 +708,7 @@ func FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*sospost.C
 }
 
 func FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.PetWithProfileList, *pnd.AppError) {
-	const sql = `
+	const query = `
 	SELECT
 		pets.id,
 		pets.owner_id,
@@ -740,7 +740,7 @@ func FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.PetWithPro
 	`
 
 	pets := pet.PetWithProfileList{}
-	rows, err := tx.QueryContext(ctx, sql, id)
+	rows, err := tx.QueryContext(ctx, query, id)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
@@ -775,7 +775,7 @@ func FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.PetWithPro
 }
 
 func FindDatesBySOSPostID(ctx context.Context, tx *database.Tx, sosPostID int) (*sospost.SOSDatesList, *pnd.AppError) {
-	const sql = `
+	const query = `
 		SELECT
 		    sos_dates.id,
 			sos_dates.date_start_at,
@@ -793,7 +793,7 @@ func FindDatesBySOSPostID(ctx context.Context, tx *database.Tx, sosPostID int) (
 	`
 
 	var sosDates sospost.SOSDatesList
-	rows, err := tx.QueryContext(ctx, sql, sosPostID)
+	rows, err := tx.QueryContext(ctx, query, sosPostID)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}

--- a/internal/postgres/sos_post_store.go
+++ b/internal/postgres/sos_post_store.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"time"
+
+	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
@@ -62,7 +63,6 @@ func WriteSosPost(ctx context.Context, tx *database.Tx, authorID int, request *s
 		&sosPost.CarerGender,
 		&sosPost.RewardType,
 		&sosPost.ThumbnailID)
-
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}

--- a/internal/postgres/sos_post_store.go
+++ b/internal/postgres/sos_post_store.go
@@ -44,7 +44,9 @@ RETURNING
 	thumbnail_id
 `
 
-func WriteSOSPost(ctx context.Context, tx *database.Tx, authorID int, request *sospost.WriteSOSPostRequest) (*sospost.SOSPost, *pnd.AppError) {
+func WriteSOSPost(
+	ctx context.Context, tx *database.Tx, authorID int, request *sospost.WriteSOSPostRequest,
+) (*sospost.SOSPost, *pnd.AppError) {
 	sosPost := &sospost.SOSPost{}
 	err := tx.QueryRowContext(ctx, writeSOSPostQuery, //nolint:execinquery
 		authorID,

--- a/internal/postgres/sos_post_store.go
+++ b/internal/postgres/sos_post_store.go
@@ -45,7 +45,7 @@ func WriteSOSPost(ctx context.Context, tx *database.Tx, authorID int, request *s
 	`
 
 	sosPost := &sospost.SOSPost{}
-	err := tx.QueryRowContext(ctx, sql,
+	err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		authorID,
 		request.Title,
 		request.Content,
@@ -84,7 +84,7 @@ func WriteSOSPost(ctx context.Context, tx *database.Tx, authorID int, request *s
 
 	for _, date := range request.Dates {
 		sosDate := sospost.SOSDates{}
-		if err := tx.QueryRowContext(ctx, sql2,
+		if err := tx.QueryRowContext(ctx, sql2, //nolint:execinquery
 			date.DateStartAt,
 			date.DateEndAt,
 		).Scan(
@@ -525,7 +525,7 @@ func UpdateSOSPost(ctx context.Context, tx *database.Tx, request *sospost.Update
 
 	for _, date := range request.Dates {
 		sosDate := sospost.SOSDates{}
-		if err := tx.QueryRowContext(ctx, sql,
+		if err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 			date.DateStartAt,
 			date.DateEndAt,
 		).Scan(
@@ -666,7 +666,7 @@ func UpdateSOSPost(ctx context.Context, tx *database.Tx, request *sospost.Update
 		thumbnail_id
 	`
 
-	if err := tx.QueryRowContext(ctx, sql2,
+	if err := tx.QueryRowContext(ctx, sql2, //nolint:execinquery
 		request.Title,
 		request.Content,
 		request.Reward,

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -27,7 +27,7 @@ func CreateUser(ctx context.Context, tx *database.Tx, request *user.RegisterUser
 	RETURNING id, email, nickname, fullname, profile_image_id, fb_provider_type, fb_uid, created_at, updated_at
 	`
 
-	user := &user.User{}
+	userData := &user.User{}
 	if err := tx.QueryRowContext(ctx, sql,
 		request.Email,
 		request.Nickname,
@@ -37,23 +37,23 @@ func CreateUser(ctx context.Context, tx *database.Tx, request *user.RegisterUser
 		request.FirebaseProviderType,
 		request.FirebaseUID,
 	).Scan(
-		&user.ID,
-		&user.Email,
-		&user.Nickname,
-		&user.Fullname,
-		&user.ProfileImageID,
-		&user.FirebaseProviderType,
-		&user.FirebaseUID,
-		&user.CreatedAt,
-		&user.UpdatedAt,
+		&userData.ID,
+		&userData.Email,
+		&userData.Nickname,
+		&userData.Fullname,
+		&userData.ProfileImageID,
+		&userData.FirebaseProviderType,
+		&userData.FirebaseUID,
+		&userData.CreatedAt,
+		&userData.UpdatedAt,
 	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return user, nil
+	return userData, nil
 }
 
-func FindUsers(ctx context.Context, tx *database.Tx, page int, size int, nickname *string) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
+func FindUsers(ctx context.Context, tx *database.Tx, page, size int, nickname *string) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
 	const sql = `
 	SELECT
 		users.id,
@@ -82,14 +82,14 @@ func FindUsers(ctx context.Context, tx *database.Tx, page int, size int, nicknam
 	defer rows.Close()
 
 	for rows.Next() {
-		user := &user.UserWithoutPrivateInfo{}
+		userData := &user.UserWithoutPrivateInfo{}
 
-		err := rows.Scan(&user.ID, &user.Nickname, &user.ProfileImageURL)
+		err := rows.Scan(&userData.ID, &userData.Nickname, &userData.ProfileImageURL)
 		if err != nil {
 			return nil, pnd.FromPostgresError(err)
 		}
 
-		userList.Items = append(userList.Items, *user)
+		userList.Items = append(userList.Items, *userData)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, pnd.FromPostgresError(err)
@@ -125,23 +125,23 @@ func FindUserByID(
 		(users.deleted_at IS NULL OR $2)
 	`
 
-	var user user.UserWithProfileImage
+	var userData user.UserWithProfileImage
 	if err := tx.QueryRowContext(ctx, sql, id, includeDeleted).Scan(
-		&user.ID,
-		&user.Email,
-		&user.Nickname,
-		&user.Fullname,
-		&user.ProfileImageURL,
-		&user.FirebaseProviderType,
-		&user.FirebaseUID,
-		&user.CreatedAt,
-		&user.UpdatedAt,
-		&user.DeletedAt,
+		&userData.ID,
+		&userData.Email,
+		&userData.Nickname,
+		&userData.Fullname,
+		&userData.ProfileImageURL,
+		&userData.FirebaseProviderType,
+		&userData.FirebaseUID,
+		&userData.CreatedAt,
+		&userData.UpdatedAt,
+		&userData.DeletedAt,
 	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return &user, nil
+	return &userData, nil
 }
 
 func FindUserByEmail(ctx context.Context, tx *database.Tx, email string) (*user.UserWithProfileImage, *pnd.AppError) {
@@ -167,22 +167,22 @@ func FindUserByEmail(ctx context.Context, tx *database.Tx, email string) (*user.
 		users.deleted_at IS NULL
 	`
 
-	var user user.UserWithProfileImage
+	var userData user.UserWithProfileImage
 	if err := tx.QueryRowContext(ctx, sql, email).Scan(
-		&user.ID,
-		&user.Email,
-		&user.Nickname,
-		&user.Fullname,
-		&user.ProfileImageURL,
-		&user.FirebaseProviderType,
-		&user.FirebaseUID,
-		&user.CreatedAt,
-		&user.UpdatedAt,
+		&userData.ID,
+		&userData.Email,
+		&userData.Nickname,
+		&userData.Fullname,
+		&userData.ProfileImageURL,
+		&userData.FirebaseProviderType,
+		&userData.FirebaseUID,
+		&userData.CreatedAt,
+		&userData.UpdatedAt,
 	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return &user, nil
+	return &userData, nil
 }
 
 func FindUserByUID(ctx context.Context, tx *database.Tx, uid string) (*user.UserWithProfileImage, *pnd.AppError) {
@@ -208,25 +208,25 @@ func FindUserByUID(ctx context.Context, tx *database.Tx, uid string) (*user.User
 		users.deleted_at IS NULL
 	`
 
-	var user user.UserWithProfileImage
+	var userData user.UserWithProfileImage
 	if err := tx.QueryRowContext(ctx, sql, uid).Scan(
-		&user.ID,
-		&user.Email,
-		&user.Nickname,
-		&user.Fullname,
-		&user.ProfileImageURL,
-		&user.FirebaseProviderType,
-		&user.FirebaseUID,
-		&user.CreatedAt,
-		&user.UpdatedAt,
+		&userData.ID,
+		&userData.Email,
+		&userData.Nickname,
+		&userData.Fullname,
+		&userData.ProfileImageURL,
+		&userData.FirebaseProviderType,
+		&userData.FirebaseUID,
+		&userData.CreatedAt,
+		&userData.UpdatedAt,
 	); err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return &user, nil
+	return &userData, nil
 }
 
-func FindUserIDByFbUID(ctx context.Context, tx *database.Tx, fbUid string) (int, *pnd.AppError) {
+func FindUserIDByFbUID(ctx context.Context, tx *database.Tx, fbUID string) (int, *pnd.AppError) {
 	const sql = `
 	SELECT
 		id
@@ -238,7 +238,7 @@ func FindUserIDByFbUID(ctx context.Context, tx *database.Tx, fbUid string) (int,
 	`
 
 	var userID int
-	if err := tx.QueryRowContext(ctx, sql, fbUid).Scan(&userID); err != nil {
+	if err := tx.QueryRowContext(ctx, sql, fbUID).Scan(&userID); err != nil {
 		return 0, pnd.FromPostgresError(err)
 	}
 
@@ -289,7 +289,7 @@ func FindUserStatusByEmail(ctx context.Context, tx *database.Tx, email string) (
 	return &userStatus, nil
 }
 
-func UpdateUserByUID(ctx context.Context, tx *database.Tx, uid string, nickname string, profileImageID *int) (*user.User, *pnd.AppError) {
+func UpdateUserByUID(ctx context.Context, tx *database.Tx, uid, nickname string, profileImageID *int) (*user.User, *pnd.AppError) {
 	const sql = `
 	UPDATE
 		users
@@ -312,27 +312,27 @@ func UpdateUserByUID(ctx context.Context, tx *database.Tx, uid string, nickname 
 		updated_at
 	`
 
-	var user user.User
+	var userData user.User
 	err := tx.QueryRowContext(ctx, sql,
 		nickname,
 		profileImageID,
 		uid,
 	).Scan(
-		&user.ID,
-		&user.Email,
-		&user.Nickname,
-		&user.Fullname,
-		&user.ProfileImageID,
-		&user.FirebaseProviderType,
-		&user.FirebaseUID,
-		&user.CreatedAt,
-		&user.UpdatedAt,
+		&userData.ID,
+		&userData.Email,
+		&userData.Nickname,
+		&userData.Fullname,
+		&userData.ProfileImageID,
+		&userData.FirebaseProviderType,
+		&userData.FirebaseUID,
+		&userData.CreatedAt,
+		&userData.UpdatedAt,
 	)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)
 	}
 
-	return &user, nil
+	return &userData, nil
 }
 
 func DeleteUserByUID(ctx context.Context, tx *database.Tx, uid string) *pnd.AppError {

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -99,7 +99,9 @@ func FindUsers(ctx context.Context, tx *database.Tx, page int, size int, nicknam
 	return userList, nil
 }
 
-func FindUserByID(ctx context.Context, tx *database.Tx, id int, includeDeleted bool) (*user.UserWithProfileImage, *pnd.AppError) {
+func FindUserByID(
+	ctx context.Context, tx *database.Tx, id int, includeDeleted bool,
+) (*user.UserWithProfileImage, *pnd.AppError) {
 	const sql = `
 	SELECT
 		users.id,

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -53,7 +53,9 @@ func CreateUser(ctx context.Context, tx *database.Tx, request *user.RegisterUser
 	return userData, nil
 }
 
-func FindUsers(ctx context.Context, tx *database.Tx, page, size int, nickname *string) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
+func FindUsers(
+	ctx context.Context, tx *database.Tx, page, size int, nickname *string,
+) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
 	const sql = `
 	SELECT
 		users.id,
@@ -289,7 +291,9 @@ func FindUserStatusByEmail(ctx context.Context, tx *database.Tx, email string) (
 	return &userStatus, nil
 }
 
-func UpdateUserByUID(ctx context.Context, tx *database.Tx, uid, nickname string, profileImageID *int) (*user.User, *pnd.AppError) {
+func UpdateUserByUID(
+	ctx context.Context, tx *database.Tx, uid, nickname string, profileImageID *int,
+) (*user.User, *pnd.AppError) {
 	const sql = `
 	UPDATE
 		users

--- a/internal/postgres/user_store.go
+++ b/internal/postgres/user_store.go
@@ -28,7 +28,7 @@ func CreateUser(ctx context.Context, tx *database.Tx, request *user.RegisterUser
 	`
 
 	userData := &user.User{}
-	if err := tx.QueryRowContext(ctx, sql,
+	if err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		request.Email,
 		request.Nickname,
 		request.Fullname,
@@ -313,7 +313,7 @@ func UpdateUserByUID(ctx context.Context, tx *database.Tx, uid, nickname string,
 	`
 
 	var userData user.User
-	err := tx.QueryRowContext(ctx, sql,
+	err := tx.QueryRowContext(ctx, sql, //nolint:execinquery
 		nickname,
 		profileImageID,
 		uid,

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 
 	"firebase.google.com/go/auth"
@@ -53,7 +53,7 @@ func (service *FirebaseBearerAuthService) VerifyAuthAndGetUser(
 
 	foundUser, err := service.userService.FindUserByUID(ctx, authToken.UID)
 	if err != nil {
-		return nil, pnd.ErrUserNotRegistered(fmt.Errorf("가입되지 않은 사용자입니다"))
+		return nil, pnd.ErrUserNotRegistered(errors.New("가입되지 않은 사용자입니다"))
 	}
 
 	return foundUser, nil
@@ -73,5 +73,5 @@ func (service *FirebaseBearerAuthService) stripBearerToken(authHeader string) (s
 		return authHeader[7:], nil
 	}
 
-	return "", pnd.ErrInvalidBearerToken(fmt.Errorf("올바른 Bearer 토큰이 아닙니다"))
+	return "", pnd.ErrInvalidBearerToken(errors.New("올바른 Bearer 토큰이 아닙니다"))
 }

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -27,7 +27,9 @@ func NewFirebaseBearerAuthService(authClient *auth.Client, userService *UserServ
 	}
 }
 
-func (service *FirebaseBearerAuthService) verifyAuth(ctx context.Context, authHeader string) (*auth.Token, *pnd.AppError) {
+func (service *FirebaseBearerAuthService) verifyAuth(
+	ctx context.Context, authHeader string,
+) (*auth.Token, *pnd.AppError) {
 	idToken, err := service.stripBearerToken(authHeader)
 	if err != nil {
 		return nil, err
@@ -41,7 +43,9 @@ func (service *FirebaseBearerAuthService) verifyAuth(ctx context.Context, authHe
 	return authToken, nil
 }
 
-func (service *FirebaseBearerAuthService) VerifyAuthAndGetUser(ctx context.Context, authHeader string) (*user.FindUserView, *pnd.AppError) {
+func (service *FirebaseBearerAuthService) VerifyAuthAndGetUser(
+	ctx context.Context, authHeader string,
+) (*user.FindUserView, *pnd.AppError) {
 	authToken, err := service.verifyAuth(ctx, authHeader)
 	if err != nil {
 		return nil, err

--- a/internal/service/breed_service.go
+++ b/internal/service/breed_service.go
@@ -19,7 +19,9 @@ func NewBreedService(conn *database.DB) *BreedService {
 	}
 }
 
-func (s *BreedService) FindBreeds(ctx context.Context, page int, size int, petType *string) (*pet.BreedListView, *pnd.AppError) {
+func (s *BreedService) FindBreeds(
+	ctx context.Context, page int, size int, petType *string,
+) (*pet.BreedListView, *pnd.AppError) {
 	tx, err := s.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -38,7 +40,9 @@ func (s *BreedService) FindBreeds(ctx context.Context, page int, size int, petTy
 	return breeds.ToBreedListView(), nil
 }
 
-func (s *BreedService) FindBreedByPetTypeAndName(ctx context.Context, petType pet.PetType, name string) (*pet.BreedView, *pnd.AppError) {
+func (s *BreedService) FindBreedByPetTypeAndName(
+	ctx context.Context, petType pet.PetType, name string,
+) (*pet.BreedView, *pnd.AppError) {
 	tx, err := s.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {

--- a/internal/service/breed_service.go
+++ b/internal/service/breed_service.go
@@ -20,7 +20,7 @@ func NewBreedService(conn *database.DB) *BreedService {
 }
 
 func (s *BreedService) FindBreeds(
-	ctx context.Context, page int, size int, petType *string,
+	ctx context.Context, page, size int, petType *string,
 ) (*pet.BreedListView, *pnd.AppError) {
 	tx, err := s.conn.BeginTx(ctx)
 	defer tx.Rollback()

--- a/internal/service/condition_service.go
+++ b/internal/service/condition_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 	"github.com/pet-sitter/pets-next-door-api/internal/postgres"
 )
@@ -19,7 +19,7 @@ func NewConditionService(conn *database.DB) *ConditionService {
 	}
 }
 
-func (service *ConditionService) FindConditions(ctx context.Context) ([]sos_post.ConditionView, *pnd.AppError) {
+func (service *ConditionService) FindConditions(ctx context.Context) ([]sospost.ConditionView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {

--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -88,7 +88,7 @@ func (s *MediaService) FindMediaByID(ctx context.Context, id int) (*media.Media,
 		return nil, err
 	}
 
-	media, err := postgres.FindMediaByID(ctx, tx, id)
+	mediaData, err := postgres.FindMediaByID(ctx, tx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -97,5 +97,5 @@ func (s *MediaService) FindMediaByID(ctx context.Context, id int) (*media.Media,
 		return nil, err
 	}
 
-	return media, nil
+	return mediaData, nil
 }

--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -53,7 +53,6 @@ func (s *MediaService) UploadMedia(ctx context.Context, file io.ReadSeeker, medi
 		MediaType: mediaType,
 		URL:       req.HTTPRequest.URL.String(),
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -35,7 +35,9 @@ type UploadFileView struct {
 	FileEndpoint string
 }
 
-func (s *MediaService) UploadMedia(ctx context.Context, file io.ReadSeeker, mediaType media.MediaType, fileName string) (*media.Media, *pnd.AppError) {
+func (s *MediaService) UploadMedia(
+	ctx context.Context, file io.ReadSeeker, mediaType media.MediaType, fileName string,
+) (*media.Media, *pnd.AppError) {
 	randomFileName := generateRandomFileName(fileName)
 	fullPath := "media/" + randomFileName
 

--- a/internal/service/sos_post_service.go
+++ b/internal/service/sos_post_service.go
@@ -21,7 +21,9 @@ func NewSosPostService(conn *database.DB) *SosPostService {
 	}
 }
 
-func (service *SosPostService) WriteSosPost(ctx context.Context, fbUid string, request *sos_post.WriteSosPostRequest) (*sos_post.WriteSosPostView, *pnd.AppError) {
+func (service *SosPostService) WriteSosPost(
+	ctx context.Context, fbUid string, request *sos_post.WriteSosPostRequest,
+) (*sos_post.WriteSosPostView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -164,7 +166,9 @@ func (service *SosPostService) FindSosPostByID(ctx context.Context, id int) (*so
 	), nil
 }
 
-func (service *SosPostService) UpdateSosPost(ctx context.Context, request *sos_post.UpdateSosPostRequest) (*sos_post.UpdateSosPostView, *pnd.AppError) {
+func (service *SosPostService) UpdateSosPost(
+	ctx context.Context, request *sos_post.UpdateSosPostRequest,
+) (*sos_post.UpdateSosPostView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -208,7 +212,9 @@ func (service *SosPostService) UpdateSosPost(ctx context.Context, request *sos_p
 	), nil
 }
 
-func (service *SosPostService) CheckUpdatePermission(ctx context.Context, fbUid string, sosPostID int) (bool, *pnd.AppError) {
+func (service *SosPostService) CheckUpdatePermission(
+	ctx context.Context, fbUid string, sosPostID int,
+) (bool, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {

--- a/internal/service/sos_post_service.go
+++ b/internal/service/sos_post_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 	"github.com/pet-sitter/pets-next-door-api/internal/postgres"
 

--- a/internal/service/sos_post_service.go
+++ b/internal/service/sos_post_service.go
@@ -8,7 +8,7 @@ import (
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 )
 
 type SosPostService struct {
@@ -22,15 +22,15 @@ func NewSosPostService(conn *database.DB) *SosPostService {
 }
 
 func (service *SosPostService) WriteSosPost(
-	ctx context.Context, fbUid string, request *sos_post.WriteSosPostRequest,
-) (*sos_post.WriteSosPostView, *pnd.AppError) {
+	ctx context.Context, fbUID string, request *sospost.WriteSosPostRequest,
+) (*sospost.WriteSosPostView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
 		return nil, err
 	}
 
-	userID, err := postgres.FindUserIDByFbUID(ctx, tx, fbUid)
+	userID, err := postgres.FindUserIDByFbUID(ctx, tx, fbUID)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (service *SosPostService) WriteSosPost(
 	), nil
 }
 
-func (service *SosPostService) FindSosPosts(ctx context.Context, page int, size int, sortBy string, filterType string) (*sos_post.FindSosPostListView, *pnd.AppError) {
+func (service *SosPostService) FindSosPosts(ctx context.Context, page, size int, sortBy, filterType string) (*sospost.FindSosPostListView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -84,7 +84,7 @@ func (service *SosPostService) FindSosPosts(ctx context.Context, page int, size 
 		return nil, err
 	}
 
-	sosPostViews := sos_post.FromEmptySosPostInfoList(sosPosts)
+	sosPostViews := sospost.FromEmptySosPostInfoList(sosPosts)
 
 	for _, sosPost := range sosPosts.Items {
 		author, err := postgres.FindUserByID(ctx, tx, sosPost.AuthorID, true)
@@ -105,7 +105,7 @@ func (service *SosPostService) FindSosPosts(ctx context.Context, page int, size 
 	return sosPostViews, nil
 }
 
-func (service *SosPostService) FindSosPostsByAuthorID(ctx context.Context, authorID int, page int, size int, sortBy string, filterType string) (*sos_post.FindSosPostListView, *pnd.AppError) {
+func (service *SosPostService) FindSosPostsByAuthorID(ctx context.Context, authorID, page, size int, sortBy, filterType string) (*sospost.FindSosPostListView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -116,7 +116,7 @@ func (service *SosPostService) FindSosPostsByAuthorID(ctx context.Context, autho
 	if err != nil {
 		return nil, err
 	}
-	sosPostViews := sos_post.FromEmptySosPostInfoList(sosPosts)
+	sosPostViews := sospost.FromEmptySosPostInfoList(sosPosts)
 
 	for _, sosPost := range sosPosts.Items {
 		author, err := postgres.FindUserByID(ctx, tx, sosPost.AuthorID, true)
@@ -136,7 +136,7 @@ func (service *SosPostService) FindSosPostsByAuthorID(ctx context.Context, autho
 	return sosPostViews, nil
 }
 
-func (service *SosPostService) FindSosPostByID(ctx context.Context, id int) (*sos_post.FindSosPostView, *pnd.AppError) {
+func (service *SosPostService) FindSosPostByID(ctx context.Context, id int) (*sospost.FindSosPostView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -167,8 +167,8 @@ func (service *SosPostService) FindSosPostByID(ctx context.Context, id int) (*so
 }
 
 func (service *SosPostService) UpdateSosPost(
-	ctx context.Context, request *sos_post.UpdateSosPostRequest,
-) (*sos_post.UpdateSosPostView, *pnd.AppError) {
+	ctx context.Context, request *sospost.UpdateSosPostRequest,
+) (*sospost.UpdateSosPostView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -213,7 +213,7 @@ func (service *SosPostService) UpdateSosPost(
 }
 
 func (service *SosPostService) CheckUpdatePermission(
-	ctx context.Context, fbUid string, sosPostID int,
+	ctx context.Context, fbUID string, sosPostID int,
 ) (bool, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
@@ -221,7 +221,7 @@ func (service *SosPostService) CheckUpdatePermission(
 		return false, err
 	}
 
-	userID, err := postgres.FindUserIDByFbUID(ctx, tx, fbUid)
+	userID, err := postgres.FindUserIDByFbUID(ctx, tx, fbUID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestSosPostService(t *testing.T) {
 	setUp := func(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
+		t.Helper()
 		db, _ := database.Open(tests.TestDatabaseURL)
 		db.Flush()
 
@@ -29,6 +30,7 @@ func TestSosPostService(t *testing.T) {
 		}
 
 		return db, func(t *testing.T) {
+			t.Helper()
 			db.Close()
 		}
 	}
@@ -426,6 +428,8 @@ func TestSosPostService(t *testing.T) {
 }
 
 func assertFindSosPostEquals(t *testing.T, got sos_post.FindSosPostView, want sos_post.WriteSosPostView) {
+	t.Helper()
+
 	if got.Title != want.Title {
 		t.Errorf("got %v want %v", got.Title, want.Title)
 	}
@@ -450,6 +454,8 @@ func assertFindSosPostEquals(t *testing.T, got sos_post.FindSosPostView, want so
 }
 
 func assertConditionEquals(t *testing.T, got []sos_post.ConditionView, want []int) {
+	t.Helper()
+
 	for i := range want {
 		if i+1 != got[i].ID {
 			t.Errorf("got %v want %v", got[i].ID, i+1)
@@ -458,12 +464,16 @@ func assertConditionEquals(t *testing.T, got []sos_post.ConditionView, want []in
 }
 
 func assertPetEquals(t *testing.T, got pet.PetView, want pet.PetView) {
+	t.Helper()
+
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
 func assertMediaEquals(t *testing.T, got media.MediaViewList, want media.MediaViewList) {
+	t.Helper()
+
 	for i, media := range want {
 		if got[i].ID != media.ID {
 			t.Errorf("got %v want %v", got[i].ID, media.ID)
@@ -478,12 +488,16 @@ func assertMediaEquals(t *testing.T, got media.MediaViewList, want media.MediaVi
 }
 
 func assertAuthorEquals(t *testing.T, got *user.UserWithoutPrivateInfo, want *user.UserWithoutPrivateInfo) {
+	t.Helper()
+
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
 func assertDatesEquals(t *testing.T, got []sos_post.SosDateView, want []sos_post.SosDateView) {
+	t.Helper()
+
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/tests"
 )
 
+//nolint:gocognit
 func TestSOSPostService(t *testing.T) {
 	setUp := func(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
 		t.Helper()

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -8,7 +8,7 @@ import (
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 	"github.com/pet-sitter/pets-next-door-api/internal/postgres"
@@ -23,7 +23,7 @@ func TestSosPostService(t *testing.T) {
 		db.Flush()
 
 		if err := database.WithTransaction(ctx, db, func(tx *database.Tx) *pnd.AppError {
-			postgres.InitConditions(ctx, tx, sos_post.ConditionName)
+			postgres.InitConditions(ctx, tx, sospost.ConditionName)
 			return nil
 		}); err != nil {
 			t.Errorf("InitConditions failed: %v", err)
@@ -123,7 +123,7 @@ func TestSosPostService(t *testing.T) {
 			petIDs := []int{addPets.ID}
 			conditionIDs := []int{1, 2}
 
-			var sosPosts []sos_post.WriteSosPostView
+			var sosPosts []sospost.WriteSosPostView
 			for i := 1; i < 4; i++ {
 				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, petIDs, i)
 				sosPosts = append(sosPosts, *sosPost)
@@ -172,7 +172,7 @@ func TestSosPostService(t *testing.T) {
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			var sosPosts []sos_post.WriteSosPostView
+			var sosPosts []sospost.WriteSosPostView
 			for i := 1; i < 4; i++ {
 				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[i-1].ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
@@ -221,7 +221,7 @@ func TestSosPostService(t *testing.T) {
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			var sosPosts []sos_post.WriteSosPostView
+			var sosPosts []sospost.WriteSosPostView
 			// 강아지인 경우
 			for i := 1; i < 3; i++ {
 				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[i-1].ID}, i)
@@ -278,7 +278,7 @@ func TestSosPostService(t *testing.T) {
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			sosPosts := make([]sos_post.WriteSosPostView, 0)
+			sosPosts := make([]sospost.WriteSosPostView, 0)
 			for i := 1; i < 4; i++ {
 				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPet.ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
@@ -328,7 +328,7 @@ func TestSosPostService(t *testing.T) {
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			sosPosts := make([]sos_post.WriteSosPostView, 0)
+			sosPosts := make([]sospost.WriteSosPostView, 0)
 			for i := 1; i < 4; i++ {
 				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPet.ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
@@ -371,19 +371,19 @@ func TestSosPostService(t *testing.T) {
 			sosPostService := service.NewSosPostService(db)
 			sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, []int{sosPostImage.ID}, []int{addPet.ID}, 1)
 
-			updateSosPostData := &sos_post.UpdateSosPostRequest{
+			updateSosPostData := &sospost.UpdateSosPostRequest{
 				ID:       sosPost.ID,
 				Title:    "Title2",
 				Content:  "Content2",
 				ImageIDs: []int{sosPostImage.ID, sosPostImage2.ID},
 				Reward:   "Reward2",
-				Dates: []sos_post.SosDateView{
+				Dates: []sospost.SosDateView{
 					{"2024-04-10", "2024-04-20"},
 					{"2024-05-10", "2024-05-20"},
 				},
-				CareType:     sos_post.CareTypeFoster,
-				CarerGender:  sos_post.CarerGenderMale,
-				RewardType:   sos_post.RewardTypeFee,
+				CareType:     sospost.CareTypeFoster,
+				CarerGender:  sospost.CarerGenderMale,
+				RewardType:   sospost.RewardTypeFee,
 				ConditionIDs: []int{1, 2},
 				PetIDs:       []int{addPet.ID},
 			}
@@ -427,7 +427,7 @@ func TestSosPostService(t *testing.T) {
 	})
 }
 
-func assertFindSosPostEquals(t *testing.T, got sos_post.FindSosPostView, want sos_post.WriteSosPostView) {
+func assertFindSosPostEquals(t *testing.T, got sospost.FindSosPostView, want sospost.WriteSosPostView) {
 	t.Helper()
 
 	if got.Title != want.Title {
@@ -453,7 +453,7 @@ func assertFindSosPostEquals(t *testing.T, got sos_post.FindSosPostView, want so
 	}
 }
 
-func assertConditionEquals(t *testing.T, got []sos_post.ConditionView, want []int) {
+func assertConditionEquals(t *testing.T, got []sospost.ConditionView, want []int) {
 	t.Helper()
 
 	for i := range want {
@@ -463,7 +463,7 @@ func assertConditionEquals(t *testing.T, got []sos_post.ConditionView, want []in
 	}
 }
 
-func assertPetEquals(t *testing.T, got pet.PetView, want pet.PetView) {
+func assertPetEquals(t *testing.T, got, want pet.PetView) {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {
@@ -471,23 +471,23 @@ func assertPetEquals(t *testing.T, got pet.PetView, want pet.PetView) {
 	}
 }
 
-func assertMediaEquals(t *testing.T, got media.MediaViewList, want media.MediaViewList) {
+func assertMediaEquals(t *testing.T, got, want media.MediaViewList) {
 	t.Helper()
 
-	for i, media := range want {
-		if got[i].ID != media.ID {
-			t.Errorf("got %v want %v", got[i].ID, media.ID)
+	for i, mediaData := range want {
+		if got[i].ID != mediaData.ID {
+			t.Errorf("got %v want %v", got[i].ID, mediaData.ID)
 		}
-		if got[i].MediaType != media.MediaType {
-			t.Errorf("got %v want %v", got[i].MediaType, media.MediaType)
+		if got[i].MediaType != mediaData.MediaType {
+			t.Errorf("got %v want %v", got[i].MediaType, mediaData.MediaType)
 		}
-		if got[i].URL != media.URL {
-			t.Errorf("got %v want %v", got[i].URL, media.URL)
+		if got[i].URL != mediaData.URL {
+			t.Errorf("got %v want %v", got[i].URL, mediaData.URL)
 		}
 	}
 }
 
-func assertAuthorEquals(t *testing.T, got *user.UserWithoutPrivateInfo, want *user.UserWithoutPrivateInfo) {
+func assertAuthorEquals(t *testing.T, got, want *user.UserWithoutPrivateInfo) {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {
@@ -495,7 +495,7 @@ func assertAuthorEquals(t *testing.T, got *user.UserWithoutPrivateInfo, want *us
 	}
 }
 
-func assertDatesEquals(t *testing.T, got []sos_post.SosDateView, want []sos_post.SosDateView) {
+func assertDatesEquals(t *testing.T, got, want []sospost.SosDateView) {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/tests"
 )
 
-func TestSosPostService(t *testing.T) {
+func TestSOSPostService(t *testing.T) {
 	setUp := func(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
 		t.Helper()
 		db, _ := database.Open(tests.TestDatabaseURL)
@@ -34,7 +34,7 @@ func TestSosPostService(t *testing.T) {
 			db.Close()
 		}
 	}
-	t.Run("CreateSosPost", func(t *testing.T) {
+	t.Run("CreateSOSPost", func(t *testing.T) {
 		t.Run("돌봄 급구 게시글을 작성한다", func(t *testing.T) {
 			ctx := context.Background()
 			db, tearDown := setUp(ctx, t)
@@ -53,12 +53,12 @@ func TestSosPostService(t *testing.T) {
 			addPets := tests.AddDummyPet(t, ctx, userService, uid, &profileImage.ID)
 
 			// when
-			sosPostService := service.NewSosPostService(db)
+			sosPostService := service.NewSOSPostService(db)
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			petIDs := []int{addPets.ID}
 
-			sosPostData := tests.GenerateDummyWriteSosPostRequest(imageIDs, petIDs, 0)
-			sosPost, err := sosPostService.WriteSosPost(ctx, uid, sosPostData)
+			sosPostData := tests.GenerateDummyWriteSOSPostRequest(imageIDs, petIDs, 0)
+			sosPost, err := sosPostService.WriteSOSPost(ctx, uid, sosPostData)
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -95,7 +95,7 @@ func TestSosPostService(t *testing.T) {
 			}
 		})
 	})
-	t.Run("FindSosPosts", func(t *testing.T) {
+	t.Run("FindSOSPosts", func(t *testing.T) {
 		t.Run("전체 돌봄 급구 게시글을 조회한다", func(t *testing.T) {
 			ctx := context.Background()
 			db, tearDown := setUp(ctx, t)
@@ -118,19 +118,19 @@ func TestSosPostService(t *testing.T) {
 			uid := owner.FirebaseUID
 			addPets := tests.AddDummyPet(t, ctx, userService, uid, &profileImage.ID)
 
-			sosPostService := service.NewSosPostService(db)
+			sosPostService := service.NewSOSPostService(db)
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			petIDs := []int{addPets.ID}
 			conditionIDs := []int{1, 2}
 
-			var sosPosts []sospost.WriteSosPostView
+			var sosPosts []sospost.WriteSOSPostView
 			for i := 1; i < 4; i++ {
-				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, petIDs, i)
+				sosPost := tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, petIDs, i)
 				sosPosts = append(sosPosts, *sosPost)
 			}
 
 			// when
-			sosPostList, err := sosPostService.FindSosPosts(ctx, 1, 3, "newest", "all")
+			sosPostList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -143,7 +143,7 @@ func TestSosPostService(t *testing.T) {
 				assertMediaEquals(t, sosPost.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
 				assertAuthorEquals(t, sosPost.Author, author)
 				assertDatesEquals(t, sosPost.Dates, sosPosts[idx].Dates)
-				assertFindSosPostEquals(t, sosPost, sosPosts[idx])
+				assertFindSOSPostEquals(t, sosPost, sosPosts[idx])
 			}
 		})
 		t.Run("전체 돌봄 급구 게시글의 정렬기준을 'deadline'으로 조회한다", func(t *testing.T) {
@@ -168,18 +168,18 @@ func TestSosPostService(t *testing.T) {
 			uid := owner.FirebaseUID
 			addPets := tests.AddDummyPets(t, ctx, userService, uid, &profileImage.ID)
 
-			sosPostService := service.NewSosPostService(db)
+			sosPostService := service.NewSOSPostService(db)
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			var sosPosts []sospost.WriteSosPostView
+			var sosPosts []sospost.WriteSOSPostView
 			for i := 1; i < 4; i++ {
-				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[i-1].ID}, i)
+				sosPost := tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[i-1].ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
 			}
 
 			// when
-			sosPostList, err := sosPostService.FindSosPosts(ctx, 1, 3, "newest", "all")
+			sosPostList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -192,7 +192,7 @@ func TestSosPostService(t *testing.T) {
 				assertMediaEquals(t, sosPost.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
 				assertAuthorEquals(t, sosPost.Author, author)
 				assertDatesEquals(t, sosPost.Dates, sosPosts[idx].Dates)
-				assertFindSosPostEquals(t, sosPost, sosPosts[idx])
+				assertFindSOSPostEquals(t, sosPost, sosPosts[idx])
 			}
 		})
 		t.Run("전체 돌봄 급구 게시글 중 반려동물이 'dog'인 경우만 조회한다", func(t *testing.T) {
@@ -217,27 +217,27 @@ func TestSosPostService(t *testing.T) {
 			uid := owner.FirebaseUID
 			addPets := tests.AddDummyPets(t, ctx, userService, uid, &profileImage.ID)
 
-			sosPostService := service.NewSosPostService(db)
+			sosPostService := service.NewSOSPostService(db)
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			var sosPosts []sospost.WriteSosPostView
+			var sosPosts []sospost.WriteSOSPostView
 			// 강아지인 경우
 			for i := 1; i < 3; i++ {
-				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[i-1].ID}, i)
+				sosPost := tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[i-1].ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
 			}
 
 			// 고양이인 경우
 			sosPosts = append(sosPosts,
-				*tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[2].ID}, 3))
+				*tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[2].ID}, 3))
 
 			// 강아지, 고양이인 경우
 			sosPosts = append(sosPosts,
-				*tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[1].ID, addPets[2].ID}, 4))
+				*tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPets[1].ID, addPets[2].ID}, 4))
 
 			// when
-			sosPostList, err := sosPostService.FindSosPosts(ctx, 1, 3, "newest", "all")
+			sosPostList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -250,7 +250,7 @@ func TestSosPostService(t *testing.T) {
 				assertMediaEquals(t, sosPost.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
 				assertAuthorEquals(t, sosPost.Author, author)
 				assertDatesEquals(t, sosPost.Dates, sosPosts[idx].Dates)
-				assertFindSosPostEquals(t, sosPost, sosPosts[idx])
+				assertFindSOSPostEquals(t, sosPost, sosPosts[idx])
 			}
 		})
 		t.Run("작성자 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
@@ -274,18 +274,18 @@ func TestSosPostService(t *testing.T) {
 			uid := owner.FirebaseUID
 			addPet := tests.AddDummyPet(t, ctx, userService, uid, &profileImage.ID)
 
-			sosPostService := service.NewSosPostService(db)
+			sosPostService := service.NewSOSPostService(db)
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			sosPosts := make([]sospost.WriteSosPostView, 0)
+			sosPosts := make([]sospost.WriteSOSPostView, 0)
 			for i := 1; i < 4; i++ {
-				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPet.ID}, i)
+				sosPost := tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPet.ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
 			}
 
 			// when
-			sosPostListByAuthorID, err := sosPostService.FindSosPostsByAuthorID(ctx, owner.ID, 1, 3, "newest", "all")
+			sosPostListByAuthorID, err := sosPostService.FindSOSPostsByAuthorID(ctx, owner.ID, 1, 3, "newest", "all")
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -298,11 +298,11 @@ func TestSosPostService(t *testing.T) {
 				assertMediaEquals(t, sosPost.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
 				assertAuthorEquals(t, sosPost.Author, author)
 				assertDatesEquals(t, sosPost.Dates, sosPosts[idx].Dates)
-				assertFindSosPostEquals(t, sosPost, sosPosts[idx])
+				assertFindSOSPostEquals(t, sosPost, sosPosts[idx])
 			}
 		})
 	})
-	t.Run("FindSosPostByID", func(t *testing.T) {
+	t.Run("FindSOSPostByID", func(t *testing.T) {
 		t.Run("게시글 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
 			ctx := context.Background()
 			db, tearDown := setUp(ctx, t)
@@ -324,18 +324,18 @@ func TestSosPostService(t *testing.T) {
 			uid := owner.FirebaseUID
 			addPet := tests.AddDummyPet(t, ctx, userService, uid, &profileImage.ID)
 
-			sosPostService := service.NewSosPostService(db)
+			sosPostService := service.NewSOSPostService(db)
 			imageIDs := []int{sosPostImage.ID, sosPostImage2.ID}
 			conditionIDs := []int{1, 2}
 
-			sosPosts := make([]sospost.WriteSosPostView, 0)
+			sosPosts := make([]sospost.WriteSOSPostView, 0)
 			for i := 1; i < 4; i++ {
-				sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPet.ID}, i)
+				sosPost := tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, imageIDs, []int{addPet.ID}, i)
 				sosPosts = append(sosPosts, *sosPost)
 			}
 
 			// when
-			findSosPostByID, err := sosPostService.FindSosPostByID(ctx, sosPosts[0].ID)
+			findSOSPostByID, err := sosPostService.FindSOSPostByID(ctx, sosPosts[0].ID)
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
@@ -343,14 +343,14 @@ func TestSosPostService(t *testing.T) {
 			// then
 			assertConditionEquals(t, sosPosts[0].Conditions, conditionIDs)
 			assertPetEquals(t, sosPosts[0].Pets[0], *addPet)
-			assertMediaEquals(t, findSosPostByID.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
-			assertAuthorEquals(t, findSosPostByID.Author, author)
-			assertDatesEquals(t, findSosPostByID.Dates, sosPosts[0].Dates)
-			assertFindSosPostEquals(t, *findSosPostByID, sosPosts[0])
+			assertMediaEquals(t, findSOSPostByID.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
+			assertAuthorEquals(t, findSOSPostByID.Author, author)
+			assertDatesEquals(t, findSOSPostByID.Dates, sosPosts[0].Dates)
+			assertFindSOSPostEquals(t, *findSOSPostByID, sosPosts[0])
 		})
 	})
 
-	t.Run("UpdateSosPost", func(t *testing.T) {
+	t.Run("UpdateSOSPost", func(t *testing.T) {
 		t.Run("돌봄 급구 게시글을 수정합니다.", func(t *testing.T) {
 			ctx := context.Background()
 			db, tearDown := setUp(ctx, t)
@@ -368,16 +368,16 @@ func TestSosPostService(t *testing.T) {
 			uid := owner.FirebaseUID
 			addPet := tests.AddDummyPet(t, ctx, userService, uid, &profileImage.ID)
 
-			sosPostService := service.NewSosPostService(db)
-			sosPost := tests.WriteDummySosPosts(t, ctx, sosPostService, uid, []int{sosPostImage.ID}, []int{addPet.ID}, 1)
+			sosPostService := service.NewSOSPostService(db)
+			sosPost := tests.WriteDummySOSPosts(t, ctx, sosPostService, uid, []int{sosPostImage.ID}, []int{addPet.ID}, 1)
 
-			updateSosPostData := &sospost.UpdateSosPostRequest{
+			updateSOSPostData := &sospost.UpdateSOSPostRequest{
 				ID:       sosPost.ID,
 				Title:    "Title2",
 				Content:  "Content2",
 				ImageIDs: []int{sosPostImage.ID, sosPostImage2.ID},
 				Reward:   "Reward2",
-				Dates: []sospost.SosDateView{
+				Dates: []sospost.SOSDateView{
 					{"2024-04-10", "2024-04-20"},
 					{"2024-05-10", "2024-05-20"},
 				},
@@ -389,45 +389,45 @@ func TestSosPostService(t *testing.T) {
 			}
 
 			// when
-			updateSosPost, err := sosPostService.UpdateSosPost(ctx, updateSosPostData)
+			updateSOSPost, err := sosPostService.UpdateSOSPost(ctx, updateSOSPostData)
 			if err != nil {
 				t.Errorf("got %v want %v", err, nil)
 			}
 
-			assertConditionEquals(t, sosPost.Conditions, updateSosPostData.ConditionIDs)
+			assertConditionEquals(t, sosPost.Conditions, updateSOSPostData.ConditionIDs)
 			assertPetEquals(t, sosPost.Pets[0], *addPet)
-			assertMediaEquals(t, updateSosPost.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
-			assertDatesEquals(t, updateSosPost.Dates, updateSosPostData.Dates)
+			assertMediaEquals(t, updateSOSPost.Media, (&media.MediaList{sosPostImage, sosPostImage2}).ToMediaViewList())
+			assertDatesEquals(t, updateSOSPost.Dates, updateSOSPostData.Dates)
 
-			if updateSosPost.Title != updateSosPostData.Title {
-				t.Errorf("got %v want %v", updateSosPost.Title, updateSosPostData.Title)
+			if updateSOSPost.Title != updateSOSPostData.Title {
+				t.Errorf("got %v want %v", updateSOSPost.Title, updateSOSPostData.Title)
 			}
-			if updateSosPost.Content != updateSosPostData.Content {
-				t.Errorf("got %v want %v", updateSosPost.Content, updateSosPostData.Content)
+			if updateSOSPost.Content != updateSOSPostData.Content {
+				t.Errorf("got %v want %v", updateSOSPost.Content, updateSOSPostData.Content)
 			}
-			if updateSosPost.Reward != updateSosPostData.Reward {
-				t.Errorf("got %v want %v", updateSosPost.Reward, updateSosPostData.Reward)
+			if updateSOSPost.Reward != updateSOSPostData.Reward {
+				t.Errorf("got %v want %v", updateSOSPost.Reward, updateSOSPostData.Reward)
 			}
-			if updateSosPost.CareType != updateSosPostData.CareType {
-				t.Errorf("got %v want %v", updateSosPost.CareType, updateSosPostData.CareType)
+			if updateSOSPost.CareType != updateSOSPostData.CareType {
+				t.Errorf("got %v want %v", updateSOSPost.CareType, updateSOSPostData.CareType)
 			}
-			if updateSosPost.CarerGender != updateSosPostData.CarerGender {
-				t.Errorf("got %v want %v", updateSosPost.CarerGender, updateSosPostData.CarerGender)
+			if updateSOSPost.CarerGender != updateSOSPostData.CarerGender {
+				t.Errorf("got %v want %v", updateSOSPost.CarerGender, updateSOSPostData.CarerGender)
 			}
-			if updateSosPost.RewardType != updateSosPostData.RewardType {
-				t.Errorf("got %v want %v", updateSosPost.RewardType, updateSosPostData.RewardType)
+			if updateSOSPost.RewardType != updateSOSPostData.RewardType {
+				t.Errorf("got %v want %v", updateSOSPost.RewardType, updateSOSPostData.RewardType)
 			}
-			if updateSosPost.ThumbnailID != sosPostImage.ID {
-				t.Errorf("got %v want %v", updateSosPost.ThumbnailID, sosPostImage.ID)
+			if updateSOSPost.ThumbnailID != sosPostImage.ID {
+				t.Errorf("got %v want %v", updateSOSPost.ThumbnailID, sosPostImage.ID)
 			}
-			if updateSosPost.AuthorID != owner.ID {
-				t.Errorf("got %v want %v", updateSosPost.AuthorID, owner.ID)
+			if updateSOSPost.AuthorID != owner.ID {
+				t.Errorf("got %v want %v", updateSOSPost.AuthorID, owner.ID)
 			}
 		})
 	})
 }
 
-func assertFindSosPostEquals(t *testing.T, got sospost.FindSosPostView, want sospost.WriteSosPostView) {
+func assertFindSOSPostEquals(t *testing.T, got sospost.FindSOSPostView, want sospost.WriteSOSPostView) {
 	t.Helper()
 
 	if got.Title != want.Title {
@@ -495,7 +495,7 @@ func assertAuthorEquals(t *testing.T, got, want *user.UserWithoutPrivateInfo) {
 	}
 }
 
-func assertDatesEquals(t *testing.T, got, want []sospost.SosDateView) {
+func assertDatesEquals(t *testing.T, got, want []sospost.SOSDateView) {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -2,6 +2,9 @@ package service_test
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
@@ -11,8 +14,6 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/postgres"
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 	"github.com/pet-sitter/pets-next-door-api/internal/tests"
-	"reflect"
-	"testing"
 )
 
 func TestSosPostService(t *testing.T) {

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -270,7 +270,7 @@ func TestUserService(t *testing.T) {
 			// Given
 			mediaService := service.NewMediaService(db, nil)
 			profileImage, _ := mediaService.CreateMedia(ctx, &media.Media{
-				MediaType: media.IMAGE_MEDIA_TYPE,
+				MediaType: media.MediaTypeImage,
 				URL:       "http://example.com",
 			})
 

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/tests"
 )
 
+//nolint:gocognit
 func TestUserService(t *testing.T) {
 	setUp := func(t *testing.T) (*database.DB, func(t *testing.T)) {
 		t.Helper()

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -15,15 +15,21 @@ import (
 
 func TestUserService(t *testing.T) {
 	setUp := func(t *testing.T) (*database.DB, func(t *testing.T)) {
+		t.Helper()
+
 		db, _ := database.Open(tests.TestDatabaseURL)
 		db.Flush()
 
 		return db, func(t *testing.T) {
+			t.Helper()
+
 			db.Close()
 		}
 	}
 
 	assertPetEquals := func(t *testing.T, expected pet.AddPetRequest, found pet.PetView) {
+		t.Helper()
+
 		if expected.Name != found.Name {
 			t.Errorf("got %v want %v", expected.Name, found.Name)
 		}
@@ -54,6 +60,8 @@ func TestUserService(t *testing.T) {
 	}
 
 	assertUpdatedPetEquals := func(t *testing.T, expected pet.UpdatePetRequest, found pet.PetView) {
+	t.Helper()
+
 		if expected.Name != found.Name {
 			t.Errorf("got %v want %v", expected.Name, found.Name)
 		}

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -60,7 +60,7 @@ func TestUserService(t *testing.T) {
 	}
 
 	assertUpdatedPetEquals := func(t *testing.T, expected pet.UpdatePetRequest, found pet.PetView) {
-	t.Helper()
+		t.Helper()
 
 		if expected.Name != found.Name {
 			t.Errorf("got %v want %v", expected.Name, found.Name)
@@ -417,7 +417,8 @@ func TestUserService(t *testing.T) {
 
 			petProfileImage := tests.AddDummyMedia(t, ctx, mediaService)
 			petRequest := tests.GenerateDummyAddPetRequest(&petProfileImage.ID)
-			createdPets, _ := userService.AddPetsToOwner(ctx, userRequest.FirebaseUID, pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{*petRequest}})
+			createdPets, _ := userService.AddPetsToOwner(
+				ctx, userRequest.FirebaseUID, pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{*petRequest}})
 			createdPet := createdPets[0]
 
 			// When
@@ -457,7 +458,11 @@ func TestUserService(t *testing.T) {
 
 			petProfileImage := tests.AddDummyMedia(t, ctx, mediaService)
 			petRequest := tests.GenerateDummyAddPetRequest(&petProfileImage.ID)
-			createdPets, _ := userService.AddPetsToOwner(ctx, userRequest.FirebaseUID, pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{*petRequest}})
+			createdPets, _ := userService.AddPetsToOwner(
+				ctx,
+				userRequest.FirebaseUID,
+				pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{*petRequest}},
+			)
 			createdPet := createdPets[0]
 
 			// When

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -27,62 +27,6 @@ func TestUserService(t *testing.T) {
 		}
 	}
 
-	assertPetEquals := func(t *testing.T, expected pet.AddPetRequest, found pet.PetView) {
-		t.Helper()
-
-		if expected.Name != found.Name {
-			t.Errorf("got %v want %v", expected.Name, found.Name)
-		}
-
-		if expected.PetType != found.PetType {
-			t.Errorf("got %v want %v", expected.PetType, found.PetType)
-		}
-
-		if expected.Sex != found.Sex {
-			t.Errorf("got %v want %v", expected.Sex, found.PetType)
-		}
-
-		if expected.Neutered != found.Neutered {
-			t.Errorf("got %v want %v", expected.Neutered, found.Neutered)
-		}
-
-		if expected.Breed != found.Breed {
-			t.Errorf("got %v want %v", expected.Breed, found.Breed)
-		}
-
-		if expected.BirthDate != found.BirthDate {
-			t.Errorf("got %v want %v", expected.BirthDate, found.BirthDate)
-		}
-
-		if expected.WeightInKg != found.WeightInKg {
-			t.Errorf("got %v want %v", expected.WeightInKg, found.WeightInKg)
-		}
-	}
-
-	assertUpdatedPetEquals := func(t *testing.T, expected pet.UpdatePetRequest, found pet.PetView) {
-		t.Helper()
-
-		if expected.Name != found.Name {
-			t.Errorf("got %v want %v", expected.Name, found.Name)
-		}
-
-		if expected.Neutered != found.Neutered {
-			t.Errorf("got %v want %v", expected.Neutered, found.Neutered)
-		}
-
-		if expected.Breed != found.Breed {
-			t.Errorf("got %v want %v", expected.Breed, found.Breed)
-		}
-
-		if expected.BirthDate != found.BirthDate {
-			t.Errorf("got %v want %v", expected.BirthDate, found.BirthDate)
-		}
-
-		if expected.WeightInKg != found.WeightInKg {
-			t.Errorf("got %v want %v", expected.WeightInKg, found.WeightInKg)
-		}
-	}
-
 	t.Run("RegisterUser", func(t *testing.T) {
 		t.Run("사용자를 새로 생성한다", func(t *testing.T) {
 			db, tearDown := setUp(t)
@@ -398,7 +342,7 @@ func TestUserService(t *testing.T) {
 
 			for _, expected := range pets.Pets {
 				for _, found := range found.Pets {
-					assertPetEquals(t, expected, found)
+					assertPetRequestAndViewEquals(t, expected, found)
 				}
 			}
 		})
@@ -475,4 +419,60 @@ func TestUserService(t *testing.T) {
 			}
 		})
 	})
+}
+
+func assertPetRequestAndViewEquals(t *testing.T, expected pet.AddPetRequest, found pet.PetView) {
+	t.Helper()
+
+	if expected.Name != found.Name {
+		t.Errorf("got %v want %v", expected.Name, found.Name)
+	}
+
+	if expected.PetType != found.PetType {
+		t.Errorf("got %v want %v", expected.PetType, found.PetType)
+	}
+
+	if expected.Sex != found.Sex {
+		t.Errorf("got %v want %v", expected.Sex, found.PetType)
+	}
+
+	if expected.Neutered != found.Neutered {
+		t.Errorf("got %v want %v", expected.Neutered, found.Neutered)
+	}
+
+	if expected.Breed != found.Breed {
+		t.Errorf("got %v want %v", expected.Breed, found.Breed)
+	}
+
+	if expected.BirthDate != found.BirthDate {
+		t.Errorf("got %v want %v", expected.BirthDate, found.BirthDate)
+	}
+
+	if expected.WeightInKg != found.WeightInKg {
+		t.Errorf("got %v want %v", expected.WeightInKg, found.WeightInKg)
+	}
+}
+
+func assertUpdatedPetEquals(t *testing.T, expected pet.UpdatePetRequest, found pet.PetView) {
+	t.Helper()
+
+	if expected.Name != found.Name {
+		t.Errorf("got %v want %v", expected.Name, found.Name)
+	}
+
+	if expected.Neutered != found.Neutered {
+		t.Errorf("got %v want %v", expected.Neutered, found.Neutered)
+	}
+
+	if expected.Breed != found.Breed {
+		t.Errorf("got %v want %v", expected.Breed, found.Breed)
+	}
+
+	if expected.BirthDate != found.BirthDate {
+		t.Errorf("got %v want %v", expected.BirthDate, found.BirthDate)
+	}
+
+	if expected.WeightInKg != found.WeightInKg {
+		t.Errorf("got %v want %v", expected.WeightInKg, found.WeightInKg)
+	}
 }

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -57,7 +57,7 @@ func (service *UserService) RegisterUser(
 }
 
 func (service *UserService) FindUsers(
-	ctx context.Context, page int, size int, nickname *string,
+	ctx context.Context, page, size int, nickname *string,
 ) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
@@ -84,7 +84,7 @@ func (service *UserService) findUserByUID(ctx context.Context, uid string) (*use
 		return nil, err
 	}
 
-	user, err := postgres.FindUserByUID(ctx, tx, uid)
+	userData, err := postgres.FindUserByUID(ctx, tx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (service *UserService) findUserByUID(ctx context.Context, uid string) (*use
 		return nil, err
 	}
 
-	return user, nil
+	return userData, nil
 }
 
 // FindMyProfile은 사용자의 프로필 정보를 조회한다.
@@ -107,7 +107,7 @@ func (service *UserService) FindPublicUserByID(
 		return nil, err
 	}
 
-	user, err := postgres.FindUserByID(ctx, tx, id, true)
+	userData, err := postgres.FindUserByID(ctx, tx, id, true)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (service *UserService) FindPublicUserByID(
 		return nil, err
 	}
 
-	return user.ToUserWithoutPrivateInfo(), nil
+	return userData.ToUserWithoutPrivateInfo(), nil
 }
 
 func (service *UserService) FindUserByEmail(
@@ -128,7 +128,7 @@ func (service *UserService) FindUserByEmail(
 		return nil, err
 	}
 
-	user, err := postgres.FindUserByEmail(ctx, tx, email)
+	userData, err := postgres.FindUserByEmail(ctx, tx, email)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (service *UserService) FindUserByEmail(
 		return nil, err
 	}
 
-	return user, nil
+	return userData, nil
 }
 
 func (service *UserService) FindUserByUID(ctx context.Context, uid string) (*user.FindUserView, *pnd.AppError) {
@@ -198,7 +198,7 @@ func (service *UserService) FindUserStatusByEmail(ctx context.Context, email str
 }
 
 func (service *UserService) UpdateUserByUID(
-	ctx context.Context, uid string, nickname string, profileImageID *int,
+	ctx context.Context, uid, nickname string, profileImageID *int,
 ) (*user.UserWithProfileImage, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
@@ -241,11 +241,7 @@ func (service *UserService) DeleteUserByUID(ctx context.Context, uid string) *pn
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Commit()
 }
 
 func (service *UserService) AddPetsToOwner(
@@ -257,7 +253,7 @@ func (service *UserService) AddPetsToOwner(
 		return nil, err
 	}
 
-	user, err := postgres.FindUserByUID(ctx, tx, uid)
+	userData, err := postgres.FindUserByUID(ctx, tx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +266,7 @@ func (service *UserService) AddPetsToOwner(
 			}
 		}
 
-		petToCreate := item.ToPet(user.ID)
+		petToCreate := item.ToPet(userData.ID)
 		createdPet, err := postgres.CreatePet(ctx, tx, petToCreate)
 		if err != nil {
 			return nil, err
@@ -351,11 +347,7 @@ func (service *UserService) DeletePet(ctx context.Context, uid string, petID int
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Commit()
 }
 
 func (service *UserService) FindPetsByOwnerUID(ctx context.Context, uid string) (*pet.FindMyPetsView, *pnd.AppError) {
@@ -365,12 +357,12 @@ func (service *UserService) FindPetsByOwnerUID(ctx context.Context, uid string) 
 		return nil, err
 	}
 
-	user, err := postgres.FindUserByUID(ctx, tx, uid)
+	userData, err := postgres.FindUserByUID(ctx, tx, uid)
 	if err != nil {
 		return nil, err
 	}
 
-	pets, err := postgres.FindPetsByOwnerID(ctx, tx, user.ID)
+	pets, err := postgres.FindPetsByOwnerID(ctx, tx, userData.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +381,7 @@ func (service *UserService) findPetByID(ctx context.Context, petID int) (*pet.Pe
 		return nil, err
 	}
 
-	pet, err := postgres.FindPetByID(ctx, tx, petID)
+	petData, err := postgres.FindPetByID(ctx, tx, petID)
 	if err != nil {
 		return nil, err
 	}
@@ -398,5 +390,5 @@ func (service *UserService) findPetByID(ctx context.Context, petID int) (*pet.Pe
 		return nil, err
 	}
 
-	return pet, nil
+	return petData, nil
 }

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -319,6 +319,9 @@ func (service *UserService) UpdatePet(
 	}
 
 	updatedPet, err := service.findPetByID(ctx, petID)
+	if err != nil {
+		return nil, err
+	}
 	return updatedPet.ToPetView(), nil
 }
 

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -23,7 +23,9 @@ func NewUserService(conn *database.DB, mediaService *MediaService) *UserService 
 	}
 }
 
-func (service *UserService) RegisterUser(ctx context.Context, registerUserRequest *user.RegisterUserRequest) (*user.RegisterUserView, *pnd.AppError) {
+func (service *UserService) RegisterUser(
+	ctx context.Context, registerUserRequest *user.RegisterUserRequest,
+) (*user.RegisterUserView, *pnd.AppError) {
 	var profileImageURL *string
 	if registerUserRequest.ProfileImageID != nil {
 		mediaData, err := service.mediaService.FindMediaByID(ctx, *registerUserRequest.ProfileImageID)
@@ -54,7 +56,9 @@ func (service *UserService) RegisterUser(ctx context.Context, registerUserReques
 	return created.ToRegisterUserView(profileImageURL), nil
 }
 
-func (service *UserService) FindUsers(ctx context.Context, page int, size int, nickname *string) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
+func (service *UserService) FindUsers(
+	ctx context.Context, page int, size int, nickname *string,
+) (*user.UserWithoutPrivateInfoList, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -94,7 +98,9 @@ func (service *UserService) findUserByUID(ctx context.Context, uid string) (*use
 
 // FindMyProfile은 사용자의 프로필 정보를 조회한다.
 // 삭제된 유저의 경우 삭제된 유저 정보를 반환한다.
-func (service *UserService) FindPublicUserByID(ctx context.Context, id int) (*user.UserWithoutPrivateInfo, *pnd.AppError) {
+func (service *UserService) FindPublicUserByID(
+	ctx context.Context, id int,
+) (*user.UserWithoutPrivateInfo, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -113,7 +119,9 @@ func (service *UserService) FindPublicUserByID(ctx context.Context, id int) (*us
 	return user.ToUserWithoutPrivateInfo(), nil
 }
 
-func (service *UserService) FindUserByEmail(ctx context.Context, email string) (*user.UserWithProfileImage, *pnd.AppError) {
+func (service *UserService) FindUserByEmail(
+	ctx context.Context, email string,
+) (*user.UserWithProfileImage, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -189,7 +197,9 @@ func (service *UserService) FindUserStatusByEmail(ctx context.Context, email str
 	return userStatus, nil
 }
 
-func (service *UserService) UpdateUserByUID(ctx context.Context, uid string, nickname string, profileImageID *int) (*user.UserWithProfileImage, *pnd.AppError) {
+func (service *UserService) UpdateUserByUID(
+	ctx context.Context, uid string, nickname string, profileImageID *int,
+) (*user.UserWithProfileImage, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -238,7 +248,9 @@ func (service *UserService) DeleteUserByUID(ctx context.Context, uid string) *pn
 	return nil
 }
 
-func (service *UserService) AddPetsToOwner(ctx context.Context, uid string, addPetsRequest pet.AddPetsToOwnerRequest) ([]pet.PetView, *pnd.AppError) {
+func (service *UserService) AddPetsToOwner(
+	ctx context.Context, uid string, addPetsRequest pet.AddPetsToOwnerRequest,
+) ([]pet.PetView, *pnd.AppError) {
 	tx, err := service.conn.BeginTx(ctx)
 	defer tx.Rollback()
 	if err != nil {
@@ -273,7 +285,9 @@ func (service *UserService) AddPetsToOwner(ctx context.Context, uid string, addP
 	return pets.ToPetViewList(), nil
 }
 
-func (service *UserService) UpdatePet(ctx context.Context, uid string, petID int, updatePetRequest pet.UpdatePetRequest) (*pet.PetView, *pnd.AppError) {
+func (service *UserService) UpdatePet(
+	ctx context.Context, uid string, petID int, updatePetRequest pet.UpdatePetRequest,
+) (*pet.PetView, *pnd.AppError) {
 	owner, err := service.findUserByUID(ctx, uid)
 	if err != nil {
 		return nil, err

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
@@ -295,7 +296,7 @@ func (service *UserService) UpdatePet(
 	}
 
 	if petToUpdate.OwnerID != owner.ID {
-		return nil, pnd.ErrForbidden(fmt.Errorf("해당 반려동물을 수정할 권한이 없습니다"))
+		return nil, pnd.ErrForbidden(errors.New("해당 반려동물을 수정할 권한이 없습니다"))
 	}
 
 	if updatePetRequest.ProfileImageID != nil {
@@ -337,7 +338,7 @@ func (service *UserService) DeletePet(ctx context.Context, uid string, petID int
 	}
 
 	if petToDelete.OwnerID != owner.ID {
-		return pnd.ErrForbidden(fmt.Errorf("해당 반려동물을 삭제할 권한이 없습니다"))
+		return pnd.ErrForbidden(errors.New("해당 반려동물을 삭제할 권한이 없습니다"))
 	}
 
 	tx, err := service.conn.BeginTx(ctx)

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -299,7 +299,7 @@ func (service *UserService) UpdatePet(
 	}
 
 	if updatePetRequest.ProfileImageID != nil {
-		if _, err := service.mediaService.FindMediaByID(ctx, *updatePetRequest.ProfileImageID); err != nil {
+		if _, err = service.mediaService.FindMediaByID(ctx, *updatePetRequest.ProfileImageID); err != nil {
 			return nil, err
 		}
 	}
@@ -314,7 +314,7 @@ func (service *UserService) UpdatePet(
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err = tx.Commit(); err != nil {
 		return nil, err
 	}
 

--- a/internal/tests/config.go
+++ b/internal/tests/config.go
@@ -4,6 +4,7 @@ import "os"
 
 var TestDatabaseURL = os.Getenv("TEST_DATABASE_URL")
 
+//nolint:gochecknoinits
 func init() {
 	if TestDatabaseURL == "" {
 		TestDatabaseURL = "postgresql://postgres:postgres@localhost:5455/pets_next_door_api_test?sslmode=disable"

--- a/internal/tests/factories.go
+++ b/internal/tests/factories.go
@@ -70,13 +70,13 @@ func GenerateDummyAddPetsRequest(profileImageID *int) []pet.AddPetRequest {
 	}
 }
 
-func GenerateDummyWriteSosPostRequest(imageID, petIDs []int, sosPostCnt int) *sospost.WriteSosPostRequest {
-	return &sospost.WriteSosPostRequest{
+func GenerateDummyWriteSOSPostRequest(imageID, petIDs []int, sosPostCnt int) *sospost.WriteSOSPostRequest {
+	return &sospost.WriteSOSPostRequest{
 		Title:    fmt.Sprintf("Title%d", sosPostCnt),
 		Content:  fmt.Sprintf("Content%d", sosPostCnt),
 		ImageIDs: imageID,
 		Reward:   "Reward",
-		Dates: []sospost.SosDateView{
+		Dates: []sospost.SOSDateView{
 			{DateStartAt: fmt.Sprintf("2024-04-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-04-2%d", sosPostCnt)},
 			{DateStartAt: fmt.Sprintf("2024-05-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-05-2%d", sosPostCnt)},
 		},

--- a/internal/tests/factories.go
+++ b/internal/tests/factories.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"

--- a/internal/tests/factories.go
+++ b/internal/tests/factories.go
@@ -77,8 +77,8 @@ func GenerateDummyWriteSosPostRequest(imageID, petIDs []int, sosPostCnt int) *so
 		ImageIDs: imageID,
 		Reward:   "Reward",
 		Dates: []sospost.SosDateView{
-			{fmt.Sprintf("2024-04-1%d", sosPostCnt), fmt.Sprintf("2024-04-2%d", sosPostCnt)},
-			{fmt.Sprintf("2024-05-1%d", sosPostCnt), fmt.Sprintf("2024-05-2%d", sosPostCnt)},
+			{DateStartAt: fmt.Sprintf("2024-04-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-04-2%d", sosPostCnt)},
+			{DateStartAt: fmt.Sprintf("2024-05-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-05-2%d", sosPostCnt)},
 		},
 		CareType:     sospost.CareTypeFoster,
 		CarerGender:  sospost.CarerGenderMale,

--- a/internal/tests/factories.go
+++ b/internal/tests/factories.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 )
 
@@ -70,19 +70,19 @@ func GenerateDummyAddPetsRequest(profileImageID *int) []pet.AddPetRequest {
 	}
 }
 
-func GenerateDummyWriteSosPostRequest(imageID []int, petIDs []int, sosPostCnt int) *sos_post.WriteSosPostRequest {
-	return &sos_post.WriteSosPostRequest{
+func GenerateDummyWriteSosPostRequest(imageID, petIDs []int, sosPostCnt int) *sospost.WriteSosPostRequest {
+	return &sospost.WriteSosPostRequest{
 		Title:    fmt.Sprintf("Title%d", sosPostCnt),
 		Content:  fmt.Sprintf("Content%d", sosPostCnt),
 		ImageIDs: imageID,
 		Reward:   "Reward",
-		Dates: []sos_post.SosDateView{
+		Dates: []sospost.SosDateView{
 			{fmt.Sprintf("2024-04-1%d", sosPostCnt), fmt.Sprintf("2024-04-2%d", sosPostCnt)},
 			{fmt.Sprintf("2024-05-1%d", sosPostCnt), fmt.Sprintf("2024-05-2%d", sosPostCnt)},
 		},
-		CareType:     sos_post.CareTypeFoster,
-		CarerGender:  sos_post.CarerGenderMale,
-		RewardType:   sos_post.RewardTypeFee,
+		CareType:     sospost.CareTypeFoster,
+		CarerGender:  sospost.CarerGenderMale,
+		RewardType:   sospost.RewardTypeFee,
 		ConditionIDs: []int{1, 2},
 		PetIDs:       petIDs,
 	}

--- a/internal/tests/helpers.go
+++ b/internal/tests/helpers.go
@@ -1,6 +1,6 @@
 package tests
 
-func CreateForEach(setUp func(), tearDown func()) func(func()) {
+func CreateForEach(setUp, tearDown func()) func(func()) {
 	return func(test func()) {
 		setUp()
 		test()

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -2,12 +2,13 @@ package tests
 
 import (
 	"context"
+	"testing"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
-	"testing"
 )
 
 func AddDummyMedia(t *testing.T, ctx context.Context, mediaService *service.MediaService) *media.Media {

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -12,6 +12,7 @@ import (
 )
 
 func AddDummyMedia(t *testing.T, ctx context.Context, mediaService *service.MediaService) *media.Media {
+	t.Helper()
 	media, err := mediaService.CreateMedia(context.Background(), &media.Media{
 		MediaType: media.IMAGE_MEDIA_TYPE,
 		URL:       "http://example.com",
@@ -29,6 +30,7 @@ func RegisterDummyUser(
 	userService *service.UserService,
 	mediaService *service.MediaService,
 ) *user.RegisterUserView {
+	t.Helper()
 	profileImage := AddDummyMedia(t, ctx, mediaService)
 	userRequest := GenerateDummyRegisterUserRequest(&profileImage.ID)
 	registeredUser, err := userService.RegisterUser(ctx, userRequest)
@@ -46,6 +48,7 @@ func AddDummyPet(
 	ownerUID string,
 	profileImageID *int,
 ) *pet.PetView {
+	t.Helper()
 	pets, err := userService.AddPetsToOwner(ctx, ownerUID, pet.AddPetsToOwnerRequest{
 		Pets: []pet.AddPetRequest{*GenerateDummyAddPetRequest(profileImageID)},
 	})
@@ -63,6 +66,7 @@ func AddDummyPets(
 	ownerUID string,
 	profileImageID *int,
 ) []pet.PetView {
+	t.Helper()
 	pets, err := userService.AddPetsToOwner(ctx, ownerUID, pet.AddPetsToOwnerRequest{
 		Pets: GenerateDummyAddPetsRequest(profileImageID),
 	})
@@ -82,6 +86,7 @@ func WriteDummySosPosts(
 	petIDs []int,
 	sosPostCnt int,
 ) *sos_post.WriteSosPostView {
+	t.Helper()
 	sosPostRequest := GenerateDummyWriteSosPostRequest(imageID, petIDs, sosPostCnt)
 	sosPost, err := sosPostService.WriteSosPost(ctx, uid, sosPostRequest)
 	if err != nil {

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -14,7 +14,7 @@ import (
 func AddDummyMedia(t *testing.T, ctx context.Context, mediaService *service.MediaService) *media.Media {
 	t.Helper()
 	mediaData, err := mediaService.CreateMedia(ctx, &media.Media{
-		MediaType: media.IMAGE_MEDIA_TYPE,
+		MediaType: media.MediaTypeImage,
 		URL:       "http://example.com",
 	})
 	if err != nil {

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -77,18 +77,18 @@ func AddDummyPets(
 	return pets
 }
 
-func WriteDummySosPosts(
+func WriteDummySOSPosts(
 	t *testing.T,
 	ctx context.Context,
-	sosPostService *service.SosPostService,
+	sosPostService *service.SOSPostService,
 	uid string,
 	imageID []int,
 	petIDs []int,
 	sosPostCnt int,
-) *sospost.WriteSosPostView {
+) *sospost.WriteSOSPostView {
 	t.Helper()
-	sosPostRequest := GenerateDummyWriteSosPostRequest(imageID, petIDs, sosPostCnt)
-	sosPost, err := sosPostService.WriteSosPost(ctx, uid, sosPostRequest)
+	sosPostRequest := GenerateDummyWriteSOSPostRequest(imageID, petIDs, sosPostCnt)
+	sosPost, err := sosPostService.WriteSOSPost(ctx, uid, sosPostRequest)
 	if err != nil {
 		t.Errorf("got %v want %v", err, nil)
 	}

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sos_post"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	"github.com/pet-sitter/pets-next-door-api/internal/service"
 )
 
 func AddDummyMedia(t *testing.T, ctx context.Context, mediaService *service.MediaService) *media.Media {
 	t.Helper()
-	media, err := mediaService.CreateMedia(context.Background(), &media.Media{
+	mediaData, err := mediaService.CreateMedia(ctx, &media.Media{
 		MediaType: media.IMAGE_MEDIA_TYPE,
 		URL:       "http://example.com",
 	})
@@ -21,7 +21,7 @@ func AddDummyMedia(t *testing.T, ctx context.Context, mediaService *service.Medi
 		t.Errorf("got %v want %v", err, nil)
 	}
 
-	return media
+	return mediaData
 }
 
 func RegisterDummyUser(
@@ -85,7 +85,7 @@ func WriteDummySosPosts(
 	imageID []int,
 	petIDs []int,
 	sosPostCnt int,
-) *sos_post.WriteSosPostView {
+) *sospost.WriteSosPostView {
 	t.Helper()
 	sosPostRequest := GenerateDummyWriteSosPostRequest(imageID, petIDs, sosPostCnt)
 	sosPost, err := sosPostService.WriteSosPost(ctx, uid, sosPostRequest)

--- a/lib/middleware/auth.go
+++ b/lib/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+
 	"github.com/labstack/echo/v4"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/auth"
 	"github.com/pet-sitter/pets-next-door-api/internal/service"


### PR DESCRIPTION
## About

golangci-lint를 CI에 추가하고 Lint 오류를 수정합니다.

그리고 gofumpt 포매터를 추가합니다.

## Formatter - gofumpt

추가로 [gofumpt](https://github.com/mvdan/gofumpt) 를 포매터로 추가합니다.

```
# 로컬 환경
$ make format:install
$ make format
```

golangci-lint에 연동되어, 포매팅이 맞지 않으면 린터에서도 오류를 냅니다.

## Linter - golangci-lint

로컬에서 린터 설정은 기존에 추가한 것처럼 다음과 같이 가능합니다.

```
# 로컬 환경
$ make lint:install
$ make lint
$ make lint:fix  # 해당 린터 플러그인이 fix를 지원할 경우
```

이번에 작업한 사항은 린트 수정이며 동작상 달라지는 부분은 없거나 미미합니다.

Lint 오류 발견 시 CI에서 해당 코드에 어노테이션을 달아줍니다. (Comment 아님)

- https://github.com/golangci/golangci-lint
- https://github.com/golangci/golangci-lint-action
