### PR TITLE
golangci-lint 룰을 일부 수정합니다.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -617,3 +617,7 @@ issues:
         - gosec
         - noctx
         - wrapcheck
+    - path: internal/tests/config.go # https://github.com/golangci/golangci-lint/issues/4697
+      text: "don't use `init` function"
+    - path: internal/configs/server.go
+      text: "don't use `init` function"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -491,7 +491,6 @@ linters:
     - durationcheck # checks for two durations multiplied together
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
     - exhaustive # checks exhaustiveness of enum switch statements
     - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # forbids identifiers

--- a/internal/configs/server.go
+++ b/internal/configs/server.go
@@ -65,7 +65,7 @@ var (
 	BreedsGoogleSheetsID = os.Getenv("BREEDS_GOOGLE_SHEETS_ID")
 )
 
-//nolint:gochecknoinits
+//nolint:init // initializes required environment variables
 func init() {
 	if Port == "" {
 		Port = "8080"

--- a/internal/tests/config.go
+++ b/internal/tests/config.go
@@ -4,7 +4,7 @@ import "os"
 
 var TestDatabaseURL = os.Getenv("TEST_DATABASE_URL")
 
-//nolint:gochecknoinits
+//nolint:init // initializes required environment variables
 func init() {
 	if TestDatabaseURL == "" {
 		TestDatabaseURL = "postgresql://postgres:postgres@localhost:5455/pets_next_door_api_test?sslmode=disable"


### PR DESCRIPTION
golangci-lint 룰을 일부 수정합니다.

1. deprecated된 `execinquery` 린터를 제거합니다. 그냥 insert/update할 땐 `Query` 대신 `Exec`을 사용하면 됩니다.

```
internal/tests/config.go:7:1: directive `//nolint:gochecknoinits` is unused for linter "gochecknoinits" (nolintlint)
```

2. `gochecknoinits`가 린터에서 `init`이라는 이름을 쓰는 것에 대해 임시로 처리합니다.

nolint를 걸어놨는데도 최근 들어 lint 에러가 뜨길래 봤더니 이름을 `init`으로 쓰고 있는 듯 합니다. 이슈를 보니 고쳐진 듯 하지만 임시로 제거합니다.