### PR TITLE
docker-compose 파일에서 version property를 제거합니다.

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   db_test:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   db:
     image: postgres:15-alpine


### PR DESCRIPTION
## About

docker-compose 파일에서 deprecated 된 version property를 제거합니다.

```
WARN[0000] .../pets-next-door-api/docker-compose-test.yml: `version` is obsolete
```

## REF

https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete