### PR TITLE
chore(lint): enable tagliatelle

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -575,7 +575,7 @@ linters:
     #- misspell # [useless] finds commonly misspelled English words in comments
     #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
     #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
-    #- tagliatelle # checks the struct tags
+    - tagliatelle # checks the struct tags
     #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
 

--- a/internal/configs/server.go
+++ b/internal/configs/server.go
@@ -22,6 +22,7 @@ var (
 
 var FirebaseCredentialsPath = os.Getenv("FIREBASE_CREDENTIALS_PATH")
 
+//nolint:tagliatelle
 type FirebaseCredentialsJSONType struct {
 	Type                    string `json:"type"`
 	ProjectID               string `json:"project_id"`

--- a/internal/domain/auth/view.go
+++ b/internal/domain/auth/view.go
@@ -12,7 +12,7 @@ type KakaoCallbackView struct {
 	FirebaseProviderType user.FirebaseProviderType `json:"fbProviderType"`
 	FirebaseUID          string                    `json:"fbUid"`
 	Email                string                    `json:"email"`
-	PhotoURL             string                    `json:"photoURL"`
+	PhotoURL             string                    `json:"photoUrl"`
 }
 
 func NewKakaoCallbackView(authToken string, kakaoUserProfile *kakaoinfra.KakaoUserProfile) KakaoCallbackView {
@@ -36,7 +36,7 @@ type GenerateFBCustomTokenResponse struct {
 	FirebaseProviderType user.FirebaseProviderType `json:"fbProviderType"`
 	FirebaseUID          string                    `json:"fbUid"`
 	Email                string                    `json:"email"`
-	PhotoURL             string                    `json:"photoURL"`
+	PhotoURL             string                    `json:"photoUrl"`
 }
 
 func NewGenerateFBCustomTokenResponse(

--- a/internal/domain/media/media.go
+++ b/internal/domain/media/media.go
@@ -16,11 +16,11 @@ const (
 
 type Media struct {
 	ID        int       `field:"id" json:"id"`
-	MediaType MediaType `field:"media_type" json:"media_type"`
+	MediaType MediaType `field:"media_type" json:"mediaType"`
 	URL       string    `field:"url" json:"url"`
-	CreatedAt string    `field:"created_at" json:"created_at"`
-	UpdatedAt string    `field:"updated_at" json:"updated_at"`
-	DeletedAt string    `field:"deleted_at" json:"deleted_at"`
+	CreatedAt string    `field:"created_at" json:"createdAt"`
+	UpdatedAt string    `field:"updated_at" json:"updatedAt"`
+	DeletedAt string    `field:"deleted_at" json:"deletedAt"`
 }
 
 type MediaList []*Media

--- a/internal/domain/pet/pet.go
+++ b/internal/domain/pet/pet.go
@@ -10,18 +10,18 @@ import (
 
 type BasePet struct {
 	ID         int     `field:"id" json:"id"`
-	OwnerID    int     `field:"owner_id" json:"owner_id"`
+	OwnerID    int     `field:"owner_id" json:"ownerId"`
 	Name       string  `field:"name" json:"name"`
-	PetType    PetType `field:"pet_type" json:"pet_type"`
+	PetType    PetType `field:"pet_type" json:"petType"`
 	Sex        PetSex  `field:"sex" json:"sex"`
 	Neutered   bool    `field:"neutered" json:"neutered"`
 	Breed      string  `field:"breed" json:"breed"`
-	BirthDate  string  `field:"birth_date" json:"birth_date"`
-	WeightInKg float64 `field:"weight_in_kg" json:"weight_in_kg"`
+	BirthDate  string  `field:"birth_date" json:"birthDate"`
+	WeightInKg float64 `field:"weight_in_kg" json:"weightInKg"`
 	Remarks    string  `field:"remarks" json:"remarks"`
-	CreatedAt  string  `field:"created_at" json:"created_at"`
-	UpdatedAt  string  `field:"updated_at" json:"updated_at"`
-	DeletedAt  string  `field:"deleted_at" json:"deleted_at"`
+	CreatedAt  string  `field:"created_at" json:"createdAt"`
+	UpdatedAt  string  `field:"updated_at" json:"updatedAt"`
+	DeletedAt  string  `field:"deleted_at" json:"deletedAt"`
 }
 
 type Pet struct {
@@ -33,7 +33,7 @@ type PetList []*Pet
 
 type PetWithProfileImage struct {
 	BasePet
-	ProfileImageURL *string `field:"profile_image_url" json:"profile_image_url"`
+	ProfileImageURL *string `field:"profile_image_url" json:"profileImageUrl"`
 }
 
 type PetWithProfileList []*PetWithProfileImage

--- a/internal/domain/sospost/sos_post.go
+++ b/internal/domain/sospost/sos_post.go
@@ -89,11 +89,11 @@ func NewSOSPostInfoList(page, size int) *SOSPostInfoList {
 
 type SOSDates struct {
 	ID          int       `field:"id" json:"id"`
-	DateStartAt string    `field:"date_start_at" json:"date_start_at"`
-	DateEndAt   string    `field:"date_end_at" json:"date_end_at"`
-	CreatedAt   time.Time `field:"created_at" json:"created_at"`
-	UpdatedAt   time.Time `field:"updated_at" json:"updated_at"`
-	DeletedAt   time.Time `field:"deleted_at" json:"deleted_at"`
+	DateStartAt string    `field:"date_start_at" json:"dateStartAt"`
+	DateEndAt   string    `field:"date_end_at" json:"dateEndAt"`
+	CreatedAt   time.Time `field:"created_at" json:"createdAt"`
+	UpdatedAt   time.Time `field:"updated_at" json:"updatedAt"`
+	DeletedAt   time.Time `field:"deleted_at" json:"deletedAt"`
 }
 
 type SOSDatesList []*SOSDates

--- a/internal/infra/kakao/view.go
+++ b/internal/infra/kakao/view.go
@@ -2,6 +2,7 @@ package kakaoinfra
 
 import "net/url"
 
+//nolint:tagliatelle
 type KakaoTokenRequest struct {
 	GrantType   string `json:"grant_type"`
 	ClientID    string `json:"client_id"`
@@ -28,6 +29,7 @@ func (r KakaoTokenRequest) ToURLValues() url.Values {
 	return values
 }
 
+//nolint:tagliatelle
 type KakaoTokenResponse struct {
 	TokenType             string `json:"token_type"`
 	AccessToken           string `json:"access_token"`
@@ -37,6 +39,7 @@ type KakaoTokenResponse struct {
 	Scope                 string `json:"scope"`
 }
 
+//nolint:tagliatelle
 type KakaoUserProfile struct {
 	ID           int64        `json:"id"`
 	ConnectedAt  string       `json:"connected_at"`
@@ -44,18 +47,21 @@ type KakaoUserProfile struct {
 	KakaoAccount kakaoAccount `json:"kakao_account"`
 }
 
+//nolint:tagliatelle
 type properties struct {
 	Nickname       string `json:"nickname"`
 	ProfileImage   string `json:"profile_image"`
 	ThumbnailImage string `json:"thumbnail_image"`
 }
 
+//nolint:tagliatelle
 type kakaoProfile struct {
 	Nickname          string `json:"nickname"`
 	ProfileImageURL   string `json:"profile_image_url"`
 	ThumbnailImageURL string `json:"thumbnail_image_url"`
 }
 
+//nolint:tagliatelle
 type kakaoAccount struct {
 	ProfileNeedsAgreement  bool         `json:"profile_needs_agreement"`
 	Profile                kakaoProfile `json:"profile"`


### PR DESCRIPTION
[tagliatelle](https://github.com/ldez/tagliatelle) 린터를 활성화하고 json으로 나갈 때 camel case가 아닌 것을 수정합니다.

바뀐 struct들이 아마 클라이언트로 노출된 것들이 아니라서 어드민 제외하고 영향 가는 API는 없을 것 같습니다.