### PR TITLE
uuid PK, FK 필드 추가 및 마이그레이션합니다.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ run:
 	go run ./cmd/server
 
 test:
-	make db:test:down
+	make db:test:destroy
 	make db:test:up
 	go test ./... -count=1 -p=1
-	make db:test:down
+	make db:test:destroy
 test\:run:
 	go test ./... -count=1 -p=1
 

--- a/api/web.go
+++ b/api/web.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/google/uuid"
+
 	"github.com/go-playground/validator"
 	"github.com/labstack/echo/v4"
 )
@@ -20,16 +22,14 @@ func ParseBody(c echo.Context, payload interface{}) *AppError {
 	return nil
 }
 
-func ParseIDFromPath(c echo.Context, path string) (*int, *AppError) {
-	id, err := strconv.Atoi(c.Param(path))
+func ParseIDFromPath(c echo.Context, path string) (uuid.UUID, *AppError) {
+	idStr := c.Param(path)
+	id, err := uuid.Parse(idStr)
 	if err != nil {
-		return nil, ErrInvalidParam(err)
-	}
-	if id <= 0 {
-		return nil, ErrInvalidParam(fmt.Errorf("expected integer value bigger than 0 for path: %s", path))
+		return uuid.UUID{}, ErrInvalidParam(fmt.Errorf("expected valid UUID for path: %s", path))
 	}
 
-	return &id, nil
+	return id, nil
 }
 
 func ParseOptionalIntQuery(c echo.Context, query string) (*int, *AppError) {

--- a/api/web.go
+++ b/api/web.go
@@ -32,6 +32,20 @@ func ParseIDFromPath(c echo.Context, path string) (uuid.UUID, *AppError) {
 	return id, nil
 }
 
+func ParseOptionalUUIDQuery(c echo.Context, query string) (uuid.NullUUID, *AppError) {
+	queryStr := c.QueryParam(query)
+	if queryStr == "" {
+		return uuid.NullUUID{}, nil
+	}
+
+	id, err := uuid.Parse(queryStr)
+	if err != nil {
+		return uuid.NullUUID{}, ErrInvalidQuery(fmt.Errorf("expected valid UUID for query: %s", query))
+	}
+
+	return uuid.NullUUID{UUID: id, Valid: true}, nil
+}
+
 func ParseOptionalIntQuery(c echo.Context, query string) (*int, *AppError) {
 	queryStr := c.QueryParam(query)
 	if queryStr == "" {

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	"log"
 
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
@@ -116,6 +117,7 @@ func importBreed(
 	}
 
 	breedData, err := databasegen.New(conn).CreateBreed(ctx, databasegen.CreateBreedParams{
+		ID:      datatype.NewUUIDV7(),
 		Name:    row.Breed,
 		PetType: petType.String(),
 	})
@@ -131,7 +133,7 @@ func importBreed(
 	)
 
 	return &breed.DetailView{
-		ID:      int64(breedData.ID),
+		ID:      breedData.ID,
 		PetType: commonvo.PetType(breedData.PetType),
 		Name:    breedData.Name,
 	}, nil

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	"log"
+
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"

--- a/cmd/migrateuuids/main.go
+++ b/cmd/migrateuuids/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	pnd "github.com/pet-sitter/pets-next-door-api/api"
+	"github.com/pet-sitter/pets-next-door-api/internal/configs"
+	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
+	"github.com/rs/zerolog/log"
+)
+
+var targetTables = map[string][]string{
+	"users":                {"uuid", "profile_image_uuid"},
+	"media":                {"uuid"},
+	"breeds":               {"uuid"},
+	"pets":                 {"uuid", "owner_uuid", "profile_image_uuid"},
+	"base_posts":           {"uuid", "author_uuid"},
+	"sos_posts":            {"thumbnail_uuid"},
+	"sos_dates":            {"uuid"},
+	"sos_posts_dates":      {"uuid", "sos_post_uuid", "sos_dates_uuid"},
+	"sos_conditions":       {"uuid"},
+	"sos_posts_conditions": {"uuid", "sos_post_uuid", "sos_condition_uuid"},
+	"sos_posts_pets":       {"uuid", "sos_post_uuid", "pet_uuid"},
+	"resource_media":       {"uuid", "media_uuid", "resource_uuid"},
+}
+
+func main() {
+	log.Print("Running UUID migration script")
+
+	db, err := database.Open(configs.DatabaseURL)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error opening database")
+	}
+
+	for tableName, columns := range targetTables {
+		log.Printf("Processing table %s", tableName)
+		for _, column := range columns {
+			log.Printf(" - Column %s", column)
+		}
+	}
+
+	log.Print("Starting migration")
+	ctx := context.Background()
+	pndErr := migrateUUID(ctx, db)
+	if pndErr != nil {
+		log.Fatal().Err(pndErr.Err).Msg("error migrating UUIDs")
+	}
+	log.Print("Completed migration")
+}
+
+func migrateUUID(ctx context.Context, db *database.DB) *pnd.AppError {
+	type Row struct {
+		ID int
+	}
+
+	tx, err := db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	for tableName, columns := range targetTables {
+		log.Printf("Processing table %s", tableName)
+
+		var count int
+		err := tx.QueryRow("SELECT COUNT(*) FROM " + tableName).Scan(&count)
+		if err != nil {
+			return pnd.ErrUnknown(fmt.Errorf("error counting rows from table %s due to %w", tableName, err))
+		}
+		log.Printf(" - Total rows: %d", count)
+
+		rows, err := tx.Query("SELECT id FROM " + tableName + " ORDER BY created_at ASC")
+		if err != nil {
+			return pnd.ErrUnknown(
+				fmt.Errorf("error selecting rows from table %s due to %w", tableName, err),
+			)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var row Row
+			err = rows.Scan(&row.ID)
+			if err != nil {
+				return pnd.ErrUnknown(
+					fmt.Errorf("error scanning row from table %s with id %d due to %w", tableName, row.ID, err),
+				)
+			}
+			for _, column := range columns {
+				newUUID, err := uuid.NewV7()
+				if err != nil {
+					return pnd.ErrUnknown(
+						fmt.Errorf("error generating new UUID for table %s column %s due to %w", tableName, column, err),
+					)
+				}
+
+				log.Printf("SQL: UPDATE %s SET %s = %s WHERE id = %d", tableName, column, newUUID, row.ID)
+				// _, err = tx.Exec("UPDATE "+tableName+" SET "+column+" = $1 WHERE id = $2", newUUID, row.ID)
+				// if err != nil {
+				// 	return pnd.ErrUnknown(
+				// 		fmt.Errorf(
+				// 			"error updating table %s column %s with new UUID %s for id %d due to %w",
+				// 			tableName, column, newUUID, row.ID, err),
+				// 	)
+				// }
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/migrateuuids/main.go
+++ b/cmd/migrateuuids/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	ctx := context.Background()
 
-	pndErr := migrate(ctx, db, MigrateOptions{ReadOnly: true, Force: false})
+	pndErr := migrate(ctx, db, MigrateOptions{ReadOnly: *readOnlyPtr, Force: *forcePtr})
 	if pndErr != nil {
 		panic(pndErr.Err)
 	}

--- a/cmd/migrateuuids/main.go
+++ b/cmd/migrateuuids/main.go
@@ -2,110 +2,52 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"flag"
+	"log"
 
-	"github.com/google/uuid"
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
-	"github.com/rs/zerolog/log"
 )
 
-var targetTables = map[string][]string{
-	"users":                {"uuid", "profile_image_uuid"},
-	"media":                {"uuid"},
-	"breeds":               {"uuid"},
-	"pets":                 {"uuid", "owner_uuid", "profile_image_uuid"},
-	"base_posts":           {"uuid", "author_uuid"},
-	"sos_posts":            {"thumbnail_uuid"},
-	"sos_dates":            {"uuid"},
-	"sos_posts_dates":      {"uuid", "sos_post_uuid", "sos_dates_uuid"},
-	"sos_conditions":       {"uuid"},
-	"sos_posts_conditions": {"uuid", "sos_post_uuid", "sos_condition_uuid"},
-	"sos_posts_pets":       {"uuid", "sos_post_uuid", "pet_uuid"},
-	"resource_media":       {"uuid", "media_uuid", "resource_uuid"},
-}
-
 func main() {
-	log.Print("Running UUID migration script")
+	readOnlyPtr := flag.Bool("readonly", false, "Run migration in read-only mode")
+	forcePtr := flag.Bool("force", false, "Run migration in force mode")
+	flag.Parse()
+
+	var readOnly bool
+	if *readOnlyPtr {
+		readOnly = true
+	}
+
+	var force bool
+	if *forcePtr {
+		force = true
+	}
+
+	log.Printf("Running UUID migration script with readonly: %v, force: %v\n", readOnly, force)
+
+	log.Println("Running UUID migration script")
 
 	db, err := database.Open(configs.DatabaseURL)
 	if err != nil {
-		log.Fatal().Err(err).Msg("error opening database")
+		panic(err)
 	}
 
-	for tableName, columns := range targetTables {
-		log.Printf("Processing table %s", tableName)
-		for _, column := range columns {
-			log.Printf(" - Column %s", column)
+	for _, target := range Targets {
+		log.Printf("Processing table %s\n", target.Table)
+		for _, fk := range target.FKs {
+			log.Printf(" - FK %s\n", fk.Column)
 		}
 	}
 
-	log.Print("Starting migration")
+	log.Println("Starting migration")
+
 	ctx := context.Background()
-	pndErr := migrateUUID(ctx, db)
+
+	pndErr := migrate(ctx, db, MigrateOptions{ReadOnly: true, Force: false})
 	if pndErr != nil {
-		log.Fatal().Err(pndErr.Err).Msg("error migrating UUIDs")
-	}
-	log.Print("Completed migration")
-}
-
-func migrateUUID(ctx context.Context, db *database.DB) *pnd.AppError {
-	type Row struct {
-		ID int
+		panic(pndErr.Err)
 	}
 
-	tx, err := db.BeginTx(ctx)
-	if err != nil {
-		return err
-	}
-
-	for tableName, columns := range targetTables {
-		log.Printf("Processing table %s", tableName)
-
-		var count int
-		err := tx.QueryRow("SELECT COUNT(*) FROM " + tableName).Scan(&count)
-		if err != nil {
-			return pnd.ErrUnknown(fmt.Errorf("error counting rows from table %s due to %w", tableName, err))
-		}
-		log.Printf(" - Total rows: %d", count)
-
-		rows, err := tx.Query("SELECT id FROM " + tableName + " ORDER BY created_at ASC")
-		if err != nil {
-			return pnd.ErrUnknown(
-				fmt.Errorf("error selecting rows from table %s due to %w", tableName, err),
-			)
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var row Row
-			err = rows.Scan(&row.ID)
-			if err != nil {
-				return pnd.ErrUnknown(
-					fmt.Errorf("error scanning row from table %s with id %d due to %w", tableName, row.ID, err),
-				)
-			}
-			for _, column := range columns {
-				newUUID, err := uuid.NewV7()
-				if err != nil {
-					return pnd.ErrUnknown(
-						fmt.Errorf("error generating new UUID for table %s column %s due to %w", tableName, column, err),
-					)
-				}
-
-				log.Printf("SQL: UPDATE %s SET %s = %s WHERE id = %d", tableName, column, newUUID, row.ID)
-				// _, err = tx.Exec("UPDATE "+tableName+" SET "+column+" = $1 WHERE id = $2", newUUID, row.ID)
-				// if err != nil {
-				// 	return pnd.ErrUnknown(
-				// 		fmt.Errorf(
-				// 			"error updating table %s column %s with new UUID %s for id %d due to %w",
-				// 			tableName, column, newUUID, row.ID, err),
-				// 	)
-				// }
-			}
-		}
-	}
-
-	return nil
+	log.Println("Completed migration")
 }

--- a/cmd/migrateuuids/uuidmigrator.go
+++ b/cmd/migrateuuids/uuidmigrator.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	pnd "github.com/pet-sitter/pets-next-door-api/api"
+	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
+)
+
+type Target struct {
+	Table      string
+	UUIDColumn string
+	FKs        []FK
+}
+
+// Many To One 관계 업데이트
+// table로부터 column을 가져오고, 그 column으로 SELECT를 해서
+// reference table로부터 reference column 값을 가져와서 table의 UUID columnName을 업데이트
+// e.g.
+// SELECT id, column names, fks FROM table_name
+// for each row
+// SELECT reference_column, uuid FROM reference_table WHERE id = row.id
+// UPDATE table_name SET uuid_column = uuid WHERE id = row
+type FK struct {
+	Column     string // FK 컬럼 이름
+	UUIDColumn string // UUID 버전의 FK 컬럼 이름
+
+	ReferencedTable  string
+	ReferencedColumn string
+}
+
+var Targets = []Target{
+	{"users", "uuid", []FK{
+		{Column: "profile_image_id", UUIDColumn: "profile_image_uuid", ReferencedTable: "media", ReferencedColumn: "uuid"},
+	}},
+	{"media", "uuid", []FK{}},
+	{"breeds", "uuid", []FK{}},
+	{"pets", "uuid", []FK{
+		{Column: "owner_id", UUIDColumn: "owner_uuid", ReferencedTable: "users", ReferencedColumn: "uuid"},
+		{Column: "profile_image_id", UUIDColumn: "profile_image_uuid", ReferencedTable: "media", ReferencedColumn: "uuid"},
+	}},
+	{"base_posts", "uuid", []FK{
+		{Column: "author_id", UUIDColumn: "author_uuid", ReferencedTable: "users", ReferencedColumn: "uuid"},
+	}},
+	{"sos_posts", "uuid", []FK{
+		{Column: "thumbnail_id", UUIDColumn: "thumbnail_uuid", ReferencedTable: "media", ReferencedColumn: "uuid"},
+	}},
+	{"sos_dates", "uuid", []FK{}},
+	{"sos_posts_dates", "uuid", []FK{
+		{Column: "sos_post_id", UUIDColumn: "sos_post_uuid", ReferencedTable: "sos_posts", ReferencedColumn: "uuid"},
+		{Column: "sos_dates_id", UUIDColumn: "sos_dates_uuid", ReferencedTable: "sos_dates", ReferencedColumn: "uuid"},
+	}},
+	{"sos_conditions", "uuid", []FK{}},
+	{"sos_posts_conditions", "uuid", []FK{
+		{Column: "sos_post_id", UUIDColumn: "sos_post_uuid", ReferencedTable: "sos_posts", ReferencedColumn: "uuid"},
+		{
+			Column: "sos_condition_id", UUIDColumn: "sos_condition_uuid", ReferencedTable: "sos_conditions",
+			ReferencedColumn: "uuid",
+		},
+	}},
+	{"sos_posts_pets", "uuid", []FK{
+		{Column: "sos_post_id", UUIDColumn: "sos_post_uuid", ReferencedTable: "sos_posts", ReferencedColumn: "uuid"},
+		{Column: "pet_id", UUIDColumn: "pet_uuid", ReferencedTable: "pets", ReferencedColumn: "uuid"},
+	}},
+	{
+		"resource_media", "uuid", []FK{
+			{Column: "media_id", UUIDColumn: "media_uuid", ReferencedTable: "media", ReferencedColumn: "uuid"},
+			// Conditional FK -- Thankfully, we only have SOS post for resource
+			{Column: "resource_id", UUIDColumn: "resource_uuid", ReferencedTable: "sos_posts", ReferencedColumn: "uuid"},
+		},
+	},
+}
+
+type MigrateOptions struct {
+	ReadOnly bool
+	Force    bool
+	Log      bool
+}
+
+func migrate(ctx context.Context, db *database.DB, options MigrateOptions) *pnd.AppError {
+	log.Println("Migrating UUIDs for tables")
+	tx, err := db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	// UUID 컬럼만 먼저 업데이트
+	err = MigrateUUID(tx, options)
+	if err != nil {
+		return err
+	}
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	log.Println()
+
+	log.Println("Migrating FKs for tables")
+	// Read fk constraints and update them as well
+	tx, err = db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	err = MigrateFK(tx, options)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MigrateUUID(tx *database.Tx, options MigrateOptions) *pnd.AppError {
+	type Row struct {
+		ID   int
+		UUID *string
+	}
+
+	total := 0
+	succeeded := 0
+	skipped := 0
+
+	for _, target := range Targets {
+		log.Printf("Processing table %s\n", target.Table)
+
+		var count int
+		err := tx.QueryRow("SELECT COUNT(*) FROM " + target.Table).Scan(&count)
+		if err != nil {
+			return pnd.ErrUnknown(fmt.Errorf("error counting rows from table %s due to %w", target.Table, err))
+		}
+		log.Printf(" - Total rows: %d\n", count)
+		total += count
+
+		rows, err := tx.Query("SELECT id, uuid FROM " + target.Table + " ORDER BY created_at ASC")
+		if err != nil {
+			return pnd.ErrUnknown(
+				fmt.Errorf("error selecting rows from table %s due to %w", target.Table, err),
+			)
+		}
+
+		var rowData []Row
+		for rows.Next() {
+			var row Row
+			err = rows.Scan(&row.ID, &row.UUID)
+			if err != nil {
+				return pnd.ErrUnknown(
+					fmt.Errorf("error scanning row from table %s with id %d due to %w", target.Table, row.ID, err),
+				)
+			}
+			rowData = append(rowData, row)
+		}
+		rows.Close()
+
+		for _, row := range rowData {
+			if !options.Force && row.UUID != nil {
+				skipped++
+				log.Printf(" - Skipping row %d with UUID %s\n", row.ID, *row.UUID)
+				continue
+			}
+
+			newUUID, err := uuid.NewV7()
+			if err != nil {
+				return pnd.ErrUnknown(fmt.Errorf("error generating UUID due to %w", err))
+			}
+
+			if !options.ReadOnly {
+				_, err = tx.Exec("UPDATE "+target.Table+" SET "+target.UUIDColumn+" = $1 WHERE id = $2", newUUID, row.ID)
+				if err != nil {
+					return pnd.ErrUnknown(
+						fmt.Errorf("error updating UUID column in table %s with id %d due to %w", target.Table, row.ID, err),
+					)
+				}
+				log.Printf(" - Updated row %d with UUID %s\n", row.ID, newUUID)
+			}
+
+			succeeded++
+		}
+	}
+
+	log.Printf("Total rows: %d, Succeeded: %d, Skipped: %d\n", total, succeeded, skipped)
+
+	return nil
+}
+
+// FK 컬럼을 연관된 테이블의 uuid 컬럼을 조회해 업데이트
+func MigrateFK(tx *database.Tx, options MigrateOptions) *pnd.AppError {
+	for _, target := range Targets {
+		log.Printf("Processing table %s\n", target.Table)
+
+		for _, fk := range target.FKs {
+			succeeded := 0
+			skipped := 0
+
+			rows, err := tx.Query("SELECT id, " + fk.Column + " FROM " + target.Table)
+			if err != nil {
+				return pnd.ErrUnknown(
+					fmt.Errorf("error selecting rows from table %s due to %w", target.Table, err),
+				)
+			}
+
+			type RowData struct {
+				ID      int
+				FKValue *int
+			}
+
+			var rowData []RowData
+			for rows.Next() {
+				var row struct{ ID int }
+				var fkValue *int
+
+				err = rows.Scan(&row.ID, &fkValue)
+				if err != nil {
+					return pnd.ErrUnknown(
+						fmt.Errorf("error scanning row from table %s with id %d due to %w", target.Table, row.ID, err),
+					)
+				}
+
+				rowData = append(rowData, RowData{row.ID, fkValue})
+			}
+			rows.Close()
+
+			total := len(rowData)
+			log.Printf(" - FK %s, Total rows: %d\n", fk.Column, len(rowData))
+
+			for _, row := range rowData {
+				// Skip if FK is not set
+				if row.FKValue == nil {
+					log.Printf(" - Skipping row %d with FK %s due to null value\n", row.ID, fk.Column)
+					skipped++
+					continue
+				}
+
+				var uuidValue *string
+				err = tx.QueryRow(
+					"SELECT "+fk.ReferencedColumn+" FROM "+fk.ReferencedTable+" WHERE id = $1",
+					row.FKValue).Scan(&uuidValue)
+				if err != nil && err.Error() != "sql: no rows in result set" {
+					return pnd.ErrUnknown(
+						fmt.Errorf("error selecting UUID from table %s with id %d due to %w", fk.ReferencedTable, row.FKValue, err),
+					)
+				}
+
+				// Skip if UUID is not set
+				if uuidValue == nil {
+					// Perhaps you forgot to run MigrateUUID() before MigrateFK()
+					log.Printf(" - Skipping row %d with FK %s due to missing UUID\n", row.ID, fk.Column)
+					skipped++
+					continue
+				}
+
+				if !options.ReadOnly {
+					_, err = tx.Exec("UPDATE "+target.Table+" SET "+fk.UUIDColumn+" = $1 WHERE id = $2", uuidValue, row.ID)
+					if err != nil {
+						return pnd.ErrUnknown(
+							fmt.Errorf("error updating UUID column in table %s with id %d due to %w", target.Table, row.ID, err),
+						)
+					}
+				}
+
+				succeeded++
+			}
+
+			log.Printf(" - FK %s, Total rows: %d, Succeeded: %d, Skipped: %d\n", fk.Column, total, succeeded, skipped)
+		}
+	}
+
+	return nil
+}

--- a/cmd/migrateuuids/uuidmigrator.go
+++ b/cmd/migrateuuids/uuidmigrator.go
@@ -174,7 +174,12 @@ func MigrateUUID(tx *database.Tx, options MigrateOptions) *pnd.AppError {
 			}
 			rowData = append(rowData, row)
 		}
-		rows.Close()
+		err = rows.Close()
+		if err != nil {
+			return pnd.ErrUnknown(
+				fmt.Errorf("error closing rows from table %s due to %w", target.Table, err),
+			)
+		}
 
 		for _, row := range rowData {
 			if !options.Force && row.UUID != nil {

--- a/cmd/migrateuuids/uuidmigrator.go
+++ b/cmd/migrateuuids/uuidmigrator.go
@@ -108,6 +108,10 @@ func migrate(ctx context.Context, db *database.DB, options MigrateOptions) *pnd.
 	if err != nil {
 		return err
 	}
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -251,7 +255,7 @@ func MigrateFK(tx *database.Tx, options MigrateOptions) *pnd.AppError {
 				}
 
 				if !options.ReadOnly {
-					_, err = tx.Exec("UPDATE "+target.Table+" SET "+fk.UUIDColumn+" = $1 WHERE id = $2", uuidValue, row.ID)
+					_, err = tx.Exec("UPDATE "+target.Table+" SET "+fk.UUIDColumn+" = $1 WHERE id = $2", *uuidValue, row.ID)
 					if err != nil {
 						return pnd.ErrUnknown(
 							fmt.Errorf("error updating UUID column in table %s with id %d due to %w", target.Table, row.ID, err),

--- a/cmd/server/handler/media_handler.go
+++ b/cmd/server/handler/media_handler.go
@@ -36,7 +36,7 @@ func (h *MediaHandler) FindMediaByID(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	found, err := h.mediaService.FindMediaByID(c.Request().Context(), int64(*id))
+	found, err := h.mediaService.FindMediaByID(c.Request().Context(), id)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -1,165 +1,156 @@
 package handler
 
-import (
-	"errors"
-	"net/http"
-
-	"github.com/labstack/echo/v4"
-
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
-	"github.com/pet-sitter/pets-next-door-api/internal/service"
-)
-
-type SOSPostHandler struct {
-	sosPostService service.SOSPostService
-	authService    service.AuthService
-}
-
-func NewSOSPostHandler(sosPostService service.SOSPostService, authService service.AuthService) *SOSPostHandler {
-	return &SOSPostHandler{
-		sosPostService: sosPostService,
-		authService:    authService,
-	}
-}
-
-// WriteSOSPost godoc
-// @Summary 돌봄급구 게시글을 업로드합니다.
-// @Description
-// @Tags posts
-// @Accept  json
-// @Produce  json
-// @Param request body sospost.WriteSOSPostRequest true "돌봄급구 게시글 업로드 요청"
-// @Security FirebaseAuth
-// @Success 201 {object} sospost.DetailView
-// @Router /posts/sos [post]
-func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
-	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	var writeSOSPostRequest sospost.WriteSOSPostRequest
-	if err = pnd.ParseBody(c, &writeSOSPostRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	res, err := h.sosPostService.WriteSOSPost(c.Request().Context(), foundUser.FirebaseUID, &writeSOSPostRequest)
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	return c.JSON(http.StatusCreated, res)
-}
-
-// FindSOSPosts godoc
-// @Summary 돌봄급구 게시글을 조회합니다.
-// @Description
-// @Tags posts
-// @Accept  json
-// @Produce  json
-// @Param author_id query int false "작성자 ID"
-// @Param page query int false "페이지 번호" default(1)
-// @Param size query int false "페이지 사이즈" default(20)
-// @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
-// @Param filter_type query string false "필터링 기준" Enums(dog, cat, all)
-// @Success 200 {object} sospost.FindSOSPostListView
-// @Router /posts/sos [get]
-func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
-	authorID, err := pnd.ParseOptionalIntQuery(c, "author_id")
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	sortBy := "newest"
-	if sortByQuery := pnd.ParseOptionalStringQuery(c, "sort_by"); sortByQuery != nil {
-		sortBy = *sortByQuery
-	}
-	filterType := "all"
-	if filterTypeQuery := pnd.ParseOptionalStringQuery(c, "filter_type"); filterTypeQuery != nil {
-		filterType = *filterTypeQuery
-	}
-
-	page, size, err := pnd.ParsePaginationQueries(c, 1, 20)
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	var res *sospost.FindSOSPostListView
-	if authorID != nil {
-		res, err = h.sosPostService.FindSOSPostsByAuthorID(c.Request().Context(), *authorID, page, size, sortBy, filterType)
-		if err != nil {
-			return c.JSON(err.StatusCode, err)
-		}
-	} else {
-		res, err = h.sosPostService.FindSOSPosts(c.Request().Context(), page, size, sortBy, filterType)
-		if err != nil {
-			return c.JSON(err.StatusCode, err)
-		}
-	}
-
-	return c.JSON(http.StatusOK, res)
-}
-
-// FindSOSPostByID godoc
-// @Summary 게시글 ID로 돌봄급구 게시글을 조회합니다.
-// @Description
-// @Tags posts
-// @Produce  json
-// @Param id path int true "게시글 ID"
-// @Success 200 {object} sospost.FindSOSPostView
-// @Router /posts/sos/{id} [get]
-func (h *SOSPostHandler) FindSOSPostByID(c echo.Context) error {
-	id, err := pnd.ParseIDFromPath(c, "id")
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-	res, err := h.sosPostService.FindSOSPostByID(c.Request().Context(), *id)
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	return c.JSON(http.StatusOK, res)
-}
-
-// UpdateSOSPost godoc
-// @Summary 돌봄급구 게시글을 수정합니다.
-// @Description
-// @Tags posts
-// @Accept  json
-// @Produce  json
-// @Security FirebaseAuth
-// @Param request body sospost.UpdateSOSPostRequest true "돌봄급구 수정 요청"
-// @Success 200
-// @Router /posts/sos [put]
-func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
-	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	var updateSOSPostRequest sospost.UpdateSOSPostRequest
-	if err = pnd.ParseBody(c, &updateSOSPostRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	permission, err := h.sosPostService.CheckUpdatePermission(
-		c.Request().Context(),
-		foundUser.FirebaseUID,
-		updateSOSPostRequest.ID,
-	)
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-	if !permission {
-		pndErr := pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
-		return c.JSON(pndErr.StatusCode, pndErr)
-	}
-
-	res, err := h.sosPostService.UpdateSOSPost(c.Request().Context(), &updateSOSPostRequest)
-	if err != nil {
-		return c.JSON(err.StatusCode, err)
-	}
-
-	return c.JSON(http.StatusOK, res)
-}
+// type SOSPostHandler struct {
+// 	sosPostService service.SOSPostService
+// 	authService    service.AuthService
+// }
+//
+// func NewSOSPostHandler(sosPostService service.SOSPostService, authService service.AuthService) *SOSPostHandler {
+// 	return &SOSPostHandler{
+// 		sosPostService: sosPostService,
+// 		authService:    authService,
+// 	}
+// }
+//
+// // WriteSOSPost godoc
+// // @Summary 돌봄급구 게시글을 업로드합니다.
+// // @Description
+// // @Tags posts
+// // @Accept  json
+// // @Produce  json
+// // @Param request body sospost.WriteSOSPostRequest true "돌봄급구 게시글 업로드 요청"
+// // @Security FirebaseAuth
+// // @Success 201 {object} sospost.DetailView
+// // @Router /posts/sos [post]
+// func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
+// 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	var writeSOSPostRequest sospost.WriteSOSPostRequest
+// 	if err = pnd.ParseBody(c, &writeSOSPostRequest); err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	res, err := h.sosPostService.WriteSOSPost(c.Request().Context(), foundUser.FirebaseUID, &writeSOSPostRequest)
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	return c.JSON(http.StatusCreated, res)
+// }
+//
+// // FindSOSPosts godoc
+// // @Summary 돌봄급구 게시글을 조회합니다.
+// // @Description
+// // @Tags posts
+// // @Accept  json
+// // @Produce  json
+// // @Param author_id query int false "작성자 ID"
+// // @Param page query int false "페이지 번호" default(1)
+// // @Param size query int false "페이지 사이즈" default(20)
+// // @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
+// // @Param filter_type query string false "필터링 기준" Enums(dog, cat, all)
+// // @Success 200 {object} sospost.FindSOSPostListView
+// // @Router /posts/sos [get]
+// func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
+// 	authorID, err := pnd.ParseOptionalIntQuery(c, "author_id")
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	sortBy := "newest"
+// 	if sortByQuery := pnd.ParseOptionalStringQuery(c, "sort_by"); sortByQuery != nil {
+// 		sortBy = *sortByQuery
+// 	}
+// 	filterType := "all"
+// 	if filterTypeQuery := pnd.ParseOptionalStringQuery(c, "filter_type"); filterTypeQuery != nil {
+// 		filterType = *filterTypeQuery
+// 	}
+//
+// 	page, size, err := pnd.ParsePaginationQueries(c, 1, 20)
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	var res *sospost.FindSOSPostListView
+// 	if authorID != nil {
+// 		res, err = h.sosPostService.FindSOSPostsByAuthorID(
+//		  c.Request().Context(), *authorID, page, size, sortBy, filterType)
+// 		if err != nil {
+// 			return c.JSON(err.StatusCode, err)
+// 		}
+// 	} else {
+// 		res, err = h.sosPostService.FindSOSPosts(c.Request().Context(), page, size, sortBy, filterType)
+// 		if err != nil {
+// 			return c.JSON(err.StatusCode, err)
+// 		}
+// 	}
+//
+// 	return c.JSON(http.StatusOK, res)
+// }
+//
+// // FindSOSPostByID godoc
+// // @Summary 게시글 ID로 돌봄급구 게시글을 조회합니다.
+// // @Description
+// // @Tags posts
+// // @Produce  json
+// // @Param id path int true "게시글 ID"
+// // @Success 200 {object} sospost.FindSOSPostView
+// // @Router /posts/sos/{id} [get]
+// func (h *SOSPostHandler) FindSOSPostByID(c echo.Context) error {
+// 	id, err := pnd.ParseIDFromPath(c, "id")
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+// 	res, err := h.sosPostService.FindSOSPostByID(c.Request().Context(), *id)
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	return c.JSON(http.StatusOK, res)
+// }
+//
+// // UpdateSOSPost godoc
+// // @Summary 돌봄급구 게시글을 수정합니다.
+// // @Description
+// // @Tags posts
+// // @Accept  json
+// // @Produce  json
+// // @Security FirebaseAuth
+// // @Param request body sospost.UpdateSOSPostRequest true "돌봄급구 수정 요청"
+// // @Success 200
+// // @Router /posts/sos [put]
+// func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
+// 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	var updateSOSPostRequest sospost.UpdateSOSPostRequest
+// 	if err = pnd.ParseBody(c, &updateSOSPostRequest); err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	permission, err := h.sosPostService.CheckUpdatePermission(
+// 		c.Request().Context(),
+// 		foundUser.FirebaseUID,
+// 		updateSOSPostRequest.ID,
+// 	)
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+// 	if !permission {
+// 		pndErr := pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
+// 		return c.JSON(pndErr.StatusCode, pndErr)
+// 	}
+//
+// 	res, err := h.sosPostService.UpdateSOSPost(c.Request().Context(), &updateSOSPostRequest)
+// 	if err != nil {
+// 		return c.JSON(err.StatusCode, err)
+// 	}
+//
+// 	return c.JSON(http.StatusOK, res)
+// }
+//

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -1,156 +1,165 @@
 package handler
 
-// type SOSPostHandler struct {
-// 	sosPostService service.SOSPostService
-// 	authService    service.AuthService
-// }
-//
-// func NewSOSPostHandler(sosPostService service.SOSPostService, authService service.AuthService) *SOSPostHandler {
-// 	return &SOSPostHandler{
-// 		sosPostService: sosPostService,
-// 		authService:    authService,
-// 	}
-// }
-//
-// // WriteSOSPost godoc
-// // @Summary 돌봄급구 게시글을 업로드합니다.
-// // @Description
-// // @Tags posts
-// // @Accept  json
-// // @Produce  json
-// // @Param request body sospost.WriteSOSPostRequest true "돌봄급구 게시글 업로드 요청"
-// // @Security FirebaseAuth
-// // @Success 201 {object} sospost.DetailView
-// // @Router /posts/sos [post]
-// func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
-// 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	var writeSOSPostRequest sospost.WriteSOSPostRequest
-// 	if err = pnd.ParseBody(c, &writeSOSPostRequest); err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	res, err := h.sosPostService.WriteSOSPost(c.Request().Context(), foundUser.FirebaseUID, &writeSOSPostRequest)
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	return c.JSON(http.StatusCreated, res)
-// }
-//
-// // FindSOSPosts godoc
-// // @Summary 돌봄급구 게시글을 조회합니다.
-// // @Description
-// // @Tags posts
-// // @Accept  json
-// // @Produce  json
-// // @Param author_id query int false "작성자 ID"
-// // @Param page query int false "페이지 번호" default(1)
-// // @Param size query int false "페이지 사이즈" default(20)
-// // @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
-// // @Param filter_type query string false "필터링 기준" Enums(dog, cat, all)
-// // @Success 200 {object} sospost.FindSOSPostListView
-// // @Router /posts/sos [get]
-// func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
-// 	authorID, err := pnd.ParseOptionalIntQuery(c, "author_id")
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	sortBy := "newest"
-// 	if sortByQuery := pnd.ParseOptionalStringQuery(c, "sort_by"); sortByQuery != nil {
-// 		sortBy = *sortByQuery
-// 	}
-// 	filterType := "all"
-// 	if filterTypeQuery := pnd.ParseOptionalStringQuery(c, "filter_type"); filterTypeQuery != nil {
-// 		filterType = *filterTypeQuery
-// 	}
-//
-// 	page, size, err := pnd.ParsePaginationQueries(c, 1, 20)
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	var res *sospost.FindSOSPostListView
-// 	if authorID != nil {
-// 		res, err = h.sosPostService.FindSOSPostsByAuthorID(
-//		  c.Request().Context(), *authorID, page, size, sortBy, filterType)
-// 		if err != nil {
-// 			return c.JSON(err.StatusCode, err)
-// 		}
-// 	} else {
-// 		res, err = h.sosPostService.FindSOSPosts(c.Request().Context(), page, size, sortBy, filterType)
-// 		if err != nil {
-// 			return c.JSON(err.StatusCode, err)
-// 		}
-// 	}
-//
-// 	return c.JSON(http.StatusOK, res)
-// }
-//
-// // FindSOSPostByID godoc
-// // @Summary 게시글 ID로 돌봄급구 게시글을 조회합니다.
-// // @Description
-// // @Tags posts
-// // @Produce  json
-// // @Param id path int true "게시글 ID"
-// // @Success 200 {object} sospost.FindSOSPostView
-// // @Router /posts/sos/{id} [get]
-// func (h *SOSPostHandler) FindSOSPostByID(c echo.Context) error {
-// 	id, err := pnd.ParseIDFromPath(c, "id")
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-// 	res, err := h.sosPostService.FindSOSPostByID(c.Request().Context(), *id)
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	return c.JSON(http.StatusOK, res)
-// }
-//
-// // UpdateSOSPost godoc
-// // @Summary 돌봄급구 게시글을 수정합니다.
-// // @Description
-// // @Tags posts
-// // @Accept  json
-// // @Produce  json
-// // @Security FirebaseAuth
-// // @Param request body sospost.UpdateSOSPostRequest true "돌봄급구 수정 요청"
-// // @Success 200
-// // @Router /posts/sos [put]
-// func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
-// 	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	var updateSOSPostRequest sospost.UpdateSOSPostRequest
-// 	if err = pnd.ParseBody(c, &updateSOSPostRequest); err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	permission, err := h.sosPostService.CheckUpdatePermission(
-// 		c.Request().Context(),
-// 		foundUser.FirebaseUID,
-// 		updateSOSPostRequest.ID,
-// 	)
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-// 	if !permission {
-// 		pndErr := pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
-// 		return c.JSON(pndErr.StatusCode, pndErr)
-// 	}
-//
-// 	res, err := h.sosPostService.UpdateSOSPost(c.Request().Context(), &updateSOSPostRequest)
-// 	if err != nil {
-// 		return c.JSON(err.StatusCode, err)
-// 	}
-//
-// 	return c.JSON(http.StatusOK, res)
-// }
-//
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	pnd "github.com/pet-sitter/pets-next-door-api/api"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
+	"github.com/pet-sitter/pets-next-door-api/internal/service"
+)
+
+type SOSPostHandler struct {
+	sosPostService service.SOSPostService
+	authService    service.AuthService
+}
+
+func NewSOSPostHandler(sosPostService service.SOSPostService, authService service.AuthService) *SOSPostHandler {
+	return &SOSPostHandler{
+		sosPostService: sosPostService,
+		authService:    authService,
+	}
+}
+
+// WriteSOSPost godoc
+// @Summary 돌봄급구 게시글을 업로드합니다.
+// @Description
+// @Tags posts
+// @Accept  json
+// @Produce  json
+// @Param request body sospost.WriteSOSPostRequest true "돌봄급구 게시글 업로드 요청"
+// @Security FirebaseAuth
+// @Success 201 {object} sospost.DetailView
+// @Router /posts/sos [post]
+func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
+	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	var writeSOSPostRequest sospost.WriteSOSPostRequest
+	if err = pnd.ParseBody(c, &writeSOSPostRequest); err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	res, err := h.sosPostService.WriteSOSPost(c.Request().Context(), foundUser.FirebaseUID, &writeSOSPostRequest)
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+// FindSOSPosts godoc
+// @Summary 돌봄급구 게시글을 조회합니다.
+// @Description
+// @Tags posts
+// @Accept  json
+// @Produce  json
+// @Param author_id query string false "작성자 ID"
+// @Param page query int false "페이지 번호" default(1)
+// @Param size query int false "페이지 사이즈" default(20)
+// @Param sort_by query string false "정렬 기준" Enums(newest, deadline)
+// @Param filter_type query string false "필터링 기준" Enums(dog, cat, all)
+// @Success 200 {object} sospost.FindSOSPostListView
+// @Router /posts/sos [get]
+func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
+	authorID, err := pnd.ParseOptionalUUIDQuery(c, "author_id")
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	sortBy := "newest"
+	if sortByQuery := pnd.ParseOptionalStringQuery(c, "sort_by"); sortByQuery != nil {
+		sortBy = *sortByQuery
+	}
+	filterType := "all"
+	if filterTypeQuery := pnd.ParseOptionalStringQuery(c, "filter_type"); filterTypeQuery != nil {
+		filterType = *filterTypeQuery
+	}
+
+	page, size, err := pnd.ParsePaginationQueries(c, 1, 20)
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	var res *sospost.FindSOSPostListView
+	if authorID.Valid {
+		res, err = h.sosPostService.FindSOSPostsByAuthorID(
+			c.Request().Context(), authorID.UUID, page, size, sortBy, filterType)
+		if err != nil {
+			return c.JSON(err.StatusCode, err)
+		}
+	} else {
+		res, err = h.sosPostService.FindSOSPosts(c.Request().Context(), page, size, sortBy, filterType)
+		if err != nil {
+			return c.JSON(err.StatusCode, err)
+		}
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// FindSOSPostByID godoc
+// @Summary 게시글 ID로 돌봄급구 게시글을 조회합니다.
+// @Description
+// @Tags posts
+// @Produce  json
+// @Param id path int true "게시글 ID"
+// @Success 200 {object} sospost.FindSOSPostView
+// @Router /posts/sos/{id} [get]
+func (h *SOSPostHandler) FindSOSPostByID(c echo.Context) error {
+	id, err := pnd.ParseIDFromPath(c, "id")
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+	res, err := h.sosPostService.FindSOSPostByID(c.Request().Context(), id)
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// UpdateSOSPost godoc
+// @Summary 돌봄급구 게시글을 수정합니다.
+// @Description
+// @Tags posts
+// @Accept  json
+// @Produce  json
+// @Security FirebaseAuth
+// @Param request body sospost.UpdateSOSPostRequest true "돌봄급구 수정 요청"
+// @Success 200
+// @Router /posts/sos [put]
+func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
+	foundUser, err := h.authService.VerifyAuthAndGetUser(c.Request().Context(), c.Request().Header.Get("Authorization"))
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	var updateSOSPostRequest sospost.UpdateSOSPostRequest
+	if err = pnd.ParseBody(c, &updateSOSPostRequest); err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	permission, err := h.sosPostService.CheckUpdatePermission(
+		c.Request().Context(),
+		foundUser.FirebaseUID,
+		updateSOSPostRequest.ID,
+	)
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+	if !permission {
+		pndErr := pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
+		return c.JSON(pndErr.StatusCode, pndErr)
+	}
+
+	res, err := h.sosPostService.UpdateSOSPost(c.Request().Context(), &updateSOSPostRequest)
+	if err != nil {
+		return c.JSON(err.StatusCode, err)
+	}
+
+	return c.JSON(http.StatusOK, res)
+}

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"github.com/google/uuid"
+
 	"github.com/labstack/echo/v4"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
@@ -148,7 +150,10 @@ func (h *UserHandler) FindUserByID(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	res, err := h.userService.FindUserProfile(c.Request().Context(), user.FindUserParams{ID: userID})
+	res, err := h.userService.FindUserProfile(
+		c.Request().Context(),
+		user.FindUserParams{ID: uuid.NullUUID{UUID: userID, Valid: true}},
+	)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
@@ -276,8 +281,9 @@ func (h *UserHandler) FindMyPets(c echo.Context) error {
 	res, err := h.userService.FindPets(c.Request().Context(), pet.FindPetsParams{
 		Page:    1,
 		Size:    100,
-		OwnerID: &foundUser.ID,
-	})
+		OwnerID: uuid.NullUUID{UUID: foundUser.ID, Valid: true},
+	},
+	)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
@@ -313,7 +319,7 @@ func (h *UserHandler) UpdateMyPet(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	res, err := h.userService.UpdatePet(c.Request().Context(), uid, int64(*petID), updatePetRequest)
+	res, err := h.userService.UpdatePet(c.Request().Context(), uid, petID, updatePetRequest)
 	if err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
@@ -341,7 +347,7 @@ func (h *UserHandler) DeleteMyPet(c echo.Context) error {
 		return c.JSON(err.StatusCode, err)
 	}
 
-	if err := h.userService.DeletePet(c.Request().Context(), uid, int64(*petID)); err != nil {
+	if err := h.userService.DeletePet(c.Request().Context(), uid, petID); err != nil {
 		return c.JSON(err.StatusCode, err)
 	}
 

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -52,7 +52,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 	userService := service.NewUserService(db, mediaService)
 	authService := service.NewFirebaseBearerAuthService(authClient, userService)
 	breedService := service.NewBreedService(db)
-	// sosPostService := service.NewSOSPostService(db)
+	sosPostService := service.NewSOSPostService(db)
 	conditionService := service.NewSOSConditionService(db)
 
 	// Initialize handlers
@@ -60,7 +60,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 	userHandler := handler.NewUserHandler(*userService, authService)
 	mediaHandler := handler.NewMediaHandler(*mediaService)
 	breedHandler := handler.NewBreedHandler(*breedService)
-	// sosPostHandler := handler.NewSOSPostHandler(*sosPostService, authService)
+	sosPostHandler := handler.NewSOSPostHandler(*sosPostService, authService)
 	conditionHandler := handler.NewConditionHandler(*conditionService)
 
 	// Register middlewares
@@ -124,10 +124,10 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 
 	postAPIGroup := apiRouteGroup.Group("/posts")
 	{
-		// postAPIGroup.POST("/sos", sosPostHandler.WriteSOSPost)
-		// postAPIGroup.GET("/sos/:id", sosPostHandler.FindSOSPostByID)
-		// postAPIGroup.GET("/sos", sosPostHandler.FindSOSPosts)
-		// postAPIGroup.PUT("/sos", sosPostHandler.UpdateSOSPost)
+		postAPIGroup.POST("/sos", sosPostHandler.WriteSOSPost)
+		postAPIGroup.GET("/sos/:id", sosPostHandler.FindSOSPostByID)
+		postAPIGroup.GET("/sos", sosPostHandler.FindSOSPosts)
+		postAPIGroup.PUT("/sos", sosPostHandler.UpdateSOSPost)
 		postAPIGroup.GET("/sos/conditions", conditionHandler.FindConditions)
 	}
 

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -52,7 +52,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 	userService := service.NewUserService(db, mediaService)
 	authService := service.NewFirebaseBearerAuthService(authClient, userService)
 	breedService := service.NewBreedService(db)
-	sosPostService := service.NewSOSPostService(db)
+	// sosPostService := service.NewSOSPostService(db)
 	conditionService := service.NewSOSConditionService(db)
 
 	// Initialize handlers
@@ -60,7 +60,7 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 	userHandler := handler.NewUserHandler(*userService, authService)
 	mediaHandler := handler.NewMediaHandler(*mediaService)
 	breedHandler := handler.NewBreedHandler(*breedService)
-	sosPostHandler := handler.NewSOSPostHandler(*sosPostService, authService)
+	// sosPostHandler := handler.NewSOSPostHandler(*sosPostService, authService)
 	conditionHandler := handler.NewConditionHandler(*conditionService)
 
 	// Register middlewares
@@ -124,10 +124,10 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 
 	postAPIGroup := apiRouteGroup.Group("/posts")
 	{
-		postAPIGroup.POST("/sos", sosPostHandler.WriteSOSPost)
-		postAPIGroup.GET("/sos/:id", sosPostHandler.FindSOSPostByID)
-		postAPIGroup.GET("/sos", sosPostHandler.FindSOSPosts)
-		postAPIGroup.PUT("/sos", sosPostHandler.UpdateSOSPost)
+		// postAPIGroup.POST("/sos", sosPostHandler.WriteSOSPost)
+		// postAPIGroup.GET("/sos/:id", sosPostHandler.FindSOSPostByID)
+		// postAPIGroup.GET("/sos", sosPostHandler.FindSOSPosts)
+		// postAPIGroup.PUT("/sos", sosPostHandler.UpdateSOSPost)
 		postAPIGroup.GET("/sos/conditions", conditionHandler.FindConditions)
 	}
 

--- a/db/migrations/000019_add_uuid.down.sql
+++ b/db/migrations/000019_add_uuid.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE	users DROP COLUMN uuid, DROP COLUMN profile_image_uuid;
+ALTER TABLE	media DROP COLUMN uuid;
+ALTER TABLE	breeds DROP COLUMN uuid;
+ALTER TABLE	pets DROP COLUMN uuid, DROP COLUMN owner_uuid, DROP COLUMN profile_image_uuid;
+ALTER TABLE	base_posts DROP COLUMN uuid, DROP COLUMN author_uuid;
+ALTER TABLE	sos_posts DROP COLUMN thumbnail_uuid;
+ALTER TABLE	sos_dates DROP COLUMN uuid;
+ALTER TABLE	sos_posts_dates DROP COLUMN uuid, DROP COLUMN sos_post_uuid, DROP COLUMN sos_dates_uuid;
+ALTER TABLE	sos_conditions DROP COLUMN uuid;
+ALTER TABLE	sos_posts_conditions DROP COLUMN uuid, DROP COLUMN sos_post_uuid, DROP COLUMN sos_condition_uuid;
+ALTER TABLE	sos_posts_pets DROP COLUMN uuid, DROP COLUMN sos_post_uuid, DROP COLUMN pet_uuid;
+ALTER TABLE	resource_media DROP COLUMN uuid, DROP COLUMN media_uuid, DROP COLUMN resource_uuid;
+

--- a/db/migrations/000019_add_uuid.down.sql
+++ b/db/migrations/000019_add_uuid.down.sql
@@ -1,13 +1,36 @@
-ALTER TABLE	users DROP COLUMN uuid, DROP COLUMN profile_image_uuid;
-ALTER TABLE	media DROP COLUMN uuid;
-ALTER TABLE	breeds DROP COLUMN uuid;
-ALTER TABLE	pets DROP COLUMN uuid, DROP COLUMN owner_uuid, DROP COLUMN profile_image_uuid;
-ALTER TABLE	base_posts DROP COLUMN uuid, DROP COLUMN author_uuid;
-ALTER TABLE	sos_posts DROP COLUMN thumbnail_uuid;
-ALTER TABLE	sos_dates DROP COLUMN uuid;
-ALTER TABLE	sos_posts_dates DROP COLUMN uuid, DROP COLUMN sos_post_uuid, DROP COLUMN sos_dates_uuid;
-ALTER TABLE	sos_conditions DROP COLUMN uuid;
-ALTER TABLE	sos_posts_conditions DROP COLUMN uuid, DROP COLUMN sos_post_uuid, DROP COLUMN sos_condition_uuid;
-ALTER TABLE	sos_posts_pets DROP COLUMN uuid, DROP COLUMN sos_post_uuid, DROP COLUMN pet_uuid;
-ALTER TABLE	resource_media DROP COLUMN uuid, DROP COLUMN media_uuid, DROP COLUMN resource_uuid;
-
+ALTER TABLE users
+    DROP COLUMN uuid,
+    DROP COLUMN profile_image_uuid;
+ALTER TABLE media
+    DROP COLUMN uuid;
+ALTER TABLE breeds
+    DROP COLUMN uuid;
+ALTER TABLE pets
+    DROP COLUMN uuid,
+    DROP COLUMN owner_uuid,
+    DROP COLUMN profile_image_uuid;
+ALTER TABLE base_posts
+    DROP COLUMN uuid,
+    DROP COLUMN author_uuid;
+ALTER TABLE sos_posts
+    DROP COLUMN thumbnail_uuid;
+ALTER TABLE sos_dates
+    DROP COLUMN uuid;
+ALTER TABLE sos_posts_dates
+    DROP COLUMN uuid,
+    DROP COLUMN sos_post_uuid,
+    DROP COLUMN sos_dates_uuid;
+ALTER TABLE sos_conditions
+    DROP COLUMN uuid;
+ALTER TABLE sos_posts_conditions
+    DROP COLUMN uuid,
+    DROP COLUMN sos_post_uuid,
+    DROP COLUMN sos_condition_uuid;
+ALTER TABLE sos_posts_pets
+    DROP COLUMN uuid,
+    DROP COLUMN sos_post_uuid,
+    DROP COLUMN pet_uuid;
+ALTER TABLE resource_media
+    DROP COLUMN uuid,
+    DROP COLUMN media_uuid,
+    DROP COLUMN resource_uuid;

--- a/db/migrations/000019_add_uuid.up.sql
+++ b/db/migrations/000019_add_uuid.up.sql
@@ -1,60 +1,136 @@
 ALTER TABLE
-users
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN profile_image_uuid UUID NULL;
+    users
+    ADD COLUMN uuid               UUID NULL,
+    ADD COLUMN profile_image_uuid UUID NULL;
 
 ALTER TABLE
-media
-ADD COLUMN uuid UUID NULL;
+    media
+    ADD COLUMN uuid UUID NULL;
 
 ALTER TABLE
-breeds
-ADD COLUMN uuid UUID NULL;
+    breeds
+    ADD COLUMN uuid UUID NULL;
 
 ALTER TABLE
-pets
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN owner_uuid UUID NULL,
-ADD COLUMN profile_image_uuid UUID NULL;
+    pets
+    ADD COLUMN uuid               UUID NULL,
+    ADD COLUMN owner_uuid         UUID NULL,
+    ADD COLUMN profile_image_uuid UUID NULL;
 
 ALTER TABLE
-base_posts
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN author_uuid UUID NULL;;
+    base_posts
+    ADD COLUMN uuid        UUID NULL,
+    ADD COLUMN author_uuid UUID NULL;
 
 ALTER TABLE
-sos_posts
-ADD COLUMN thumbnail_uuid UUID NULL;
+    sos_posts
+    ADD COLUMN thumbnail_uuid UUID NULL;
 
 ALTER TABLE
-sos_dates
-ADD COLUMN uuid UUID NULL;
+    sos_dates
+    ADD COLUMN uuid UUID NULL;
 
 ALTER TABLE
-sos_posts_dates
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN sos_post_uuid UUID NULL,
-ADD COLUMN sos_dates_uuid UUID NULL;
+    sos_posts_dates
+    ADD COLUMN uuid           UUID NULL,
+    ADD COLUMN sos_post_uuid  UUID NULL,
+    ADD COLUMN sos_dates_uuid UUID NULL;
 
 ALTER TABLE
-sos_conditions
-ADD COLUMN uuid UUID NULL;
+    sos_conditions
+    ADD COLUMN uuid UUID NULL;
 
 ALTER TABLE
-sos_posts_conditions
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN sos_post_uuid UUID NULL,
-ADD COLUMN sos_condition_uuid UUID NULL;
+    sos_posts_conditions
+    ADD COLUMN uuid               UUID NULL,
+    ADD COLUMN sos_post_uuid      UUID NULL,
+    ADD COLUMN sos_condition_uuid UUID NULL;
 
 ALTER TABLE
-sos_posts_pets
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN sos_post_uuid UUID NULL,
-ADD COLUMN pet_uuid UUID NULL;
+    sos_posts_pets
+    ADD COLUMN uuid          UUID NULL,
+    ADD COLUMN sos_post_uuid UUID NULL,
+    ADD COLUMN pet_uuid      UUID NULL;
 
 ALTER TABLE
-resource_media
-ADD COLUMN uuid UUID NULL,
-ADD COLUMN media_uuid UUID NULL,
-ADD COLUMN resource_uuid UUID NULL;;
+    resource_media
+    ADD COLUMN uuid          UUID NULL,
+    ADD COLUMN media_uuid    UUID NULL,
+    ADD COLUMN resource_uuid UUID NULL;;
 
+-- Add view
+-- 돌봄 급구(SosPosts) 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_sos_posts AS
+SELECT sos_posts.id,
+       sos_posts.title,
+       sos_posts.content,
+       sos_posts.reward,
+       sos_posts.reward_type,
+       sos_posts.care_type,
+       sos_posts.carer_gender,
+       sos_posts.thumbnail_id,
+       sos_posts.author_id,
+       sos_posts.created_at,
+       sos_posts.updated_at,
+       MIN(sos_dates.date_start_at)                                      AS earliest_date_start_at,
+       json_agg(sos_dates.*) FILTER (WHERE sos_dates.deleted_at IS NULL) AS dates
+FROM sos_posts
+         LEFT JOIN sos_posts_dates ON sos_posts.id = sos_posts_dates.sos_post_id
+         LEFT JOIN sos_dates ON sos_posts_dates.sos_dates_id = sos_dates.id
+WHERE sos_posts.deleted_at IS NULL
+  AND sos_dates.deleted_at IS NULL
+  AND sos_posts_dates.deleted_at IS NULL
+GROUP BY sos_posts.id;
+
+-- 돌봄 급구 Conditions 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_conditions AS
+SELECT sos_posts_conditions.sos_post_id,
+       json_agg(sos_conditions.*)
+       FILTER (WHERE sos_conditions.deleted_at IS NULL) AS conditions_info
+FROM sos_posts_conditions
+         LEFT JOIN sos_conditions ON sos_posts_conditions.sos_condition_id = sos_conditions.id
+WHERE sos_conditions.deleted_at IS NULL
+  AND sos_posts_conditions.deleted_at IS NULL
+GROUP BY sos_posts_conditions.sos_post_id;
+
+-- 돌봄 급구 관련 Pets 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_pets_for_sos_posts AS
+SELECT sos_posts_pets.sos_post_id,
+       array_agg(pets.pet_type)                         AS pet_type_list,
+       json_agg(
+       json_build_object(
+               'id', pets.id,
+               'owner_id', pets.owner_id,
+               'name', pets.name,
+               'pet_type', pets.pet_type,
+               'sex', pets.sex,
+               'neutered', pets.neutered,
+               'breed', pets.breed,
+               'birth_date', pets.birth_date,
+               'weight_in_kg', pets.weight_in_kg,
+               'additional_note', pets.additional_note,
+               'created_at', pets.created_at,
+               'updated_at', pets.updated_at,
+               'deleted_at', pets.deleted_at,
+               'remarks', pets.remarks,
+               'profile_image_id', pets.profile_image_id,
+               'profile_image_url', media.url
+       )
+               ) FILTER (WHERE pets.deleted_at IS NULL) AS pets_info
+FROM sos_posts_pets
+         INNER JOIN pets ON sos_posts_pets.pet_id = pets.id AND pets.deleted_at IS NULL
+         LEFT JOIN media ON pets.profile_image_id = media.id
+WHERE sos_posts_pets.deleted_at IS NULL
+GROUP BY sos_posts_pets.sos_post_id;
+
+
+
+-- 돌봄 급구 관련 Media 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_media_for_sos_posts AS
+SELECT resource_media.resource_id                                AS sos_post_id,
+       json_agg(media.*) FILTER (WHERE media.deleted_at IS NULL) AS media_info
+FROM resource_media
+         LEFT JOIN media ON resource_media.media_id = media.id
+WHERE media.deleted_at IS NULL
+  AND resource_media.deleted_at IS NULL
+GROUP BY resource_media.resource_id;

--- a/db/migrations/000019_add_uuid.up.sql
+++ b/db/migrations/000019_add_uuid.up.sql
@@ -1,0 +1,60 @@
+ALTER TABLE
+users
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN profile_image_uuid UUID NULL;
+
+ALTER TABLE
+media
+ADD COLUMN uuid UUID NULL;
+
+ALTER TABLE
+breeds
+ADD COLUMN uuid UUID NULL;
+
+ALTER TABLE
+pets
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN owner_uuid UUID NULL,
+ADD COLUMN profile_image_uuid UUID NULL;
+
+ALTER TABLE
+base_posts
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN author_uuid UUID NULL;;
+
+ALTER TABLE
+sos_posts
+ADD COLUMN thumbnail_uuid UUID NULL;
+
+ALTER TABLE
+sos_dates
+ADD COLUMN uuid UUID NULL;
+
+ALTER TABLE
+sos_posts_dates
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN sos_post_uuid UUID NULL,
+ADD COLUMN sos_dates_uuid UUID NULL;
+
+ALTER TABLE
+sos_conditions
+ADD COLUMN uuid UUID NULL;
+
+ALTER TABLE
+sos_posts_conditions
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN sos_post_uuid UUID NULL,
+ADD COLUMN sos_condition_uuid UUID NULL;
+
+ALTER TABLE
+sos_posts_pets
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN sos_post_uuid UUID NULL,
+ADD COLUMN pet_uuid UUID NULL;
+
+ALTER TABLE
+resource_media
+ADD COLUMN uuid UUID NULL,
+ADD COLUMN media_uuid UUID NULL,
+ADD COLUMN resource_uuid UUID NULL;;
+

--- a/db/migrations/000019_create_chat_room_message.down.sql
+++ b/db/migrations/000019_create_chat_room_message.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS user_chat_rooms;
+DROP TABLE IF EXISTS chat_messages;
+DROP TABLE IF EXISTS chat_rooms;

--- a/db/migrations/000019_create_chat_room_message.up.sql
+++ b/db/migrations/000019_create_chat_room_message.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE chat_rooms (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    room_type VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE TABLE chat_messages (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    room_id BIGINT NOT NULL,
+    message_type VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMPTZ,
+    FOREIGN KEY (room_id) REFERENCES chat_rooms(id)
+);
+
+CREATE TABLE user_chat_rooms (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    room_id BIGINT NOT NULL,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    left_at TIMESTAMPTZ,
+    FOREIGN KEY (room_id) REFERENCES chat_rooms(id)
+);

--- a/db/migrations/000020_add_uuid.down.sql
+++ b/db/migrations/000020_add_uuid.down.sql
@@ -9,11 +9,6 @@ ALTER TABLE pets
     DROP COLUMN uuid,
     DROP COLUMN owner_uuid,
     DROP COLUMN profile_image_uuid;
-ALTER TABLE base_posts
-    DROP COLUMN uuid,
-    DROP COLUMN author_uuid;
-ALTER TABLE sos_posts
-    DROP COLUMN thumbnail_uuid;
 ALTER TABLE sos_dates
     DROP COLUMN uuid;
 ALTER TABLE sos_posts_dates
@@ -34,3 +29,13 @@ ALTER TABLE resource_media
     DROP COLUMN uuid,
     DROP COLUMN media_uuid,
     DROP COLUMN resource_uuid;
+ALTER TABLE chat_rooms
+    DROP COLUMN uuid;
+ALTER TABLE chat_messages
+    DROP COLUMN uuid,
+    DROP COLUMN user_uuid,
+    DROP COLUMN room_uuid;
+ALTER TABLE user_chat_rooms
+    DROP COLUMN uuid,
+    DROP COLUMN user_uuid,
+    DROP COLUMN room_uuid;

--- a/db/migrations/000020_add_uuid.up.sql
+++ b/db/migrations/000020_add_uuid.up.sql
@@ -56,7 +56,23 @@ ALTER TABLE
     resource_media
     ADD COLUMN uuid          UUID NULL,
     ADD COLUMN media_uuid    UUID NULL,
-    ADD COLUMN resource_uuid UUID NULL;;
+    ADD COLUMN resource_uuid UUID NULL;
+
+ALTER TABLE
+    chat_rooms
+    ADD COLUMN uuid UUID NULL;
+
+ALTER TABLE
+    chat_messages
+    ADD COLUMN uuid      UUID NULL,
+    ADD COLUMN user_uuid UUID NULL,
+    ADD COLUMN room_uuid UUID NULL;
+
+ALTER TABLE
+    user_chat_rooms
+    ADD COLUMN uuid      UUID NULL,
+    ADD COLUMN user_uuid UUID NULL,
+    ADD COLUMN room_uuid UUID NULL;
 
 -- Add view
 -- 돌봄 급구(SosPosts) 테이블 VIEW 생성

--- a/db/migrations/000020_uuidv7_pk.down.sql
+++ b/db/migrations/000020_uuidv7_pk.down.sql
@@ -1,3 +1,9 @@
+-- DROP VIEWS
+DROP VIEW IF EXISTS v_sos_posts;
+DROP VIEW IF EXISTS v_conditions;
+DROP VIEW IF EXISTS v_pets_for_sos_posts;
+DROP VIEW IF EXISTS v_media_for_sos_posts;
+
 -- DROP INDEXES
 DROP INDEX resource_media_resource_id;
 DROP INDEX pets_owner_id_idx;
@@ -94,39 +100,35 @@ ALTER TABLE pets
     RENAME COLUMN profile_image_legacy_id TO profile_image_id;
 
 -- base_posts
--- Add legacy_id column
-ALTER TABLE base_posts
-    ADD COLUMN legacy_id SERIAL;
-ALTER TABLE base_posts
-    ADD COLUMN author_legacy_id INTEGER;
--- Rename id to uuid and legacy_id to id
-ALTER TABLE base_posts
-    DROP CONSTRAINT base_posts_pkey;
-ALTER TABLE base_posts
-    RENAME COLUMN id TO uuid;
-ALTER TABLE base_posts
-    RENAME COLUMN legacy_id TO id;
-ALTER TABLE base_posts
-    ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE base_posts
-    ADD PRIMARY KEY (id);
--- author_id -> author_uuid
-ALTER TABLE base_posts
-    RENAME COLUMN author_id TO author_uuid;
-ALTER TABLE base_posts
-    RENAME COLUMN author_legacy_id TO author_id;
-ALTER TABLE base_posts
-    ALTER COLUMN author_uuid DROP NOT NULL;
+CREATE TABLE IF NOT EXISTS base_posts
+(
+    id         UUID PRIMARY KEY,
+    title      VARCHAR(200),
+    content    TEXT,
+    author_id  UUID,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP
+);
 
--- sos_posts
--- Add legacy_id column
-ALTER TABLE sos_posts
-    ADD COLUMN thumbnail_legacy_id INTEGER;
--- thumbnail_id -> thumbnail_uuid
-ALTER TABLE sos_posts
-    RENAME COLUMN thumbnail_id TO thumbnail_uuid;
-ALTER TABLE sos_posts
-    RENAME COLUMN thumbnail_legacy_id TO thumbnail_id;
+CREATE TABLE IF NOT EXISTS sos_posts_temp
+(
+    id           UUID PRIMARY KEY,
+    reward       VARCHAR(20),
+    care_type    VARCHAR(20),
+    carer_gender VARCHAR(10),
+    reward_type  VARCHAR(30),
+    thumbnail_id UUID
+) INHERITS (base_posts);
+
+INSERT INTO sos_posts_temp (id, title, content, author_id, created_at, updated_at, deleted_at)
+SELECT id, title, content, author_id, created_at, updated_at, deleted_at
+FROM sos_posts;
+
+DROP TABLE sos_posts;
+
+ALTER TABLE sos_posts_temp
+    RENAME TO sos_posts;
 
 -- sos_dates
 -- Add legacy_id column
@@ -297,80 +299,3 @@ CREATE INDEX IF NOT EXISTS sos_posts_conditions_sos_post_id ON sos_posts_conditi
 CREATE INDEX IF NOT EXISTS sos_posts_pets_sos_post_id ON sos_posts_pets (sos_post_id);
 CREATE INDEX IF NOT EXISTS sos_posts_dates_sos_post_id ON sos_posts_dates (sos_post_id);
 CREATE INDEX IF NOT EXISTS sos_posts_author_id_deleted_at ON sos_posts (author_id);
-
--- Add view
--- 돌봄 급구(SosPosts) 테이블 VIEW 생성
-CREATE OR REPLACE VIEW v_sos_posts AS
-SELECT sos_posts.id,
-       sos_posts.title,
-       sos_posts.content,
-       sos_posts.reward,
-       sos_posts.reward_type,
-       sos_posts.care_type,
-       sos_posts.carer_gender,
-       sos_posts.thumbnail_id,
-       sos_posts.author_id,
-       sos_posts.created_at,
-       sos_posts.updated_at,
-       MIN(sos_dates.date_start_at)                                      AS earliest_date_start_at,
-       json_agg(sos_dates.*) FILTER (WHERE sos_dates.deleted_at IS NULL) AS dates
-FROM sos_posts
-         LEFT JOIN sos_posts_dates ON sos_posts.id = sos_posts_dates.sos_post_id
-         LEFT JOIN sos_dates ON sos_posts_dates.sos_dates_id = sos_dates.id
-WHERE sos_posts.deleted_at IS NULL
-  AND sos_dates.deleted_at IS NULL
-  AND sos_posts_dates.deleted_at IS NULL
-GROUP BY sos_posts.id;
-
--- 돌봄 급구 Conditions 테이블 VIEW 생성
-CREATE OR REPLACE VIEW v_conditions AS
-SELECT sos_posts_conditions.sos_post_id,
-       json_agg(sos_conditions.*)
-       FILTER (WHERE sos_conditions.deleted_at IS NULL) AS conditions_info
-FROM sos_posts_conditions
-         LEFT JOIN sos_conditions ON sos_posts_conditions.sos_condition_id = sos_conditions.id
-WHERE sos_conditions.deleted_at IS NULL
-  AND sos_posts_conditions.deleted_at IS NULL
-GROUP BY sos_posts_conditions.sos_post_id;
-
--- 돌봄 급구 관련 Pets 테이블 VIEW 생성
-CREATE OR REPLACE VIEW v_pets_for_sos_posts AS
-SELECT sos_posts_pets.sos_post_id,
-       array_agg(pets.pet_type)                         AS pet_type_list,
-       json_agg(
-       json_build_object(
-               'id', pets.id,
-               'owner_id', pets.owner_id,
-               'name', pets.name,
-               'pet_type', pets.pet_type,
-               'sex', pets.sex,
-               'neutered', pets.neutered,
-               'breed', pets.breed,
-               'birth_date', pets.birth_date,
-               'weight_in_kg', pets.weight_in_kg,
-               'additional_note', pets.additional_note,
-               'created_at', pets.created_at,
-               'updated_at', pets.updated_at,
-               'deleted_at', pets.deleted_at,
-               'remarks', pets.remarks,
-               'profile_image_id', pets.profile_image_id,
-               'profile_image_url', media.url
-       )
-               ) FILTER (WHERE pets.deleted_at IS NULL) AS pets_info
-FROM sos_posts_pets
-         INNER JOIN pets ON sos_posts_pets.pet_id = pets.id AND pets.deleted_at IS NULL
-         LEFT JOIN media ON pets.profile_image_id = media.id
-WHERE sos_posts_pets.deleted_at IS NULL
-GROUP BY sos_posts_pets.sos_post_id;
-
-
-
--- 돌봄 급구 관련 Media 테이블 VIEW 생성
-CREATE OR REPLACE VIEW v_media_for_sos_posts AS
-SELECT resource_media.resource_id                                AS sos_post_id,
-       json_agg(media.*) FILTER (WHERE media.deleted_at IS NULL) AS media_info
-FROM resource_media
-         LEFT JOIN media ON resource_media.media_id = media.id
-WHERE media.deleted_at IS NULL
-  AND resource_media.deleted_at IS NULL
-GROUP BY resource_media.resource_id;

--- a/db/migrations/000020_uuidv7_pk.down.sql
+++ b/db/migrations/000020_uuidv7_pk.down.sql
@@ -1,0 +1,376 @@
+-- DROP INDEXES
+DROP INDEX resource_media_resource_id;
+DROP INDEX pets_owner_id_idx;
+DROP INDEX sos_posts_conditions_sos_post_id;
+DROP INDEX sos_posts_pets_sos_post_id;
+DROP INDEX sos_posts_dates_sos_post_id;
+DROP INDEX sos_posts_author_id_deleted_at;
+
+-- users
+-- Add legacy_id column
+ALTER TABLE users
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE users
+    ADD COLUMN profile_image_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE users
+    DROP CONSTRAINT users_pkey;
+ALTER TABLE users
+    RENAME COLUMN id TO uuid;
+ALTER TABLE users
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE users
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE users
+    ADD PRIMARY KEY (id);
+-- profile_image_id -> profile_image_uuid
+ALTER TABLE users
+    RENAME COLUMN profile_image_id TO profile_image_uuid;
+ALTER TABLE users
+    RENAME COLUMN profile_image_legacy_id TO profile_image_id;
+
+-- media
+-- Add legacy_id column
+ALTER TABLE media
+    ADD COLUMN legacy_id SERIAL;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE media
+    DROP CONSTRAINT media_pkey;
+ALTER TABLE media
+    RENAME COLUMN id TO uuid;
+ALTER TABLE media
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE media
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE media
+    ADD PRIMARY KEY (id);
+
+-- breeds
+-- Add legacy_id column
+ALTER TABLE breeds
+    ADD COLUMN legacy_id SERIAL;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE breeds
+    DROP CONSTRAINT breeds_pkey;
+ALTER TABLE breeds
+    RENAME COLUMN id TO uuid;
+ALTER TABLE breeds
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE breeds
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE breeds
+    ADD PRIMARY KEY (id);
+
+-- pets
+-- Add legacy_id column
+ALTER TABLE pets
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE pets
+    ADD COLUMN owner_legacy_id INTEGER;
+ALTER TABLE pets
+    ADD COLUMN profile_image_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE pets
+    DROP CONSTRAINT pets_pkey;
+ALTER TABLE pets
+    RENAME COLUMN id TO uuid;
+ALTER TABLE pets
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE pets
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE pets
+    ADD PRIMARY KEY (id);
+-- owner_id -> owner_uuid
+ALTER TABLE pets
+    RENAME COLUMN owner_id TO owner_uuid;
+ALTER TABLE pets
+    RENAME COLUMN owner_legacy_id TO owner_id;
+ALTER TABLE pets
+    ALTER COLUMN owner_id DROP NOT NULL;
+-- profile_image_id -> profile_image_uuid
+ALTER TABLE pets
+    RENAME COLUMN profile_image_id TO profile_image_uuid;
+ALTER TABLE pets
+    RENAME COLUMN profile_image_legacy_id TO profile_image_id;
+
+-- base_posts
+-- Add legacy_id column
+ALTER TABLE base_posts
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE base_posts
+    ADD COLUMN author_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE base_posts
+    DROP CONSTRAINT base_posts_pkey;
+ALTER TABLE base_posts
+    RENAME COLUMN id TO uuid;
+ALTER TABLE base_posts
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE base_posts
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE base_posts
+    ADD PRIMARY KEY (id);
+-- author_id -> author_uuid
+ALTER TABLE base_posts
+    RENAME COLUMN author_id TO author_uuid;
+ALTER TABLE base_posts
+    RENAME COLUMN author_legacy_id TO author_id;
+ALTER TABLE base_posts
+    ALTER COLUMN author_uuid DROP NOT NULL;
+
+-- sos_posts
+-- Add legacy_id column
+ALTER TABLE sos_posts
+    ADD COLUMN thumbnail_legacy_id INTEGER;
+-- thumbnail_id -> thumbnail_uuid
+ALTER TABLE sos_posts
+    RENAME COLUMN thumbnail_id TO thumbnail_uuid;
+ALTER TABLE sos_posts
+    RENAME COLUMN thumbnail_legacy_id TO thumbnail_id;
+
+-- sos_dates
+-- Add legacy_id column
+ALTER TABLE sos_dates
+    ADD COLUMN legacy_id SERIAL;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE sos_dates
+    DROP CONSTRAINT sos_dates_pkey;
+ALTER TABLE sos_dates
+    RENAME COLUMN id TO uuid;
+ALTER TABLE sos_dates
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE sos_dates
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE sos_dates
+    ADD PRIMARY KEY (id);
+
+-- sos_posts_dates
+-- Add legacy_id column
+ALTER TABLE sos_posts_dates
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE sos_posts_dates
+    ADD COLUMN sos_post_legacy_id INTEGER;
+ALTER TABLE sos_posts_dates
+    ADD COLUMN sos_dates_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE sos_posts_dates
+    DROP CONSTRAINT sos_posts_dates_pkey;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN id TO uuid;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE sos_posts_dates
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE sos_posts_dates
+    ADD PRIMARY KEY (id);
+-- sos_post_id -> sos_post_uuid
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_post_id TO sos_post_uuid;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_post_legacy_id TO sos_post_id;
+ALTER TABLE sos_posts_dates
+    ALTER COLUMN sos_post_uuid DROP NOT NULL;
+-- sos_dates_id -> sos_dates_uuid
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_dates_id TO sos_dates_uuid;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_dates_legacy_id TO sos_dates_id;
+
+-- sos_conditions
+-- Add legacy_id column
+ALTER TABLE sos_conditions
+    ADD COLUMN legacy_id SERIAL;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE sos_conditions
+    DROP CONSTRAINT sos_conditions_pkey;
+ALTER TABLE sos_conditions
+    RENAME COLUMN id TO uuid;
+ALTER TABLE sos_conditions
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE sos_conditions
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE sos_conditions
+    ADD PRIMARY KEY (id);
+
+-- sos_posts_conditions
+-- Add legacy_id column
+ALTER TABLE sos_posts_conditions
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE sos_posts_conditions
+    ADD COLUMN sos_post_legacy_id INTEGER;
+ALTER TABLE sos_posts_conditions
+    ADD COLUMN sos_condition_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE sos_posts_conditions
+    DROP CONSTRAINT sos_posts_conditions_pkey;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN id TO uuid;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE sos_posts_conditions
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE sos_posts_conditions
+    ADD PRIMARY KEY (id);
+-- sos_post_id -> sos_post_uuid
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_post_id TO sos_post_uuid;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_post_legacy_id TO sos_post_id;
+ALTER TABLE sos_posts_conditions
+    ALTER COLUMN sos_post_uuid DROP NOT NULL;
+-- sos_condition_id -> sos_condition_uuid
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_condition_id TO sos_condition_uuid;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_condition_legacy_id TO sos_condition_id;
+
+-- sos_posts_pets
+-- Add legacy_id column
+ALTER TABLE sos_posts_pets
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE sos_posts_pets
+    ADD COLUMN sos_post_legacy_id INTEGER;
+ALTER TABLE sos_posts_pets
+    ADD COLUMN pet_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE sos_posts_pets
+    DROP CONSTRAINT sos_posts_pets_pkey;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN id TO uuid;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE sos_posts_pets
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE sos_posts_pets
+    ADD PRIMARY KEY (id);
+-- sos_post_id -> sos_post_uuid
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN sos_post_id TO sos_post_uuid;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN sos_post_legacy_id TO sos_post_id;
+ALTER TABLE sos_posts_pets
+    ALTER COLUMN sos_post_uuid DROP NOT NULL;
+-- pet_id -> pet_uuid
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN pet_id TO pet_uuid;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN pet_legacy_id TO pet_id;
+
+-- resource_media
+-- Add legacy_id column
+ALTER TABLE resource_media
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE resource_media
+    ADD COLUMN media_legacy_id INTEGER;
+ALTER TABLE resource_media
+    ADD COLUMN resource_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE resource_media
+    DROP CONSTRAINT resource_media_pkey;
+ALTER TABLE resource_media
+    RENAME COLUMN id TO uuid;
+ALTER TABLE resource_media
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE resource_media
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE resource_media
+    ADD PRIMARY KEY (id);
+-- media_id -> media_uuid
+ALTER TABLE resource_media
+    RENAME COLUMN media_id TO media_uuid;
+ALTER TABLE resource_media
+    RENAME COLUMN media_legacy_id TO media_id;
+ALTER TABLE resource_media
+    ALTER COLUMN media_uuid DROP NOT NULL;
+-- resource_id -> resource_uuid
+ALTER TABLE resource_media
+    RENAME COLUMN resource_id TO resource_uuid;
+ALTER TABLE resource_media
+    RENAME COLUMN resource_legacy_id TO resource_id;
+ALTER TABLE resource_media
+    ALTER COLUMN resource_uuid DROP NOT NULL;
+
+-- ADD INDEXES
+CREATE INDEX IF NOT EXISTS resource_media_resource_id ON resource_media (resource_id);
+CREATE INDEX IF NOT EXISTS pets_owner_id_idx ON pets (owner_id);
+CREATE INDEX IF NOT EXISTS sos_posts_conditions_sos_post_id ON sos_posts_conditions (sos_post_id);
+CREATE INDEX IF NOT EXISTS sos_posts_pets_sos_post_id ON sos_posts_pets (sos_post_id);
+CREATE INDEX IF NOT EXISTS sos_posts_dates_sos_post_id ON sos_posts_dates (sos_post_id);
+CREATE INDEX IF NOT EXISTS sos_posts_author_id_deleted_at ON sos_posts (author_id);
+
+-- Add view
+-- 돌봄 급구(SosPosts) 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_sos_posts AS
+SELECT sos_posts.id,
+       sos_posts.title,
+       sos_posts.content,
+       sos_posts.reward,
+       sos_posts.reward_type,
+       sos_posts.care_type,
+       sos_posts.carer_gender,
+       sos_posts.thumbnail_id,
+       sos_posts.author_id,
+       sos_posts.created_at,
+       sos_posts.updated_at,
+       MIN(sos_dates.date_start_at)                                      AS earliest_date_start_at,
+       json_agg(sos_dates.*) FILTER (WHERE sos_dates.deleted_at IS NULL) AS dates
+FROM sos_posts
+         LEFT JOIN sos_posts_dates ON sos_posts.id = sos_posts_dates.sos_post_id
+         LEFT JOIN sos_dates ON sos_posts_dates.sos_dates_id = sos_dates.id
+WHERE sos_posts.deleted_at IS NULL
+  AND sos_dates.deleted_at IS NULL
+  AND sos_posts_dates.deleted_at IS NULL
+GROUP BY sos_posts.id;
+
+-- 돌봄 급구 Conditions 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_conditions AS
+SELECT sos_posts_conditions.sos_post_id,
+       json_agg(sos_conditions.*)
+       FILTER (WHERE sos_conditions.deleted_at IS NULL) AS conditions_info
+FROM sos_posts_conditions
+         LEFT JOIN sos_conditions ON sos_posts_conditions.sos_condition_id = sos_conditions.id
+WHERE sos_conditions.deleted_at IS NULL
+  AND sos_posts_conditions.deleted_at IS NULL
+GROUP BY sos_posts_conditions.sos_post_id;
+
+-- 돌봄 급구 관련 Pets 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_pets_for_sos_posts AS
+SELECT sos_posts_pets.sos_post_id,
+       array_agg(pets.pet_type)                         AS pet_type_list,
+       json_agg(
+       json_build_object(
+               'id', pets.id,
+               'owner_id', pets.owner_id,
+               'name', pets.name,
+               'pet_type', pets.pet_type,
+               'sex', pets.sex,
+               'neutered', pets.neutered,
+               'breed', pets.breed,
+               'birth_date', pets.birth_date,
+               'weight_in_kg', pets.weight_in_kg,
+               'additional_note', pets.additional_note,
+               'created_at', pets.created_at,
+               'updated_at', pets.updated_at,
+               'deleted_at', pets.deleted_at,
+               'remarks', pets.remarks,
+               'profile_image_id', pets.profile_image_id,
+               'profile_image_url', media.url
+       )
+               ) FILTER (WHERE pets.deleted_at IS NULL) AS pets_info
+FROM sos_posts_pets
+         INNER JOIN pets ON sos_posts_pets.pet_id = pets.id AND pets.deleted_at IS NULL
+         LEFT JOIN media ON pets.profile_image_id = media.id
+WHERE sos_posts_pets.deleted_at IS NULL
+GROUP BY sos_posts_pets.sos_post_id;
+
+
+
+-- 돌봄 급구 관련 Media 테이블 VIEW 생성
+CREATE OR REPLACE VIEW v_media_for_sos_posts AS
+SELECT resource_media.resource_id                                AS sos_post_id,
+       json_agg(media.*) FILTER (WHERE media.deleted_at IS NULL) AS media_info
+FROM resource_media
+         LEFT JOIN media ON resource_media.media_id = media.id
+WHERE media.deleted_at IS NULL
+  AND resource_media.deleted_at IS NULL
+GROUP BY resource_media.resource_id;

--- a/db/migrations/000020_uuidv7_pk.up.sql
+++ b/db/migrations/000020_uuidv7_pk.up.sql
@@ -1,0 +1,325 @@
+-- DROP VIEWS
+DROP VIEW IF EXISTS v_sos_posts;
+DROP VIEW IF EXISTS v_conditions;
+DROP VIEW IF EXISTS v_pets_for_sos_posts;
+DROP VIEW IF EXISTS v_media_for_sos_posts;
+
+-- DROP INDEXES
+ALTER TABLE resource_media
+    DROP CONSTRAINT IF EXISTS resource_media_media_id_fkey;
+ALTER TABLE resource_media
+    DROP CONSTRAINT IF EXISTS resource_media_resource_id_fkey;
+ALTER TABLE sos_posts_conditions
+    DROP CONSTRAINT IF EXISTS sos_posts_conditions_sos_post_id_fkey;
+ALTER TABLE sos_posts_conditions
+    DROP CONSTRAINT IF EXISTS sos_posts_conditions_sos_condition_id_fkey;
+ALTER TABLE sos_posts_dates
+    DROP CONSTRAINT IF EXISTS sos_posts_dates_sos_dates_id_fkey;
+ALTER TABLE sos_posts_dates
+    DROP CONSTRAINT IF EXISTS sos_posts_dates_sos_post_id_fkey;
+ALTER TABLE sos_posts_pets
+    DROP CONSTRAINT IF EXISTS sos_posts_pets_pet_id_fkey;
+ALTER TABLE sos_posts_pets
+    DROP CONSTRAINT IF EXISTS sos_posts_pets_sos_post_id_fkey;
+DROP INDEX resource_media_resource_id;
+DROP INDEX pets_owner_id_idx;
+DROP INDEX sos_posts_conditions_sos_post_id;
+DROP INDEX sos_posts_pets_sos_post_id;
+DROP INDEX sos_posts_dates_sos_post_id;
+DROP INDEX sos_posts_author_id_deleted_at;
+
+-- users
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE users
+    DROP CONSTRAINT users_pkey;
+ALTER TABLE users
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE users
+    RENAME COLUMN uuid TO id;
+ALTER TABLE users
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE users
+    ADD PRIMARY KEY (id);
+-- profile_image_uuid -> profile_image_id
+ALTER TABLE users
+    RENAME COLUMN profile_image_id TO profile_image_legacy_id;
+ALTER TABLE users
+    RENAME COLUMN profile_image_uuid TO profile_image_id;
+-- DROP legacy columns
+ALTER TABLE users
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE users
+    DROP COLUMN IF EXISTS profile_image_legacy_id;
+
+-- media
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE media
+    DROP CONSTRAINT media_pkey;
+ALTER TABLE media
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE media
+    RENAME COLUMN uuid TO id;
+ALTER TABLE media
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE media
+    ADD PRIMARY KEY (id);
+-- DROP legacy columns
+ALTER TABLE media
+    DROP COLUMN IF EXISTS legacy_id;
+
+-- breeds
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE breeds
+    DROP CONSTRAINT breeds_pkey;
+ALTER TABLE breeds
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE breeds
+    RENAME COLUMN uuid TO id;
+ALTER TABLE breeds
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE breeds
+    ADD PRIMARY KEY (id);
+-- DROP legacy columns
+ALTER TABLE breeds
+    DROP COLUMN IF EXISTS legacy_id;
+
+-- pets
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE pets
+    DROP CONSTRAINT pets_pkey;
+ALTER TABLE pets
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE pets
+    RENAME COLUMN uuid TO id;
+ALTER TABLE pets
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE pets
+    ADD PRIMARY KEY (id);
+-- owner_uuid -> owner_id
+ALTER TABLE pets
+    RENAME COLUMN owner_id TO owner_legacy_id;
+ALTER TABLE pets
+    RENAME COLUMN owner_uuid TO owner_id;
+ALTER TABLE pets
+    ALTER COLUMN owner_id SET NOT NULL;
+-- profile_image_uuid -> profile_image_id
+ALTER TABLE pets
+    RENAME COLUMN profile_image_id TO profile_image_legacy_id;
+ALTER TABLE pets
+    RENAME COLUMN profile_image_uuid TO profile_image_id;
+-- DROP legacy columns
+ALTER TABLE pets
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE pets
+    DROP COLUMN IF EXISTS owner_legacy_id;
+ALTER TABLE pets
+    DROP COLUMN IF EXISTS profile_image_legacy_id;
+
+-- base_posts
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE base_posts
+    DROP CONSTRAINT base_posts_pkey;
+ALTER TABLE base_posts
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE base_posts
+    RENAME COLUMN uuid TO id;
+ALTER TABLE base_posts
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE base_posts
+    ADD PRIMARY KEY (id);
+-- author_uuid -> author_id
+ALTER TABLE base_posts
+    RENAME COLUMN author_id TO author_legacy_id;
+ALTER TABLE base_posts
+    RENAME COLUMN author_uuid TO author_id;
+ALTER TABLE base_posts
+    ALTER COLUMN author_id SET NOT NULL;
+-- DROP legacy columns
+ALTER TABLE base_posts
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE base_posts
+    DROP COLUMN IF EXISTS author_legacy_id;
+
+-- sos_posts
+-- thumbnail_uuid -> thumbnail_id
+ALTER TABLE sos_posts
+    RENAME COLUMN thumbnail_id TO thumbnail_legacy_id;
+ALTER TABLE sos_posts
+    RENAME COLUMN thumbnail_uuid TO thumbnail_id;
+-- DROP legacy columns
+ALTER TABLE sos_posts
+    DROP COLUMN IF EXISTS thumbnail_legacy_id;
+
+-- sos_dates
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE sos_dates
+    DROP CONSTRAINT sos_dates_pkey;
+ALTER TABLE sos_dates
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE sos_dates
+    RENAME COLUMN uuid TO id;
+ALTER TABLE sos_dates
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE sos_dates
+    ADD PRIMARY KEY (id);
+-- DROP legacy columns
+ALTER TABLE sos_dates
+    DROP COLUMN IF EXISTS legacy_id;
+
+-- sos_posts_dates
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE sos_posts_dates
+    DROP CONSTRAINT sos_posts_dates_pkey;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN uuid TO id;
+ALTER TABLE sos_posts_dates
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE sos_posts_dates
+    ADD PRIMARY KEY (id);
+-- sos_post_uuid -> sos_post_id
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_post_id TO sos_post_legacy_id;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_post_uuid TO sos_post_id;
+ALTER TABLE sos_posts_dates
+    ALTER COLUMN sos_post_id SET NOT NULL;
+-- sos_dates_uuid -> sos_dates_id
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_dates_id TO sos_dates_legacy_id;
+ALTER TABLE sos_posts_dates
+    RENAME COLUMN sos_dates_uuid TO sos_dates_id;
+ALTER TABLE sos_posts_dates
+    ALTER COLUMN sos_dates_id SET NOT NULL;
+-- DROP legacy columns
+ALTER TABLE sos_posts_dates
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE sos_posts_dates
+    DROP COLUMN IF EXISTS sos_post_legacy_id;
+ALTER TABLE sos_posts_dates
+    DROP COLUMN IF EXISTS sos_dates_legacy_id;
+
+-- sos_conditions
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE sos_conditions
+    DROP CONSTRAINT sos_conditions_pkey;
+ALTER TABLE sos_conditions
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE sos_conditions
+    RENAME COLUMN uuid TO id;
+ALTER TABLE sos_conditions
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE sos_conditions
+    ADD PRIMARY KEY (id);
+-- DROP legacy columns
+ALTER TABLE sos_conditions
+    DROP COLUMN IF EXISTS legacy_id;
+
+-- sos_posts_conditions
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE sos_posts_conditions
+    DROP CONSTRAINT sos_posts_conditions_pkey;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN uuid TO id;
+ALTER TABLE sos_posts_conditions
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE sos_posts_conditions
+    ADD PRIMARY KEY (id);
+-- sos_post_uuid -> sos_post_id
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_post_id TO sos_post_legacy_id;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_post_uuid TO sos_post_id;
+ALTER TABLE sos_posts_conditions
+    ALTER COLUMN sos_post_id SET NOT NULL;
+-- sos_condition_uuid -> sos_condition_id
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_condition_id TO sos_condition_legacy_id;
+ALTER TABLE sos_posts_conditions
+    RENAME COLUMN sos_condition_uuid TO sos_condition_id;
+-- DROP legacy columns
+ALTER TABLE sos_posts_conditions
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE sos_posts_conditions
+    DROP COLUMN IF EXISTS sos_post_legacy_id;
+ALTER TABLE sos_posts_conditions
+    DROP COLUMN IF EXISTS sos_condition_legacy_id;
+
+-- sos_posts_pets
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE sos_posts_pets
+    DROP CONSTRAINT sos_posts_pets_pkey;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN uuid TO id;
+ALTER TABLE sos_posts_pets
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE sos_posts_pets
+    ADD PRIMARY KEY (id);
+-- sos_post_uuid -> sos_post_id
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN sos_post_id TO sos_post_legacy_id;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN sos_post_uuid TO sos_post_id;
+ALTER TABLE sos_posts_pets
+    ALTER COLUMN sos_post_id SET NOT NULL;
+-- pet_uuid -> pet_id
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN pet_id TO pet_legacy_id;
+ALTER TABLE sos_posts_pets
+    RENAME COLUMN pet_uuid TO pet_id;
+ALTER TABLE sos_posts_pets
+    ALTER COLUMN pet_id SET NOT NULL;
+-- DROP legacy columns
+ALTER TABLE sos_posts_pets
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE sos_posts_pets
+    DROP COLUMN IF EXISTS sos_post_legacy_id;
+ALTER TABLE sos_posts_pets
+    DROP COLUMN IF EXISTS pet_legacy_id;
+
+-- resource_media
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE resource_media
+    DROP CONSTRAINT resource_media_pkey;
+ALTER TABLE resource_media
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE resource_media
+    RENAME COLUMN uuid TO id;
+ALTER TABLE resource_media
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE resource_media
+    ADD PRIMARY KEY (id);
+-- media_uuid -> media_id
+ALTER TABLE resource_media
+    RENAME COLUMN media_id TO media_legacy_id;
+ALTER TABLE resource_media
+    RENAME COLUMN media_uuid TO media_id;
+ALTER TABLE resource_media
+    ALTER COLUMN media_id SET NOT NULL;
+-- resource_uuid -> resource_id
+ALTER TABLE resource_media
+    RENAME COLUMN resource_id TO resource_legacy_id;
+ALTER TABLE resource_media
+    RENAME COLUMN resource_uuid TO resource_id;
+ALTER TABLE resource_media
+    ALTER COLUMN resource_id SET NOT NULL;
+-- DROP legacy columns
+ALTER TABLE resource_media
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE resource_media
+    DROP COLUMN IF EXISTS media_legacy_id;
+ALTER TABLE resource_media
+    DROP COLUMN IF EXISTS resource_legacy_id;
+
+-- ADD INDEXES
+CREATE INDEX IF NOT EXISTS resource_media_resource_id ON resource_media (resource_id);
+CREATE INDEX IF NOT EXISTS pets_owner_id_idx ON pets (owner_id);
+CREATE INDEX IF NOT EXISTS sos_posts_conditions_sos_post_id ON sos_posts_conditions (sos_post_id);
+CREATE INDEX IF NOT EXISTS sos_posts_pets_sos_post_id ON sos_posts_pets (sos_post_id);
+CREATE INDEX IF NOT EXISTS sos_posts_dates_sos_post_id ON sos_posts_dates (sos_post_id);
+CREATE INDEX IF NOT EXISTS sos_posts_author_id_deleted_at ON sos_posts (author_id);

--- a/db/migrations/000021_uuidv7_pk.down.sql
+++ b/db/migrations/000021_uuidv7_pk.down.sql
@@ -292,6 +292,90 @@ ALTER TABLE resource_media
 ALTER TABLE resource_media
     ALTER COLUMN resource_uuid DROP NOT NULL;
 
+-- chat_rooms
+-- Add legacy_id column
+ALTER TABLE chat_rooms
+    ADD COLUMN legacy_id SERIAL;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE chat_rooms
+    DROP CONSTRAINT chat_rooms_pkey;
+ALTER TABLE chat_rooms
+    RENAME COLUMN id TO uuid;
+ALTER TABLE chat_rooms
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE chat_rooms
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE chat_rooms
+    ADD PRIMARY KEY (id);
+
+-- chat_messages
+-- Add legacy_id column
+ALTER TABLE chat_messages
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE chat_messages
+    ADD COLUMN user_legacy_id INTEGER;
+ALTER TABLE chat_messages
+    ADD COLUMN room_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE chat_messages
+    DROP CONSTRAINT chat_messages_pkey;
+ALTER TABLE chat_messages
+    RENAME COLUMN id TO uuid;
+ALTER TABLE chat_messages
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE chat_messages
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE chat_messages
+    ADD PRIMARY KEY (id);
+-- user_id -> user_uuid
+ALTER TABLE chat_messages
+    RENAME COLUMN user_id TO user_uuid;
+ALTER TABLE chat_messages
+    RENAME COLUMN user_legacy_id TO user_id;
+ALTER TABLE chat_messages
+    ALTER COLUMN user_uuid DROP NOT NULL;
+-- room_id -> room_uuid
+ALTER TABLE chat_messages
+    RENAME COLUMN room_id TO room_uuid;
+ALTER TABLE chat_messages
+    RENAME COLUMN room_legacy_id TO room_id;
+ALTER TABLE chat_messages
+    ALTER COLUMN room_uuid DROP NOT NULL;
+
+-- user_chat_rooms
+-- Add legacy_id column
+ALTER TABLE user_chat_rooms
+    ADD COLUMN legacy_id SERIAL;
+ALTER TABLE user_chat_rooms
+    ADD COLUMN user_legacy_id INTEGER;
+ALTER TABLE user_chat_rooms
+    ADD COLUMN room_legacy_id INTEGER;
+-- Rename id to uuid and legacy_id to id
+ALTER TABLE user_chat_rooms
+    DROP CONSTRAINT user_chat_rooms_pkey;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN id TO uuid;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN legacy_id TO id;
+ALTER TABLE user_chat_rooms
+    ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE user_chat_rooms
+    ADD PRIMARY KEY (id);
+-- user_id -> user_uuid
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN user_id TO user_uuid;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN user_legacy_id TO user_id;
+ALTER TABLE user_chat_rooms
+    ALTER COLUMN user_uuid DROP NOT NULL;
+-- room_id -> room_uuid
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN room_id TO room_uuid;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN room_legacy_id TO room_id;
+ALTER TABLE user_chat_rooms
+    ALTER COLUMN room_uuid DROP NOT NULL;
+
 -- ADD INDEXES
 CREATE INDEX IF NOT EXISTS resource_media_resource_id ON resource_media (resource_id);
 CREATE INDEX IF NOT EXISTS pets_owner_id_idx ON pets (owner_id);

--- a/db/migrations/000021_uuidv7_pk.up.sql
+++ b/db/migrations/000021_uuidv7_pk.up.sql
@@ -21,6 +21,10 @@ ALTER TABLE sos_posts_pets
     DROP CONSTRAINT IF EXISTS sos_posts_pets_pet_id_fkey;
 ALTER TABLE sos_posts_pets
     DROP CONSTRAINT IF EXISTS sos_posts_pets_sos_post_id_fkey;
+ALTER TABLE chat_messages
+    DROP CONSTRAINT IF EXISTS chat_messages_room_id_fkey;
+ALTER TABLE user_chat_rooms
+    DROP CONSTRAINT IF EXISTS user_chat_rooms_room_id_fkey;
 DROP INDEX resource_media_resource_id;
 DROP INDEX pets_owner_id_idx;
 DROP INDEX sos_posts_conditions_sos_post_id;
@@ -319,6 +323,90 @@ ALTER TABLE resource_media
     DROP COLUMN IF EXISTS media_legacy_id;
 ALTER TABLE resource_media
     DROP COLUMN IF EXISTS resource_legacy_id;
+
+-- chat_rooms
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE chat_rooms
+    DROP CONSTRAINT chat_rooms_pkey;
+ALTER TABLE chat_rooms
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE chat_rooms
+    RENAME COLUMN uuid TO id;
+ALTER TABLE chat_rooms
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE chat_rooms
+    ADD PRIMARY KEY (id);
+-- DROP legacy columns
+ALTER TABLE chat_rooms
+    DROP COLUMN IF EXISTS legacy_id;
+
+-- chat_messages
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE chat_messages
+    DROP CONSTRAINT chat_messages_pkey;
+ALTER TABLE chat_messages
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE chat_messages
+    RENAME COLUMN uuid TO id;
+ALTER TABLE chat_messages
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE chat_messages
+    ADD PRIMARY KEY (id);
+-- user_uuid -> user_id
+ALTER TABLE chat_messages
+    RENAME COLUMN user_id TO user_legacy_id;
+ALTER TABLE chat_messages
+    RENAME COLUMN user_uuid TO user_id;
+ALTER TABLE chat_messages
+    ALTER COLUMN user_id SET NOT NULL;
+-- room_uuid -> room_id
+ALTER TABLE chat_messages
+    RENAME COLUMN room_id TO room_legacy_id;
+ALTER TABLE chat_messages
+    RENAME COLUMN room_uuid TO room_id;
+ALTER TABLE chat_messages
+    ALTER COLUMN room_id SET NOT NULL;
+-- DROP legacy columns
+ALTER TABLE chat_messages
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE chat_messages
+    DROP COLUMN IF EXISTS user_legacy_id;
+ALTER TABLE chat_messages
+    DROP COLUMN IF EXISTS room_legacy_id;
+
+-- user_chat_rooms
+-- Rename id to legacy_id and uuid to id
+ALTER TABLE user_chat_rooms
+    DROP CONSTRAINT user_chat_rooms_pkey;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN id TO legacy_id;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN uuid TO id;
+ALTER TABLE user_chat_rooms
+    ALTER COLUMN id SET NOT NULL;
+ALTER TABLE user_chat_rooms
+    ADD PRIMARY KEY (id);
+-- user_uuid -> user_id
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN user_id TO user_legacy_id;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN user_uuid TO user_id;
+ALTER TABLE user_chat_rooms
+    ALTER COLUMN user_id SET NOT NULL;
+-- room_uuid -> room_id
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN room_id TO room_legacy_id;
+ALTER TABLE user_chat_rooms
+    RENAME COLUMN room_uuid TO room_id;
+ALTER TABLE user_chat_rooms
+    ALTER COLUMN room_id SET NOT NULL;
+-- DROP legacy columns
+ALTER TABLE user_chat_rooms
+    DROP COLUMN IF EXISTS legacy_id;
+ALTER TABLE user_chat_rooms
+    DROP COLUMN IF EXISTS user_legacy_id;
+ALTER TABLE user_chat_rooms
+    DROP COLUMN IF EXISTS room_legacy_id;
 
 -- ADD INDEXES
 CREATE INDEX IF NOT EXISTS resource_media_resource_id ON resource_media (resource_id);

--- a/internal/datatype/uuid.go
+++ b/internal/datatype/uuid.go
@@ -13,3 +13,8 @@ func NewV7() (uuid.UUID, *pnd.AppError) {
 
 	return id, nil
 }
+
+func NewUUIDV7() uuid.UUID {
+	id, _ := NewV7()
+	return id
+}

--- a/internal/domain/breed/view.go
+++ b/internal/domain/breed/view.go
@@ -1,20 +1,21 @@
 package breed
 
 import (
+	"github.com/google/uuid"
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
 type DetailView struct {
-	ID      int64            `json:"id"`
+	ID      uuid.UUID        `json:"id"`
 	PetType commonvo.PetType `json:"petType"`
 	Name    string           `json:"name"`
 }
 
 func ToDetailViewFromRows(row databasegen.FindBreedsRow) *DetailView {
 	return &DetailView{
-		ID:      int64(row.ID),
+		ID:      row.ID,
 		PetType: commonvo.PetType(row.PetType),
 		Name:    row.Name,
 	}

--- a/internal/domain/media/model.go
+++ b/internal/domain/media/model.go
@@ -1,5 +1,7 @@
 package media
 
+import "github.com/google/uuid"
+
 type Type string
 
 const (
@@ -11,12 +13,12 @@ func (mt Type) String() string {
 }
 
 type ViewForSOSPost struct {
-	ID        int64  `field:"id" json:"id"`
-	MediaType Type   `field:"media_type" json:"media_type"`
-	URL       string `field:"url" json:"url"`
-	CreatedAt string `field:"created_at" json:"created_at"`
-	UpdatedAt string `field:"updated_at" json:"updated_at"`
-	DeletedAt string `field:"deleted_at" json:"deleted_at"`
+	ID        uuid.UUID `field:"id" json:"id"`
+	MediaType Type      `field:"media_type" json:"media_type"`
+	URL       string    `field:"url" json:"url"`
+	CreatedAt string    `field:"created_at" json:"created_at"`
+	UpdatedAt string    `field:"updated_at" json:"updated_at"`
+	DeletedAt string    `field:"deleted_at" json:"deleted_at"`
 }
 
 type ViewListForSOSPost []*ViewForSOSPost

--- a/internal/domain/media/view.go
+++ b/internal/domain/media/view.go
@@ -3,11 +3,13 @@ package media
 import (
 	"time"
 
+	"github.com/google/uuid"
+
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
 type DetailView struct {
-	ID        int64     `json:"id"`
+	ID        uuid.UUID `json:"id"`
 	MediaType Type      `json:"mediaType"`
 	URL       string    `json:"url"`
 	CreatedAt time.Time `json:"createdAt"`
@@ -17,7 +19,7 @@ type ListView []*DetailView
 
 func ToDetailView(media databasegen.FindSingleMediaRow) *DetailView {
 	return &DetailView{
-		ID:        int64(media.ID),
+		ID:        media.ID,
 		MediaType: Type(media.MediaType),
 		URL:       media.Url,
 		CreatedAt: media.CreatedAt,
@@ -26,7 +28,7 @@ func ToDetailView(media databasegen.FindSingleMediaRow) *DetailView {
 
 func ToDetailViewFromCreated(media databasegen.CreateMediaRow) *DetailView {
 	return &DetailView{
-		ID:        int64(media.ID),
+		ID:        media.ID,
 		MediaType: Type(media.MediaType),
 		URL:       media.Url,
 		CreatedAt: media.CreatedAt,
@@ -35,7 +37,7 @@ func ToDetailViewFromCreated(media databasegen.CreateMediaRow) *DetailView {
 
 func ToDetailViewFromResourceMediaRows(resourceMedia databasegen.FindResourceMediaRow) *DetailView {
 	return &DetailView{
-		ID:        int64(resourceMedia.MediaID),
+		ID:        resourceMedia.MediaID,
 		MediaType: Type(resourceMedia.MediaType),
 		URL:       resourceMedia.Url,
 		CreatedAt: resourceMedia.CreatedAt,

--- a/internal/domain/pet/model.go
+++ b/internal/domain/pet/model.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/google/uuid"
+
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
@@ -19,8 +21,8 @@ const (
 )
 
 type WithProfileImage struct {
-	ID              int64
-	OwnerID         int64
+	ID              uuid.UUID
+	OwnerID         uuid.UUID
 	Name            string
 	PetType         commonvo.PetType
 	Sex             Gender
@@ -40,7 +42,7 @@ func ToWithProfileImage(row databasegen.FindPetRow) *WithProfileImage {
 	birthDate := datatype.DateOf(row.BirthDate)
 
 	return &WithProfileImage{
-		ID:              int64(row.ID),
+		ID:              row.ID,
 		OwnerID:         row.OwnerID,
 		Name:            row.Name,
 		PetType:         commonvo.PetType(row.PetType),
@@ -62,7 +64,7 @@ func ToWithProfileImageFromRows(row databasegen.FindPetsRow) *WithProfileImage {
 	birthDate := datatype.DateOf(row.BirthDate)
 
 	return &WithProfileImage{
-		ID:              int64(row.ID),
+		ID:              row.ID,
 		OwnerID:         row.OwnerID,
 		Name:            row.Name,
 		PetType:         commonvo.PetType(row.PetType),
@@ -84,7 +86,7 @@ func ToWithProfileImageFromIDsRows(row databasegen.FindPetsByIDsRow) *WithProfil
 	birthDate := datatype.DateOf(row.BirthDate)
 
 	return &WithProfileImage{
-		ID:              int64(row.ID),
+		ID:              row.ID,
 		OwnerID:         row.OwnerID,
 		Name:            row.Name,
 		PetType:         commonvo.PetType(row.PetType),
@@ -106,7 +108,7 @@ func ToWithProfileImageFromSOSPostIDRow(row databasegen.FindPetsBySOSPostIDRow) 
 	birthDate := datatype.DateOf(row.BirthDate)
 
 	return &WithProfileImage{
-		ID:              int64(row.ID),
+		ID:              row.ID,
 		OwnerID:         row.OwnerID,
 		Name:            row.Name,
 		PetType:         commonvo.PetType(row.PetType),
@@ -126,8 +128,8 @@ func ToWithProfileImageFromSOSPostIDRow(row databasegen.FindPetsBySOSPostIDRow) 
 // ViewForSOSPost
 // v_pets_for_sos_posts 뷰를 위한 구조체
 type ViewForSOSPost struct {
-	ID              int              `field:"id" json:"id"`
-	OwnerID         int              `field:"owner_id" json:"owner_id"`
+	ID              uuid.UUID        `field:"id" json:"id"`
+	OwnerID         uuid.UUID        `field:"owner_id" json:"owner_id"`
 	Name            string           `field:"name" json:"name"`
 	PetType         commonvo.PetType `field:"pet_type" json:"pet_type"`
 	Sex             Gender           `field:"sex" json:"sex"`
@@ -144,7 +146,7 @@ type ViewForSOSPost struct {
 
 func (v *ViewForSOSPost) ToDetailView() *DetailView {
 	return &DetailView{
-		ID:              int64(v.ID),
+		ID:              v.ID,
 		Name:            v.Name,
 		PetType:         v.PetType,
 		Sex:             v.Sex,

--- a/internal/domain/pet/params.go
+++ b/internal/domain/pet/params.go
@@ -1,20 +1,21 @@
 package pet
 
 import (
+	"github.com/google/uuid"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
 type FindPetParams struct {
-	ID             *int64
-	OwnerID        *int64
+	ID             uuid.NullUUID
+	OwnerID        uuid.NullUUID
 	IncludeDeleted bool
 }
 
 func (p *FindPetParams) ToDBParams() databasegen.FindPetParams {
 	return databasegen.FindPetParams{
-		ID:             utils.Int64PtrToNullInt32(p.ID),
-		OwnerID:        utils.Int64PtrToNullInt64(p.OwnerID),
+		ID:             p.ID,
+		OwnerID:        p.OwnerID,
 		IncludeDeleted: p.IncludeDeleted,
 	}
 }
@@ -22,8 +23,8 @@ func (p *FindPetParams) ToDBParams() databasegen.FindPetParams {
 type FindPetsParams struct {
 	Page           int
 	Size           int
-	ID             *int64
-	OwnerID        *int64
+	ID             uuid.NullUUID
+	OwnerID        uuid.NullUUID
 	IncludeDeleted bool
 }
 
@@ -32,8 +33,8 @@ func (p *FindPetsParams) ToDBParams() databasegen.FindPetsParams {
 	return databasegen.FindPetsParams{
 		Limit:          int32(pagination.Limit),
 		Offset:         int32(pagination.Offset),
-		ID:             utils.Int64PtrToNullInt32(p.ID),
-		OwnerID:        utils.Int64PtrToNullInt64(p.OwnerID),
+		ID:             p.ID,
+		OwnerID:        p.OwnerID,
 		IncludeDeleted: p.IncludeDeleted,
 	}
 }

--- a/internal/domain/pet/request.go
+++ b/internal/domain/pet/request.go
@@ -1,6 +1,7 @@
 package pet
 
 import (
+	"github.com/google/uuid"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
 	"github.com/shopspring/decimal"
 )
@@ -18,7 +19,7 @@ type AddPetRequest struct {
 	BirthDate      string           `json:"birthDate" validate:"required"`
 	WeightInKg     decimal.Decimal  `json:"weightInKg" validate:"required"`
 	Remarks        string           `json:"remarks"`
-	ProfileImageID *int64           `json:"profileImageId"`
+	ProfileImageID uuid.NullUUID    `json:"profileImageId"`
 }
 
 type UpdatePetRequest struct {
@@ -28,5 +29,5 @@ type UpdatePetRequest struct {
 	BirthDate      string          `json:"birthDate" validate:"required"`
 	WeightInKg     decimal.Decimal `json:"weightInKg" validate:"required"`
 	Remarks        string          `json:"remarks"`
-	ProfileImageID *int64          `json:"profileImageId"`
+	ProfileImageID uuid.NullUUID   `json:"profileImageId"`
 }

--- a/internal/domain/pet/view.go
+++ b/internal/domain/pet/view.go
@@ -1,26 +1,14 @@
 package pet
 
 import (
+	"github.com/google/uuid"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 	"github.com/shopspring/decimal"
 )
 
-type LegacyView struct {
-	ID              int              `json:"id"`
-	Name            string           `json:"name"`
-	PetType         commonvo.PetType `json:"petType"`
-	Sex             Gender           `json:"sex"`
-	Neutered        bool             `json:"neutered"`
-	Breed           string           `json:"breed"`
-	BirthDate       string           `json:"birthDate"`
-	WeightInKg      decimal.Decimal  `json:"weightInKg"`
-	Remarks         string           `json:"remarks"`
-	ProfileImageURL *string          `json:"profileImageUrl"`
-}
-
 type DetailView struct {
-	ID              int64            `json:"id"`
+	ID              uuid.UUID        `json:"id"`
 	Name            string           `json:"name"`
 	PetType         commonvo.PetType `json:"petType"`
 	Sex             Gender           `json:"sex"`

--- a/internal/domain/soscondition/model.go
+++ b/internal/domain/soscondition/model.go
@@ -1,11 +1,13 @@
 package soscondition
 
+import "github.com/google/uuid"
+
 type ViewForSOSPost struct {
-	ID        int    `field:"id"`
-	Name      string `field:"name"`
-	CreatedAt string `field:"created_at"`
-	UpdatedAt string `field:"update_at"`
-	DeletedAt string `field:"deleted_at"`
+	ID        uuid.UUID `field:"id"`
+	Name      string    `field:"name"`
+	CreatedAt string    `field:"created_at"`
+	UpdatedAt string    `field:"update_at"`
+	DeletedAt string    `field:"deleted_at"`
 }
 
 type ViewListForSOSPost []*ViewForSOSPost

--- a/internal/domain/soscondition/view.go
+++ b/internal/domain/soscondition/view.go
@@ -1,39 +1,40 @@
 package soscondition
 
 import (
+	"github.com/google/uuid"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
 type DetailView struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
 }
 
 func ToDetailView(row databasegen.SosCondition) *DetailView {
 	return &DetailView{
-		ID:   int64(row.ID),
+		ID:   row.ID,
 		Name: utils.NullStrToStr(row.Name),
 	}
 }
 
-func ToDetailViewFromRows(row databasegen.SosCondition) *DetailView {
+func ToDetailViewFromRows(row databasegen.FindConditionsRow) *DetailView {
 	return &DetailView{
-		ID:   int64(row.ID),
+		ID:   row.ID,
 		Name: utils.NullStrToStr(row.Name),
 	}
 }
 
 func ToDetailViewFromSOSPostCondition(row databasegen.FindSOSPostConditionsRow) *DetailView {
 	return &DetailView{
-		ID:   int64(row.ID),
+		ID:   row.ID,
 		Name: utils.NullStrToStr(row.Name),
 	}
 }
 
 func ToDetailViewFromViewForSOSPost(view ViewForSOSPost) *DetailView {
 	return &DetailView{
-		ID:   int64(view.ID),
+		ID:   view.ID,
 		Name: view.Name,
 	}
 }
@@ -48,7 +49,7 @@ func ToListView(row []databasegen.SosCondition) ListView {
 	return conditionViews
 }
 
-func ToListViewFromRows(rows []databasegen.SosCondition) ListView {
+func ToListViewFromRows(rows []databasegen.FindConditionsRow) ListView {
 	conditionViews := make(ListView, len(rows))
 	for i, row := range rows {
 		conditionViews[i] = ToDetailViewFromRows(row)

--- a/internal/domain/sospost/model.go
+++ b/internal/domain/sospost/model.go
@@ -1,20 +1,15 @@
 package sospost
 
 import (
-	"context"
-	"encoding/json"
-	"log"
 	"time"
 
-	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
-	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
+	"github.com/google/uuid"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
 type (
@@ -58,18 +53,18 @@ func (r *RewardType) String() string {
 }
 
 type SOSPost struct {
-	ID          int         `field:"id"`
-	AuthorID    int         `field:"author_id"`
-	Title       string      `field:"title"`
-	Content     string      `field:"content"`
-	Reward      string      `field:"reward"`
-	CareType    CareType    `field:"care_type"`
-	CarerGender CarerGender `field:"carer_gender"`
-	RewardType  RewardType  `field:"reward_type"`
-	ThumbnailID *int64      `field:"thumbnail_id"`
-	CreatedAt   time.Time   `field:"created_at"`
-	UpdatedAt   time.Time   `field:"updated_at"`
-	DeletedAt   time.Time   `field:"deleted_at"`
+	ID          uuid.UUID     `field:"id"`
+	AuthorID    uuid.UUID     `field:"author_id"`
+	Title       string        `field:"title"`
+	Content     string        `field:"content"`
+	Reward      string        `field:"reward"`
+	CareType    CareType      `field:"care_type"`
+	CarerGender CarerGender   `field:"carer_gender"`
+	RewardType  RewardType    `field:"reward_type"`
+	ThumbnailID uuid.NullUUID `field:"thumbnail_id"`
+	CreatedAt   time.Time     `field:"created_at"`
+	UpdatedAt   time.Time     `field:"updated_at"`
+	DeletedAt   time.Time     `field:"deleted_at"`
 }
 
 type SOSPostList struct {
@@ -77,8 +72,8 @@ type SOSPostList struct {
 }
 
 type SOSPostInfo struct {
-	ID          int                             `field:"id" json:"id"`
-	AuthorID    int                             `field:"author" json:"author"`
+	ID          uuid.UUID                       `field:"id" json:"id"`
+	AuthorID    uuid.UUID                       `field:"author" json:"author"`
 	Title       string                          `field:"title" json:"title"`
 	Content     string                          `field:"content" json:"content"`
 	Media       media.ViewListForSOSPost        `field:"media" json:"media"`
@@ -89,7 +84,7 @@ type SOSPostInfo struct {
 	CareType    CareType                        `field:"careType" json:"careType"`
 	CarerGender CarerGender                     `field:"carerGender" json:"carerGender"`
 	RewardType  RewardType                      `field:"rewardType" json:"rewardType"`
-	ThumbnailID *int64                          `field:"thumbnailId" json:"thumbnailId"`
+	ThumbnailID uuid.NullUUID                   `field:"thumbnailId" json:"thumbnailId"`
 	CreatedAt   time.Time                       `field:"createdAt" json:"createdAt"`
 	UpdatedAt   time.Time                       `field:"updatedAt" json:"updatedAt"`
 	DeletedAt   time.Time                       `field:"deletedAt" json:"deletedAt"`
@@ -99,152 +94,152 @@ type SOSPostInfoList struct {
 	*pnd.PaginatedView[SOSPostInfo]
 }
 
-func ToInfoFromFindRow(row databasegen.FindSOSPostsRow) *SOSPostInfo {
-	return &SOSPostInfo{
-		ID:          int(row.ID),
-		AuthorID:    int(*utils.NullInt64ToInt64Ptr(row.AuthorID)),
-		Title:       utils.NullStrToStr(row.Title),
-		Content:     utils.NullStrToStr(row.Content),
-		Media:       ParseMediaList(row.MediaInfo.RawMessage),
-		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
-		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
-		Reward:      utils.NullStrToStr(row.Reward),
-		Dates:       ParseSOSDatesList(row.Dates),
-		CareType:    CareType(row.CareType.String),
-		CarerGender: CarerGender(row.CarerGender.String),
-		RewardType:  RewardType(row.RewardType.String),
-		ThumbnailID: &row.ThumbnailID.Int64,
-		CreatedAt:   row.CreatedAt,
-		UpdatedAt:   row.UpdatedAt,
-	}
-}
-
-func ToInfoListFromFindRow(rows []databasegen.FindSOSPostsRow, page, size int) *SOSPostInfoList {
-	sl := NewSOSPostInfoList(page, size)
-	for _, row := range rows {
-		sl.Items = append(sl.Items, *ToInfoFromFindRow(row))
-	}
-	sl.CalcLastPage()
-	return sl
-}
-
-func ToInfoFromFindAuthorIDRow(row databasegen.FindSOSPostsByAuthorIDRow) *SOSPostInfo {
-	return &SOSPostInfo{
-		ID:          int(row.ID),
-		AuthorID:    int(*utils.NullInt64ToInt64Ptr(row.AuthorID)),
-		Title:       utils.NullStrToStr(row.Title),
-		Content:     utils.NullStrToStr(row.Content),
-		Media:       ParseMediaList(row.MediaInfo.RawMessage),
-		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
-		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
-		Reward:      utils.NullStrToStr(row.Reward),
-		Dates:       ParseSOSDatesList(row.Dates),
-		CareType:    CareType(row.CareType.String),
-		CarerGender: CarerGender(row.CarerGender.String),
-		RewardType:  RewardType(row.RewardType.String),
-		ThumbnailID: &row.ThumbnailID.Int64,
-		CreatedAt:   row.CreatedAt,
-		UpdatedAt:   row.UpdatedAt,
-	}
-}
-
-func ToInfoListFromFindAuthorIDRow(rows []databasegen.FindSOSPostsByAuthorIDRow, page, size int) *SOSPostInfoList {
-	sl := NewSOSPostInfoList(page, size)
-	for _, row := range rows {
-		sl.Items = append(sl.Items, *ToInfoFromFindAuthorIDRow(row))
-	}
-
-	sl.CalcLastPage()
-	return sl
-}
-
-func ToInfoFromFindByIDRow(row databasegen.FindSOSPostByIDRow) *SOSPostInfo {
-	return &SOSPostInfo{
-		ID:          int(row.ID),
-		AuthorID:    int(*utils.NullInt64ToInt64Ptr(row.AuthorID)),
-		Title:       utils.NullStrToStr(row.Title),
-		Content:     utils.NullStrToStr(row.Content),
-		Media:       ParseMediaList(row.MediaInfo.RawMessage),
-		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
-		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
-		Reward:      utils.NullStrToStr(row.Reward),
-		Dates:       ParseSOSDatesList(row.Dates),
-		CareType:    CareType(row.CareType.String),
-		CarerGender: CarerGender(row.CarerGender.String),
-		RewardType:  RewardType(row.RewardType.String),
-		ThumbnailID: &row.ThumbnailID.Int64,
-		CreatedAt:   row.CreatedAt,
-		UpdatedAt:   row.UpdatedAt,
-	}
-}
-
-func NewSOSPostList(page, size int) *SOSPostList {
-	return &SOSPostList{PaginatedView: pnd.NewPaginatedView(
-		page, size, false, make([]SOSPost, 0),
-	)}
-}
-
-func NewSOSPostInfoList(page, size int) *SOSPostInfoList {
-	return &SOSPostInfoList{PaginatedView: pnd.NewPaginatedView(
-		page, size, false, make([]SOSPostInfo, 0),
-	)}
-}
-
-func ParseMediaList(rows json.RawMessage) media.ViewListForSOSPost {
-	var mediaList media.ViewListForSOSPost
-	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-		return mediaList
-	}
-
-	if err := json.Unmarshal(rows, &mediaList); err != nil {
-		log.Println("Error unmarshalling media:", err)
-		return mediaList
-	}
-
-	return mediaList
-}
-
-func ParseConditionsList(rows json.RawMessage) soscondition.ViewListForSOSPost {
-	var conditionsList soscondition.ViewListForSOSPost
-	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-		return conditionsList
-	}
-
-	if err := json.Unmarshal(rows, &conditionsList); err != nil {
-		log.Println("Error unmarshalling conditions:", err)
-		return conditionsList
-	}
-	return conditionsList
-}
-
-func ParsePetsList(rows json.RawMessage) pet.ViewListForSOSPost {
-	var petList pet.ViewListForSOSPost
-
-	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-		return petList
-	}
-
-	if err := json.Unmarshal(rows, &petList); err != nil {
-		log.Println("Error unmarshalling pets:", err)
-		return petList
-	}
-
-	return petList
-}
-
-func ParseSOSDatesList(rows json.RawMessage) SOSDatesList {
-	var sosDatesList SOSDatesList
-
-	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-		return sosDatesList
-	}
-	if err := json.Unmarshal(rows, &sosDatesList); err != nil {
-		log.Println("Error unmarshalling sosDates:", err)
-		return sosDatesList
-	}
-
-	return sosDatesList
-}
+// func ToInfoFromFindRow(row databasegen.FindSOSPostsRow) *SOSPostInfo {
+// 	return &SOSPostInfo{
+// 		// ID:          row.ID,
+// 		// AuthorID:    row.AuthorID,
+// 		Title:       utils.NullStrToStr(row.Title),
+// 		Content:     utils.NullStrToStr(row.Content),
+// 		Media:       ParseMediaList(row.MediaInfo.RawMessage),
+// 		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
+// 		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
+// 		Reward:      utils.NullStrToStr(row.Reward),
+// 		Dates:       ParseSOSDatesList(row.Dates),
+// 		CareType:    CareType(row.CareType.String),
+// 		CarerGender: CarerGender(row.CarerGender.String),
+// 		RewardType:  RewardType(row.RewardType.String),
+// 		// ThumbnailID: row.ThumbnailID,
+// 		CreatedAt: row.CreatedAt,
+// 		UpdatedAt: row.UpdatedAt,
+// 	}
+// }
+//
+// func ToInfoListFromFindRow(rows []databasegen.FindSOSPostsRow, page, size int) *SOSPostInfoList {
+// 	sl := NewSOSPostInfoList(page, size)
+// 	for _, row := range rows {
+// 		sl.Items = append(sl.Items, *ToInfoFromFindRow(row))
+// 	}
+// 	sl.CalcLastPage()
+// 	return sl
+// }
+//
+// func ToInfoFromFindAuthorIDRow(row databasegen.FindSOSPostsByAuthorIDRow) *SOSPostInfo {
+// 	return &SOSPostInfo{
+// 		// ID:          row.ID,
+// 		// AuthorID:    row.AuthorID,
+// 		Title:       utils.NullStrToStr(row.Title),
+// 		Content:     utils.NullStrToStr(row.Content),
+// 		Media:       ParseMediaList(row.MediaInfo.RawMessage),
+// 		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
+// 		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
+// 		Reward:      utils.NullStrToStr(row.Reward),
+// 		Dates:       ParseSOSDatesList(row.Dates),
+// 		CareType:    CareType(row.CareType.String),
+// 		CarerGender: CarerGender(row.CarerGender.String),
+// 		RewardType:  RewardType(row.RewardType.String),
+// 		// ThumbnailID: row.ThumbnailID,
+// 		CreatedAt: row.CreatedAt,
+// 		UpdatedAt: row.UpdatedAt,
+// 	}
+// }
+//
+// func ToInfoListFromFindAuthorIDRow(rows []databasegen.FindSOSPostsByAuthorIDRow, page, size int) *SOSPostInfoList {
+// 	sl := NewSOSPostInfoList(page, size)
+// 	for _, row := range rows {
+// 		sl.Items = append(sl.Items, *ToInfoFromFindAuthorIDRow(row))
+// 	}
+//
+// 	sl.CalcLastPage()
+// 	return sl
+// }
+//
+// func ToInfoFromFindByIDRow(row databasegen.FindSOSPostByIDRow) *SOSPostInfo {
+// 	return &SOSPostInfo{
+// 		// ID:          row.ID,
+// 		// AuthorID:    row.AuthorID,
+// 		Title:       utils.NullStrToStr(row.Title),
+// 		Content:     utils.NullStrToStr(row.Content),
+// 		Media:       ParseMediaList(row.MediaInfo.RawMessage),
+// 		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
+// 		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
+// 		Reward:      utils.NullStrToStr(row.Reward),
+// 		Dates:       ParseSOSDatesList(row.Dates),
+// 		CareType:    CareType(row.CareType.String),
+// 		CarerGender: CarerGender(row.CarerGender.String),
+// 		RewardType:  RewardType(row.RewardType.String),
+// 		// ThumbnailID: row.ThumbnailID,
+// 		CreatedAt: row.CreatedAt,
+// 		UpdatedAt: row.UpdatedAt,
+// 	}
+// }
+//
+// func NewSOSPostList(page, size int) *SOSPostList {
+// 	return &SOSPostList{PaginatedView: pnd.NewPaginatedView(
+// 		page, size, false, make([]SOSPost, 0),
+// 	)}
+// }
+//
+// func NewSOSPostInfoList(page, size int) *SOSPostInfoList {
+// 	return &SOSPostInfoList{PaginatedView: pnd.NewPaginatedView(
+// 		page, size, false, make([]SOSPostInfo, 0),
+// 	)}
+// }
+//
+// func ParseMediaList(rows json.RawMessage) media.ViewListForSOSPost {
+// 	var mediaList media.ViewListForSOSPost
+// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+// 		return mediaList
+// 	}
+//
+// 	if err := json.Unmarshal(rows, &mediaList); err != nil {
+// 		log.Println("Error unmarshalling media:", err)
+// 		return mediaList
+// 	}
+//
+// 	return mediaList
+// }
+//
+// func ParseConditionsList(rows json.RawMessage) soscondition.ViewListForSOSPost {
+// 	var conditionsList soscondition.ViewListForSOSPost
+// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+// 		return conditionsList
+// 	}
+//
+// 	if err := json.Unmarshal(rows, &conditionsList); err != nil {
+// 		log.Println("Error unmarshalling conditions:", err)
+// 		return conditionsList
+// 	}
+// 	return conditionsList
+// }
+//
+// func ParsePetsList(rows json.RawMessage) pet.ViewListForSOSPost {
+// 	var petList pet.ViewListForSOSPost
+//
+// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+// 		return petList
+// 	}
+//
+// 	if err := json.Unmarshal(rows, &petList); err != nil {
+// 		log.Println("Error unmarshalling pets:", err)
+// 		return petList
+// 	}
+//
+// 	return petList
+// }
+//
+// func ParseSOSDatesList(rows json.RawMessage) SOSDatesList {
+// 	var sosDatesList SOSDatesList
+//
+// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+// 		return sosDatesList
+// 	}
+// 	if err := json.Unmarshal(rows, &sosDatesList); err != nil {
+// 		log.Println("Error unmarshalling sosDates:", err)
+// 		return sosDatesList
+// 	}
+//
+// 	return sosDatesList
+// }
 
 type SOSDates struct {
 	ID          int       `field:"id" json:"id"`
@@ -257,34 +252,34 @@ type SOSDates struct {
 
 type SOSDatesList []*SOSDates
 
-type SOSPostStore interface {
-	WriteSOSPost(
-		ctx context.Context,
-		tx *database.Tx,
-		authorID int,
-		utcDateStart string,
-		utcDateEnd string,
-		request *WriteSOSPostRequest,
-	) (*SOSPost, *pnd.AppError)
-	FindSOSPosts(
-		ctx context.Context,
-		tx *database.Tx,
-		page int,
-		size int,
-		sortBy string,
-	) (*SOSPostInfoList, *pnd.AppError)
-	FindSOSPostsByAuthorID(
-		ctx context.Context,
-		tx *database.Tx,
-		authorID int,
-		page int,
-		size int,
-		sortBy string,
-	) (*SOSPostInfoList, *pnd.AppError)
-	FindSOSPostByID(ctx context.Context, tx *database.Tx, id int) (*SOSPost, *pnd.AppError)
-	UpdateSOSPost(ctx context.Context, tx *database.Tx, request *UpdateSOSPostRequest) (*SOSPost, *pnd.AppError)
-	FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*soscondition.ViewListForSOSPost, *pnd.AppError)
-	FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.ViewListForSOSPost, *pnd.AppError)
-	WriteDates(ctx context.Context, tx *database.Tx, dates []string, sosPostID int) (*SOSDatesList, *pnd.AppError)
-	FindDatesBySOSPostID(ctx context.Context, tx *database.Tx, sosPostID int) (*SOSDatesList, *pnd.AppError)
-}
+// type SOSPostStore interface {
+// 	WriteSOSPost(
+// 		ctx context.Context,
+// 		tx *database.Tx,
+// 		authorID int,
+// 		utcDateStart string,
+// 		utcDateEnd string,
+// 		request *WriteSOSPostRequest,
+// 	) (*SOSPost, *pnd.AppError)
+// 	FindSOSPosts(
+// 		ctx context.Context,
+// 		tx *database.Tx,
+// 		page int,
+// 		size int,
+// 		sortBy string,
+// 	) (*SOSPostInfoList, *pnd.AppError)
+// 	FindSOSPostsByAuthorID(
+// 		ctx context.Context,
+// 		tx *database.Tx,
+// 		authorID int,
+// 		page int,
+// 		size int,
+// 		sortBy string,
+// 	) (*SOSPostInfoList, *pnd.AppError)
+// 	FindSOSPostByID(ctx context.Context, tx *database.Tx, id int) (*SOSPost, *pnd.AppError)
+// 	UpdateSOSPost(ctx context.Context, tx *database.Tx, request *UpdateSOSPostRequest) (*SOSPost, *pnd.AppError)
+// 	FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*soscondition.ViewListForSOSPost, *pnd.AppError)
+// 	FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.ViewListForSOSPost, *pnd.AppError)
+// 	WriteDates(ctx context.Context, tx *database.Tx, dates []string, sosPostID int) (*SOSDatesList, *pnd.AppError)
+// 	FindDatesBySOSPostID(ctx context.Context, tx *database.Tx, sosPostID int) (*SOSDatesList, *pnd.AppError)
+// }

--- a/internal/domain/sospost/model.go
+++ b/internal/domain/sospost/model.go
@@ -1,7 +1,12 @@
 package sospost
 
 import (
+	"encoding/json"
+	"log"
 	"time"
+
+	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
+	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 
 	"github.com/google/uuid"
 
@@ -94,155 +99,156 @@ type SOSPostInfoList struct {
 	*pnd.PaginatedView[SOSPostInfo]
 }
 
-// func ToInfoFromFindRow(row databasegen.FindSOSPostsRow) *SOSPostInfo {
-// 	return &SOSPostInfo{
-// 		// ID:          row.ID,
-// 		// AuthorID:    row.AuthorID,
-// 		Title:       utils.NullStrToStr(row.Title),
-// 		Content:     utils.NullStrToStr(row.Content),
-// 		Media:       ParseMediaList(row.MediaInfo.RawMessage),
-// 		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
-// 		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
-// 		Reward:      utils.NullStrToStr(row.Reward),
-// 		Dates:       ParseSOSDatesList(row.Dates),
-// 		CareType:    CareType(row.CareType.String),
-// 		CarerGender: CarerGender(row.CarerGender.String),
-// 		RewardType:  RewardType(row.RewardType.String),
-// 		// ThumbnailID: row.ThumbnailID,
-// 		CreatedAt: row.CreatedAt,
-// 		UpdatedAt: row.UpdatedAt,
-// 	}
-// }
-//
-// func ToInfoListFromFindRow(rows []databasegen.FindSOSPostsRow, page, size int) *SOSPostInfoList {
-// 	sl := NewSOSPostInfoList(page, size)
-// 	for _, row := range rows {
-// 		sl.Items = append(sl.Items, *ToInfoFromFindRow(row))
-// 	}
-// 	sl.CalcLastPage()
-// 	return sl
-// }
-//
-// func ToInfoFromFindAuthorIDRow(row databasegen.FindSOSPostsByAuthorIDRow) *SOSPostInfo {
-// 	return &SOSPostInfo{
-// 		// ID:          row.ID,
-// 		// AuthorID:    row.AuthorID,
-// 		Title:       utils.NullStrToStr(row.Title),
-// 		Content:     utils.NullStrToStr(row.Content),
-// 		Media:       ParseMediaList(row.MediaInfo.RawMessage),
-// 		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
-// 		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
-// 		Reward:      utils.NullStrToStr(row.Reward),
-// 		Dates:       ParseSOSDatesList(row.Dates),
-// 		CareType:    CareType(row.CareType.String),
-// 		CarerGender: CarerGender(row.CarerGender.String),
-// 		RewardType:  RewardType(row.RewardType.String),
-// 		// ThumbnailID: row.ThumbnailID,
-// 		CreatedAt: row.CreatedAt,
-// 		UpdatedAt: row.UpdatedAt,
-// 	}
-// }
-//
-// func ToInfoListFromFindAuthorIDRow(rows []databasegen.FindSOSPostsByAuthorIDRow, page, size int) *SOSPostInfoList {
-// 	sl := NewSOSPostInfoList(page, size)
-// 	for _, row := range rows {
-// 		sl.Items = append(sl.Items, *ToInfoFromFindAuthorIDRow(row))
-// 	}
-//
-// 	sl.CalcLastPage()
-// 	return sl
-// }
-//
-// func ToInfoFromFindByIDRow(row databasegen.FindSOSPostByIDRow) *SOSPostInfo {
-// 	return &SOSPostInfo{
-// 		// ID:          row.ID,
-// 		// AuthorID:    row.AuthorID,
-// 		Title:       utils.NullStrToStr(row.Title),
-// 		Content:     utils.NullStrToStr(row.Content),
-// 		Media:       ParseMediaList(row.MediaInfo.RawMessage),
-// 		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
-// 		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
-// 		Reward:      utils.NullStrToStr(row.Reward),
-// 		Dates:       ParseSOSDatesList(row.Dates),
-// 		CareType:    CareType(row.CareType.String),
-// 		CarerGender: CarerGender(row.CarerGender.String),
-// 		RewardType:  RewardType(row.RewardType.String),
-// 		// ThumbnailID: row.ThumbnailID,
-// 		CreatedAt: row.CreatedAt,
-// 		UpdatedAt: row.UpdatedAt,
-// 	}
-// }
-//
-// func NewSOSPostList(page, size int) *SOSPostList {
-// 	return &SOSPostList{PaginatedView: pnd.NewPaginatedView(
-// 		page, size, false, make([]SOSPost, 0),
-// 	)}
-// }
-//
-// func NewSOSPostInfoList(page, size int) *SOSPostInfoList {
-// 	return &SOSPostInfoList{PaginatedView: pnd.NewPaginatedView(
-// 		page, size, false, make([]SOSPostInfo, 0),
-// 	)}
-// }
-//
-// func ParseMediaList(rows json.RawMessage) media.ViewListForSOSPost {
-// 	var mediaList media.ViewListForSOSPost
-// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-// 		return mediaList
-// 	}
-//
-// 	if err := json.Unmarshal(rows, &mediaList); err != nil {
-// 		log.Println("Error unmarshalling media:", err)
-// 		return mediaList
-// 	}
-//
-// 	return mediaList
-// }
-//
-// func ParseConditionsList(rows json.RawMessage) soscondition.ViewListForSOSPost {
-// 	var conditionsList soscondition.ViewListForSOSPost
-// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-// 		return conditionsList
-// 	}
-//
-// 	if err := json.Unmarshal(rows, &conditionsList); err != nil {
-// 		log.Println("Error unmarshalling conditions:", err)
-// 		return conditionsList
-// 	}
-// 	return conditionsList
-// }
-//
-// func ParsePetsList(rows json.RawMessage) pet.ViewListForSOSPost {
-// 	var petList pet.ViewListForSOSPost
-//
-// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-// 		return petList
-// 	}
-//
-// 	if err := json.Unmarshal(rows, &petList); err != nil {
-// 		log.Println("Error unmarshalling pets:", err)
-// 		return petList
-// 	}
-//
-// 	return petList
-// }
-//
-// func ParseSOSDatesList(rows json.RawMessage) SOSDatesList {
-// 	var sosDatesList SOSDatesList
-//
-// 	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
-// 		return sosDatesList
-// 	}
-// 	if err := json.Unmarshal(rows, &sosDatesList); err != nil {
-// 		log.Println("Error unmarshalling sosDates:", err)
-// 		return sosDatesList
-// 	}
-//
-// 	return sosDatesList
-// }
+func ToInfoFromFindRow(row databasegen.FindSOSPostsRow) *SOSPostInfo {
+	return &SOSPostInfo{
+		ID:          row.ID,
+		AuthorID:    row.AuthorID,
+		Title:       utils.NullStrToStr(row.Title),
+		Content:     utils.NullStrToStr(row.Content),
+		Media:       ParseMediaList(row.MediaInfo.RawMessage),
+		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
+		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
+		Reward:      utils.NullStrToStr(row.Reward),
+		Dates:       ParseSOSDatesList(row.Dates),
+		CareType:    CareType(row.CareType.String),
+		CarerGender: CarerGender(row.CarerGender.String),
+		RewardType:  RewardType(row.RewardType.String),
+		ThumbnailID: row.ThumbnailID,
+		CreatedAt:   row.CreatedAt,
+		UpdatedAt:   row.UpdatedAt,
+	}
+}
+
+func ToInfoListFromFindRow(rows []databasegen.FindSOSPostsRow, page, size int) *SOSPostInfoList {
+	sl := NewSOSPostInfoList(page, size)
+	for _, row := range rows {
+		sl.Items = append(sl.Items, *ToInfoFromFindRow(row))
+	}
+	sl.CalcLastPage()
+	return sl
+}
+
+func ToInfoFromFindAuthorIDRow(row databasegen.FindSOSPostsByAuthorIDRow) *SOSPostInfo {
+	return &SOSPostInfo{
+		ID:          row.ID,
+		AuthorID:    row.AuthorID,
+		Title:       utils.NullStrToStr(row.Title),
+		Content:     utils.NullStrToStr(row.Content),
+		Media:       ParseMediaList(row.MediaInfo.RawMessage),
+		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
+		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
+		Reward:      utils.NullStrToStr(row.Reward),
+		Dates:       ParseSOSDatesList(row.Dates),
+		CareType:    CareType(row.CareType.String),
+		CarerGender: CarerGender(row.CarerGender.String),
+		RewardType:  RewardType(row.RewardType.String),
+		ThumbnailID: row.ThumbnailID,
+		CreatedAt:   row.CreatedAt,
+		UpdatedAt:   row.UpdatedAt,
+	}
+}
+
+func ToInfoListFromFindAuthorIDRow(rows []databasegen.FindSOSPostsByAuthorIDRow, page, size int) *SOSPostInfoList {
+	sl := NewSOSPostInfoList(page, size)
+	for _, row := range rows {
+		sl.Items = append(sl.Items, *ToInfoFromFindAuthorIDRow(row))
+	}
+
+	sl.CalcLastPage()
+	return sl
+}
+
+func ToInfoFromFindByIDRow(row databasegen.FindSOSPostByIDRow) *SOSPostInfo {
+	return &SOSPostInfo{
+		ID:          row.ID,
+		AuthorID:    row.AuthorID,
+		Title:       utils.NullStrToStr(row.Title),
+		Content:     utils.NullStrToStr(row.Content),
+		Media:       ParseMediaList(row.MediaInfo.RawMessage),
+		Conditions:  ParseConditionsList(row.ConditionsInfo.RawMessage),
+		Pets:        ParsePetsList(row.PetsInfo.RawMessage),
+		Reward:      utils.NullStrToStr(row.Reward),
+		Dates:       ParseSOSDatesList(row.Dates),
+		CareType:    CareType(row.CareType.String),
+		CarerGender: CarerGender(row.CarerGender.String),
+		RewardType:  RewardType(row.RewardType.String),
+		ThumbnailID: row.ThumbnailID,
+		CreatedAt:   row.CreatedAt,
+		UpdatedAt:   row.UpdatedAt,
+	}
+}
+
+func NewSOSPostList(page, size int) *SOSPostList {
+	return &SOSPostList{PaginatedView: pnd.NewPaginatedView(
+		page, size, false, make([]SOSPost, 0),
+	)}
+}
+
+func NewSOSPostInfoList(page, size int) *SOSPostInfoList {
+	return &SOSPostInfoList{PaginatedView: pnd.NewPaginatedView(
+		page, size, false, make([]SOSPostInfo, 0),
+	)}
+}
+
+func ParseMediaList(rows json.RawMessage) media.ViewListForSOSPost {
+	var mediaList media.ViewListForSOSPost
+	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+		return mediaList
+	}
+
+	if err := json.Unmarshal(rows, &mediaList); err != nil {
+		log.Println("Error unmarshalling media:", err)
+		return mediaList
+	}
+
+	return mediaList
+}
+
+func ParseConditionsList(rows json.RawMessage) soscondition.ViewListForSOSPost {
+	var conditionsList soscondition.ViewListForSOSPost
+	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+		return conditionsList
+	}
+
+	if err := json.Unmarshal(rows, &conditionsList); err != nil {
+		log.Println("Error unmarshalling conditions:", err)
+		return conditionsList
+	}
+
+	return conditionsList
+}
+
+func ParsePetsList(rows json.RawMessage) pet.ViewListForSOSPost {
+	var petList pet.ViewListForSOSPost
+
+	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+		return petList
+	}
+
+	if err := json.Unmarshal(rows, &petList); err != nil {
+		log.Println("Error unmarshalling pets:", err)
+		return petList
+	}
+
+	return petList
+}
+
+func ParseSOSDatesList(rows json.RawMessage) SOSDatesList {
+	var sosDatesList SOSDatesList
+
+	if len(rows) == 0 || string(rows) == JSONNullString || string(rows) == JSONEmptyArray {
+		return sosDatesList
+	}
+	if err := json.Unmarshal(rows, &sosDatesList); err != nil {
+		log.Println("Error unmarshalling sosDates:", err)
+		return sosDatesList
+	}
+
+	return sosDatesList
+}
 
 type SOSDates struct {
-	ID          int       `field:"id" json:"id"`
+	ID          uuid.UUID `field:"id" json:"id"`
 	DateStartAt string    `field:"date_start_at" json:"date_start_at"`
 	DateEndAt   string    `field:"date_end_at" json:"date_end_at"`
 	CreatedAt   time.Time `field:"created_at" json:"created_at"`
@@ -251,35 +257,3 @@ type SOSDates struct {
 }
 
 type SOSDatesList []*SOSDates
-
-// type SOSPostStore interface {
-// 	WriteSOSPost(
-// 		ctx context.Context,
-// 		tx *database.Tx,
-// 		authorID int,
-// 		utcDateStart string,
-// 		utcDateEnd string,
-// 		request *WriteSOSPostRequest,
-// 	) (*SOSPost, *pnd.AppError)
-// 	FindSOSPosts(
-// 		ctx context.Context,
-// 		tx *database.Tx,
-// 		page int,
-// 		size int,
-// 		sortBy string,
-// 	) (*SOSPostInfoList, *pnd.AppError)
-// 	FindSOSPostsByAuthorID(
-// 		ctx context.Context,
-// 		tx *database.Tx,
-// 		authorID int,
-// 		page int,
-// 		size int,
-// 		sortBy string,
-// 	) (*SOSPostInfoList, *pnd.AppError)
-// 	FindSOSPostByID(ctx context.Context, tx *database.Tx, id int) (*SOSPost, *pnd.AppError)
-// 	UpdateSOSPost(ctx context.Context, tx *database.Tx, request *UpdateSOSPostRequest) (*SOSPost, *pnd.AppError)
-// 	FindConditionByID(ctx context.Context, tx *database.Tx, id int) (*soscondition.ViewListForSOSPost, *pnd.AppError)
-// 	FindPetsByID(ctx context.Context, tx *database.Tx, id int) (*pet.ViewListForSOSPost, *pnd.AppError)
-// 	WriteDates(ctx context.Context, tx *database.Tx, dates []string, sosPostID int) (*SOSDatesList, *pnd.AppError)
-// 	FindDatesBySOSPostID(ctx context.Context, tx *database.Tx, sosPostID int) (*SOSDatesList, *pnd.AppError)
-// }

--- a/internal/domain/sospost/request.go
+++ b/internal/domain/sospost/request.go
@@ -1,28 +1,30 @@
 package sospost
 
-// type WriteSOSPostRequest struct {
-// 	Title        string        `json:"title" validate:"required"`
-// 	Content      string        `json:"content" validate:"required"`
-// 	ImageIDs     []uuid.UUID   `json:"imageIds" validate:"required"`
-// 	Reward       string        `json:"reward" validate:"required"`
-// 	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
-// 	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
-// 	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
-// 	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
-// 	ConditionIDs []uuid.UUID   `json:"conditionIds" validate:"required"`
-// 	PetIDs       []uuid.UUID   `json:"petIds" validate:"required,gte=1"`
-// }
-//
-// type UpdateSOSPostRequest struct {
-// 	ID           uuid.UUID     `json:"id" validate:"required"`
-// 	Title        string        `json:"title" validate:"required"`
-// 	Content      string        `json:"content" validate:"required"`
-// 	ImageIDs     []uuid.UUID   `json:"imageIds" validate:"required"`
-// 	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
-// 	Reward       string        `json:"reward" validate:"required"`
-// 	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
-// 	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
-// 	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
-// 	ConditionIDs []uuid.UUID   `json:"conditionIds" validate:"required"`
-// 	PetIDs       []uuid.UUID   `json:"petIds" validate:"required,gte=1"`
-// }
+import "github.com/google/uuid"
+
+type WriteSOSPostRequest struct {
+	Title        string        `json:"title" validate:"required"`
+	Content      string        `json:"content" validate:"required"`
+	ImageIDs     []uuid.UUID   `json:"imageIds" validate:"required"`
+	Reward       string        `json:"reward" validate:"required"`
+	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
+	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
+	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
+	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
+	ConditionIDs []uuid.UUID   `json:"conditionIds" validate:"required"`
+	PetIDs       []uuid.UUID   `json:"petIds" validate:"required,gte=1"`
+}
+
+type UpdateSOSPostRequest struct {
+	ID           uuid.UUID     `json:"id" validate:"required"`
+	Title        string        `json:"title" validate:"required"`
+	Content      string        `json:"content" validate:"required"`
+	ImageIDs     []uuid.UUID   `json:"imageIds" validate:"required"`
+	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
+	Reward       string        `json:"reward" validate:"required"`
+	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
+	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
+	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
+	ConditionIDs []uuid.UUID   `json:"conditionIds" validate:"required"`
+	PetIDs       []uuid.UUID   `json:"petIds" validate:"required,gte=1"`
+}

--- a/internal/domain/sospost/request.go
+++ b/internal/domain/sospost/request.go
@@ -1,28 +1,28 @@
 package sospost
 
-type WriteSOSPostRequest struct {
-	Title        string        `json:"title" validate:"required"`
-	Content      string        `json:"content" validate:"required"`
-	ImageIDs     []int64       `json:"imageIds" validate:"required"`
-	Reward       string        `json:"reward" validate:"required"`
-	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
-	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
-	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
-	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
-	ConditionIDs []int         `json:"conditionIds" validate:"required"`
-	PetIDs       []int64       `json:"petIds" validate:"required,gte=1"`
-}
-
-type UpdateSOSPostRequest struct {
-	ID           int           `json:"id" validate:"required"`
-	Title        string        `json:"title" validate:"required"`
-	Content      string        `json:"content" validate:"required"`
-	ImageIDs     []int64       `json:"imageIds" validate:"required"`
-	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
-	Reward       string        `json:"reward" validate:"required"`
-	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
-	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
-	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
-	ConditionIDs []int         `json:"conditionIds" validate:"required"`
-	PetIDs       []int64       `json:"petIds" validate:"required,gte=1"`
-}
+// type WriteSOSPostRequest struct {
+// 	Title        string        `json:"title" validate:"required"`
+// 	Content      string        `json:"content" validate:"required"`
+// 	ImageIDs     []uuid.UUID   `json:"imageIds" validate:"required"`
+// 	Reward       string        `json:"reward" validate:"required"`
+// 	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
+// 	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
+// 	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
+// 	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
+// 	ConditionIDs []uuid.UUID   `json:"conditionIds" validate:"required"`
+// 	PetIDs       []uuid.UUID   `json:"petIds" validate:"required,gte=1"`
+// }
+//
+// type UpdateSOSPostRequest struct {
+// 	ID           uuid.UUID     `json:"id" validate:"required"`
+// 	Title        string        `json:"title" validate:"required"`
+// 	Content      string        `json:"content" validate:"required"`
+// 	ImageIDs     []uuid.UUID   `json:"imageIds" validate:"required"`
+// 	Dates        []SOSDateView `json:"dates" validate:"required,gte=1"`
+// 	Reward       string        `json:"reward" validate:"required"`
+// 	CareType     CareType      `json:"careType" validate:"required,oneof=foster visiting"`
+// 	CarerGender  CarerGender   `json:"carerGender" validate:"required,oneof=male female all"`
+// 	RewardType   RewardType    `json:"rewardType" validate:"required,oneof=fee gifticon negotiable"`
+// 	ConditionIDs []uuid.UUID   `json:"conditionIds" validate:"required"`
+// 	PetIDs       []uuid.UUID   `json:"petIds" validate:"required,gte=1"`
+// }

--- a/internal/domain/sospost/view.go
+++ b/internal/domain/sospost/view.go
@@ -1,6 +1,7 @@
 package sospost
 
 import (
+	"github.com/google/uuid"
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
@@ -11,8 +12,8 @@ import (
 )
 
 type ViewParams struct {
-	ID          int
-	AuthorID    int
+	ID          uuid.UUID
+	AuthorID    uuid.UUID
 	Title       string
 	Content     string
 	MediaList   media.ListView
@@ -23,14 +24,14 @@ type ViewParams struct {
 	CareType    CareType
 	CarerGender CarerGender
 	RewardType  RewardType
-	ThumbnailID *int64
+	ThumbnailID uuid.NullUUID
 	CreatedAt   string
 	UpdatedAt   string
 }
 
 type ViewParamsInput struct {
-	ID          int64
-	AuthorID    int64
+	ID          uuid.UUID
+	AuthorID    uuid.UUID
 	Title       string
 	Content     string
 	MediaList   media.ListView
@@ -41,14 +42,14 @@ type ViewParamsInput struct {
 	CareType    string
 	CarerGender string
 	RewardType  string
-	ThumbnailID *int64
+	ThumbnailID uuid.NullUUID
 	CreatedAt   string
 	UpdatedAt   string
 }
 
 type DetailView struct {
-	ID          int                   `json:"id"`
-	AuthorID    int                   `json:"authorId"`
+	ID          uuid.UUID             `json:"id"`
+	AuthorID    uuid.UUID             `json:"authorId"`
 	Title       string                `json:"title"`
 	Content     string                `json:"content"`
 	Media       media.ListView        `json:"media"`
@@ -59,7 +60,7 @@ type DetailView struct {
 	CareType    CareType              `json:"careType"`
 	CarerGender CarerGender           `json:"carerGender"`
 	RewardType  RewardType            `json:"rewardType"`
-	ThumbnailID *int64                `json:"thumbnailId"`
+	ThumbnailID uuid.NullUUID         `json:"thumbnailId"`
 	CreatedAt   string                `json:"createdAt"`
 	UpdatedAt   string                `json:"updatedAt"`
 }
@@ -86,8 +87,8 @@ func ToDetailView(params ViewParams) *DetailView {
 
 func CreateViewParams(input ViewParamsInput) ViewParams {
 	return ViewParams{
-		ID:          int(input.ID),
-		AuthorID:    int(input.AuthorID),
+		ID:          input.ID,
+		AuthorID:    input.AuthorID,
 		Title:       input.Title,
 		Content:     input.Content,
 		MediaList:   input.MediaList,
@@ -112,8 +113,8 @@ func CreateDetailView(
 	sosDates []SOSDateView,
 ) *DetailView {
 	input := ViewParamsInput{
-		ID:          int64(sosPost.ID),
-		AuthorID:    sosPost.AuthorID.Int64,
+		// ID:          sosPost.ID,
+		// AuthorID:    sosPost.AuthorID.Int64,
 		Title:       utils.NullStrToStr(sosPost.Title),
 		Content:     utils.NullStrToStr(sosPost.Content),
 		MediaList:   mediaList,
@@ -124,16 +125,16 @@ func CreateDetailView(
 		CareType:    sosPost.CareType.String,
 		CarerGender: sosPost.CarerGender.String,
 		RewardType:  sosPost.RewardType.String,
-		ThumbnailID: &sosPost.ThumbnailID.Int64,
-		CreatedAt:   utils.FormatTimeFromTime(sosPost.CreatedAt),
-		UpdatedAt:   utils.FormatTimeFromTime(sosPost.UpdatedAt),
+		// ThumbnailID: sosPost.ThumbnailID.Int64,
+		CreatedAt: utils.FormatTimeFromTime(sosPost.CreatedAt),
+		UpdatedAt: utils.FormatTimeFromTime(sosPost.UpdatedAt),
 	}
 	params := CreateViewParams(input)
 	return ToDetailView(params)
 }
 
 type FindSOSPostView struct {
-	ID          int                      `json:"id"`
+	ID          uuid.UUID                `json:"id"`
 	Author      *user.WithoutPrivateInfo `json:"author"`
 	Title       string                   `json:"title"`
 	Content     string                   `json:"content"`
@@ -145,7 +146,7 @@ type FindSOSPostView struct {
 	CareType    CareType                 `json:"careType"`
 	CarerGender CarerGender              `json:"carerGender"`
 	RewardType  RewardType               `json:"rewardType"`
-	ThumbnailID *int64                   `json:"thumbnailId"`
+	ThumbnailID uuid.NullUUID            `json:"thumbnailId"`
 	CreatedAt   string                   `json:"createdAt"`
 	UpdatedAt   string                   `json:"updatedAt"`
 }
@@ -158,7 +159,7 @@ func (p *SOSPost) ToFindSOSPostView(
 	sosDates []SOSDateView,
 ) *FindSOSPostView {
 	return &FindSOSPostView{
-		ID:          p.ID,
+		// ID:          p.ID,
 		Author:      author,
 		Title:       p.Title,
 		Content:     p.Content,
@@ -170,9 +171,9 @@ func (p *SOSPost) ToFindSOSPostView(
 		CareType:    p.CareType,
 		CarerGender: p.CarerGender,
 		RewardType:  p.RewardType,
-		ThumbnailID: p.ThumbnailID,
-		CreatedAt:   utils.FormatDateTimeFromTime(p.CreatedAt),
-		UpdatedAt:   utils.FormatDateTimeFromTime(p.UpdatedAt),
+		// ThumbnailID: p.ThumbnailID,
+		CreatedAt: utils.FormatDateTimeFromTime(p.CreatedAt),
+		UpdatedAt: utils.FormatDateTimeFromTime(p.UpdatedAt),
 	}
 }
 
@@ -204,7 +205,7 @@ func (p *SOSPostInfo) ToFindSOSPostInfoView(
 	sosDates []SOSDateView,
 ) *FindSOSPostView {
 	return &FindSOSPostView{
-		ID:          p.ID,
+		// ID:          p.ID,
 		Author:      author,
 		Title:       p.Title,
 		Content:     p.Content,
@@ -216,9 +217,9 @@ func (p *SOSPostInfo) ToFindSOSPostInfoView(
 		CareType:    p.CareType,
 		CarerGender: p.CarerGender,
 		RewardType:  p.RewardType,
-		ThumbnailID: p.ThumbnailID,
-		CreatedAt:   utils.FormatDateTimeFromTime(p.CreatedAt),
-		UpdatedAt:   utils.FormatDateTimeFromTime(p.UpdatedAt),
+		// ThumbnailID: p.ThumbnailID,
+		CreatedAt: utils.FormatDateTimeFromTime(p.CreatedAt),
+		UpdatedAt: utils.FormatDateTimeFromTime(p.UpdatedAt),
 	}
 }
 
@@ -230,8 +231,8 @@ func UpdateDetailView(
 	sosDates []SOSDateView,
 ) *DetailView {
 	params := ViewParams{
-		ID:          int(sosPost.ID),
-		AuthorID:    int(sosPost.AuthorID.Int64),
+		// ID:          sosPost.ID,
+		// AuthorID:    sosPost.AuthorID,
 		Title:       utils.NullStrToStr(sosPost.Title),
 		Content:     utils.NullStrToStr(sosPost.Content),
 		MediaList:   mediaList,
@@ -242,9 +243,9 @@ func UpdateDetailView(
 		CareType:    CareType(sosPost.CareType.String),
 		CarerGender: CarerGender(sosPost.CarerGender.String),
 		RewardType:  RewardType(sosPost.RewardType.String),
-		ThumbnailID: &sosPost.ThumbnailID.Int64,
-		CreatedAt:   utils.FormatDateTimeFromTime(sosPost.CreatedAt),
-		UpdatedAt:   utils.FormatDateTimeFromTime(sosPost.UpdatedAt),
+		// ThumbnailID: sosPost.ThumbnailID,
+		CreatedAt: utils.FormatDateTimeFromTime(sosPost.CreatedAt),
+		UpdatedAt: utils.FormatDateTimeFromTime(sosPost.UpdatedAt),
 	}
 	return ToDetailView(params)
 }

--- a/internal/domain/sospost/view.go
+++ b/internal/domain/sospost/view.go
@@ -113,8 +113,8 @@ func CreateDetailView(
 	sosDates []SOSDateView,
 ) *DetailView {
 	input := ViewParamsInput{
-		// ID:          sosPost.ID,
-		// AuthorID:    sosPost.AuthorID.Int64,
+		ID:          sosPost.ID,
+		AuthorID:    sosPost.AuthorID,
 		Title:       utils.NullStrToStr(sosPost.Title),
 		Content:     utils.NullStrToStr(sosPost.Content),
 		MediaList:   mediaList,
@@ -125,9 +125,9 @@ func CreateDetailView(
 		CareType:    sosPost.CareType.String,
 		CarerGender: sosPost.CarerGender.String,
 		RewardType:  sosPost.RewardType.String,
-		// ThumbnailID: sosPost.ThumbnailID.Int64,
-		CreatedAt: utils.FormatTimeFromTime(sosPost.CreatedAt),
-		UpdatedAt: utils.FormatTimeFromTime(sosPost.UpdatedAt),
+		ThumbnailID: sosPost.ThumbnailID,
+		CreatedAt:   utils.FormatTimeFromTime(sosPost.CreatedAt),
+		UpdatedAt:   utils.FormatTimeFromTime(sosPost.UpdatedAt),
 	}
 	params := CreateViewParams(input)
 	return ToDetailView(params)
@@ -159,7 +159,7 @@ func (p *SOSPost) ToFindSOSPostView(
 	sosDates []SOSDateView,
 ) *FindSOSPostView {
 	return &FindSOSPostView{
-		// ID:          p.ID,
+		ID:          p.ID,
 		Author:      author,
 		Title:       p.Title,
 		Content:     p.Content,
@@ -171,9 +171,9 @@ func (p *SOSPost) ToFindSOSPostView(
 		CareType:    p.CareType,
 		CarerGender: p.CarerGender,
 		RewardType:  p.RewardType,
-		// ThumbnailID: p.ThumbnailID,
-		CreatedAt: utils.FormatDateTimeFromTime(p.CreatedAt),
-		UpdatedAt: utils.FormatDateTimeFromTime(p.UpdatedAt),
+		ThumbnailID: p.ThumbnailID,
+		CreatedAt:   utils.FormatDateTimeFromTime(p.CreatedAt),
+		UpdatedAt:   utils.FormatDateTimeFromTime(p.UpdatedAt),
 	}
 }
 
@@ -205,7 +205,7 @@ func (p *SOSPostInfo) ToFindSOSPostInfoView(
 	sosDates []SOSDateView,
 ) *FindSOSPostView {
 	return &FindSOSPostView{
-		// ID:          p.ID,
+		ID:          p.ID,
 		Author:      author,
 		Title:       p.Title,
 		Content:     p.Content,
@@ -217,9 +217,9 @@ func (p *SOSPostInfo) ToFindSOSPostInfoView(
 		CareType:    p.CareType,
 		CarerGender: p.CarerGender,
 		RewardType:  p.RewardType,
-		// ThumbnailID: p.ThumbnailID,
-		CreatedAt: utils.FormatDateTimeFromTime(p.CreatedAt),
-		UpdatedAt: utils.FormatDateTimeFromTime(p.UpdatedAt),
+		ThumbnailID: p.ThumbnailID,
+		CreatedAt:   utils.FormatDateTimeFromTime(p.CreatedAt),
+		UpdatedAt:   utils.FormatDateTimeFromTime(p.UpdatedAt),
 	}
 }
 
@@ -231,8 +231,8 @@ func UpdateDetailView(
 	sosDates []SOSDateView,
 ) *DetailView {
 	params := ViewParams{
-		// ID:          sosPost.ID,
-		// AuthorID:    sosPost.AuthorID,
+		ID:          sosPost.ID,
+		AuthorID:    sosPost.AuthorID,
 		Title:       utils.NullStrToStr(sosPost.Title),
 		Content:     utils.NullStrToStr(sosPost.Content),
 		MediaList:   mediaList,
@@ -243,9 +243,9 @@ func UpdateDetailView(
 		CareType:    CareType(sosPost.CareType.String),
 		CarerGender: CarerGender(sosPost.CarerGender.String),
 		RewardType:  RewardType(sosPost.RewardType.String),
-		// ThumbnailID: sosPost.ThumbnailID,
-		CreatedAt: utils.FormatDateTimeFromTime(sosPost.CreatedAt),
-		UpdatedAt: utils.FormatDateTimeFromTime(sosPost.UpdatedAt),
+		ThumbnailID: sosPost.ThumbnailID,
+		CreatedAt:   utils.FormatDateTimeFromTime(sosPost.CreatedAt),
+		UpdatedAt:   utils.FormatDateTimeFromTime(sosPost.UpdatedAt),
 	}
 	return ToDetailView(params)
 }

--- a/internal/domain/user/model.go
+++ b/internal/domain/user/model.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/google/uuid"
+
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
@@ -26,7 +28,7 @@ func (f FirebaseProviderType) NullString() sql.NullString {
 }
 
 type WithProfileImage struct {
-	ID                   int64
+	ID                   uuid.UUID
 	Email                string
 	Password             string
 	Nickname             string
@@ -41,7 +43,7 @@ type WithProfileImage struct {
 
 func ToWithProfileImage(row databasegen.FindUserRow) *WithProfileImage {
 	return &WithProfileImage{
-		ID:                   int64(row.ID),
+		ID:                   row.ID,
 		Email:                row.Email,
 		Nickname:             row.Nickname,
 		Fullname:             row.Fullname,

--- a/internal/domain/user/params.go
+++ b/internal/domain/user/params.go
@@ -1,12 +1,13 @@
 package user
 
 import (
+	"github.com/google/uuid"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
 type FindUserParams struct {
-	ID             *int
+	ID             uuid.NullUUID
 	Email          *string
 	FbUID          *string
 	IncludeDeleted bool
@@ -14,7 +15,7 @@ type FindUserParams struct {
 
 func (p *FindUserParams) ToDBParams() databasegen.FindUserParams {
 	return databasegen.FindUserParams{
-		ID:             utils.IntPtrToNullInt32(p.ID),
+		ID:             p.ID,
 		Email:          utils.StrPtrToNullStr(p.Email),
 		FbUid:          utils.StrPtrToNullStr(p.FbUID),
 		IncludeDeleted: p.IncludeDeleted,

--- a/internal/domain/user/request.go
+++ b/internal/domain/user/request.go
@@ -1,7 +1,9 @@
 package user
 
 import (
+	"github.com/google/uuid"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
@@ -9,18 +11,19 @@ type RegisterUserRequest struct {
 	Email                string               `json:"email" validate:"required,email"`
 	Nickname             string               `json:"nickname" validate:"required"`
 	Fullname             string               `json:"fullname" validate:"required"`
-	ProfileImageID       *int64               `json:"profileImageId"`
+	ProfileImageID       uuid.NullUUID        `json:"profileImageId"`
 	FirebaseProviderType FirebaseProviderType `json:"fbProviderType" validate:"required"`
 	FirebaseUID          string               `json:"fbUid" validate:"required"`
 }
 
 func (r *RegisterUserRequest) ToDBParams() databasegen.CreateUserParams {
 	return databasegen.CreateUserParams{
+		ID:             datatype.NewUUIDV7(),
 		Email:          r.Email,
 		Nickname:       r.Nickname,
 		Fullname:       r.Fullname,
 		Password:       "",
-		ProfileImageID: utils.Int64PtrToNullInt64(r.ProfileImageID),
+		ProfileImageID: r.ProfileImageID,
 		FbProviderType: r.FirebaseProviderType.NullString(),
 		FbUid:          utils.StrToNullStr(r.FirebaseUID),
 	}
@@ -35,6 +38,6 @@ type UserStatusRequest struct {
 }
 
 type UpdateUserRequest struct {
-	Nickname       string `json:"nickname" validate:"required"`
-	ProfileImageID *int64 `json:"profileImageId" validate:"omitempty"`
+	Nickname       string        `json:"nickname" validate:"required"`
+	ProfileImageID uuid.NullUUID `json:"profileImageId" validate:"omitempty"`
 }

--- a/internal/domain/user/view.go
+++ b/internal/domain/user/view.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"github.com/google/uuid"
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
@@ -8,7 +9,7 @@ import (
 )
 
 type InternalView struct {
-	ID                   int64                `json:"id"`
+	ID                   uuid.UUID            `json:"id"`
 	Email                string               `json:"email"`
 	Nickname             string               `json:"nickname"`
 	Fullname             string               `json:"fullname"`
@@ -29,7 +30,7 @@ func (r *InternalView) ToMyProfileView() *MyProfileView {
 }
 
 type MyProfileView struct {
-	ID                   int64                `json:"id"`
+	ID                   uuid.UUID            `json:"id"`
 	Email                string               `json:"email"`
 	Nickname             string               `json:"nickname"`
 	Fullname             string               `json:"fullname"`
@@ -38,7 +39,7 @@ type MyProfileView struct {
 }
 
 type ProfileView struct {
-	ID              int64            `json:"id"`
+	ID              uuid.UUID        `json:"id"`
 	Nickname        string           `json:"nickname"`
 	ProfileImageURL *string          `json:"profileImageUrl"`
 	Pets            []pet.DetailView `json:"pets"`
@@ -49,7 +50,7 @@ func NewProfileView(
 	pets *pet.ListView,
 ) *ProfileView {
 	return &ProfileView{
-		ID:              int64(user.ID),
+		ID:              user.ID,
 		Nickname:        user.Nickname,
 		ProfileImageURL: utils.NullStrToStrPtr(user.ProfileImageUrl),
 		Pets:            pets.Pets,
@@ -80,14 +81,14 @@ func NewStatusView(providerType FirebaseProviderType) *StatusView {
 }
 
 type WithoutPrivateInfo struct {
-	ID              int64   `json:"id"`
-	Nickname        string  `json:"nickname"`
-	ProfileImageURL *string `json:"profileImageUrl"`
+	ID              uuid.UUID `json:"id"`
+	Nickname        string    `json:"nickname"`
+	ProfileImageURL *string   `json:"profileImageUrl"`
 }
 
 func ToWithoutPrivateInfo(row databasegen.FindUserRow) *WithoutPrivateInfo {
 	return &WithoutPrivateInfo{
-		ID:              int64(row.ID),
+		ID:              row.ID,
 		Nickname:        row.Nickname,
 		ProfileImageURL: utils.NullStrToStrPtr(row.ProfileImageUrl),
 	}
@@ -104,7 +105,7 @@ func ToListWithoutPrivateInfo(page, size int, rows []databasegen.FindUsersRow) *
 
 	for _, row := range rows {
 		ul.Items = append(ul.Items, WithoutPrivateInfo{
-			ID:              int64(row.ID),
+			ID:              row.ID,
 			Nickname:        row.Nickname,
 			ProfileImageURL: utils.NullStrToStrPtr(row.ProfileImageUrl),
 		})

--- a/internal/infra/database/database.go
+++ b/internal/infra/database/database.go
@@ -53,7 +53,6 @@ func (db *DB) Flush() error {
 		"sos_posts_dates",
 		"sos_dates",
 		"sos_posts",
-		"base_posts",
 	}
 
 	for _, tableName := range tableNames {

--- a/internal/infra/database/gen/breeds.sql.go
+++ b/internal/infra/database/gen/breeds.sql.go
@@ -9,24 +9,28 @@ import (
 	"context"
 	"database/sql"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const createBreed = `-- name: CreateBreed :one
-INSERT INTO breeds (name,
+INSERT INTO breeds (id,
+                    name,
                     pet_type,
                     created_at,
                     updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 RETURNING id, pet_type, name, created_at, updated_at
 `
 
 type CreateBreedParams struct {
+	ID      uuid.UUID
 	Name    string
 	PetType string
 }
 
 type CreateBreedRow struct {
-	ID        int32
+	ID        uuid.UUID
 	PetType   string
 	Name      string
 	CreatedAt time.Time
@@ -34,7 +38,7 @@ type CreateBreedRow struct {
 }
 
 func (q *Queries) CreateBreed(ctx context.Context, arg CreateBreedParams) (CreateBreedRow, error) {
-	row := q.db.QueryRowContext(ctx, createBreed, arg.Name, arg.PetType)
+	row := q.db.QueryRowContext(ctx, createBreed, arg.ID, arg.Name, arg.PetType)
 	var i CreateBreedRow
 	err := row.Scan(
 		&i.ID,
@@ -69,7 +73,7 @@ type FindBreedsParams struct {
 }
 
 type FindBreedsRow struct {
-	ID        int32
+	ID        uuid.UUID
 	Name      string
 	PetType   string
 	CreatedAt time.Time

--- a/internal/infra/database/gen/media.sql.go
+++ b/internal/infra/database/gen/media.sql.go
@@ -7,27 +7,30 @@ package databasegen
 
 import (
 	"context"
-	"database/sql"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const createMedia = `-- name: CreateMedia :one
 INSERT INTO media
-(media_type,
+(id,
+ media_type,
  url,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 RETURNING id, media_type, url, created_at, updated_at
 `
 
 type CreateMediaParams struct {
+	ID        uuid.UUID
 	MediaType string
 	Url       string
 }
 
 type CreateMediaRow struct {
-	ID        int32
+	ID        uuid.UUID
 	MediaType string
 	Url       string
 	CreatedAt time.Time
@@ -35,7 +38,7 @@ type CreateMediaRow struct {
 }
 
 func (q *Queries) CreateMedia(ctx context.Context, arg CreateMediaParams) (CreateMediaRow, error) {
-	row := q.db.QueryRowContext(ctx, createMedia, arg.MediaType, arg.Url)
+	row := q.db.QueryRowContext(ctx, createMedia, arg.ID, arg.MediaType, arg.Url)
 	var i CreateMediaRow
 	err := row.Scan(
 		&i.ID,
@@ -60,12 +63,12 @@ WHERE (id = $1 OR $1 IS NULL)
 `
 
 type FindSingleMediaParams struct {
-	ID             sql.NullInt32
+	ID             uuid.NullUUID
 	IncludeDeleted bool
 }
 
 type FindSingleMediaRow struct {
-	ID        int32
+	ID        uuid.UUID
 	MediaType string
 	Url       string
 	CreatedAt time.Time

--- a/internal/infra/database/gen/models.go
+++ b/internal/infra/database/gen/models.go
@@ -6,41 +6,40 @@ package databasegen
 
 import (
 	"database/sql"
-	"encoding/json"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type BasePost struct {
-	ID        int32
 	Title     sql.NullString
 	Content   sql.NullString
-	AuthorID  sql.NullInt64
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt sql.NullTime
+	ID        uuid.UUID
+	AuthorID  uuid.UUID
 }
 
 type Breed struct {
-	ID        int32
 	Name      string
 	PetType   string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt sql.NullTime
+	ID        uuid.UUID
 }
 
 type Medium struct {
-	ID        int32
 	MediaType string
 	Url       string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt sql.NullTime
+	ID        uuid.UUID
 }
 
 type Pet struct {
-	ID             int32
-	OwnerID        int64
 	Name           string
 	PetType        string
 	Sex            string
@@ -52,81 +51,82 @@ type Pet struct {
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      sql.NullTime
-	ProfileImageID sql.NullInt64
 	Remarks        string
+	ID             uuid.UUID
+	OwnerID        uuid.UUID
+	ProfileImageID uuid.NullUUID
 }
 
 type ResourceMedium struct {
-	ID           int32
-	MediaID      sql.NullInt64
-	ResourceID   sql.NullInt64
 	ResourceType sql.NullString
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	DeletedAt    sql.NullTime
+	ID           uuid.UUID
+	MediaID      uuid.UUID
+	ResourceID   uuid.UUID
 }
 
 type SosCondition struct {
-	ID        int32
 	Name      sql.NullString
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt sql.NullTime
+	ID        uuid.UUID
 }
 
 type SosDate struct {
-	ID          int32
 	DateStartAt sql.NullTime
 	DateEndAt   sql.NullTime
 	CreatedAt   sql.NullTime
 	UpdatedAt   sql.NullTime
 	DeletedAt   sql.NullTime
+	ID          uuid.UUID
 }
 
 type SosPost struct {
-	ID          int32
-	Title       sql.NullString
-	Content     sql.NullString
-	AuthorID    sql.NullInt64
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	DeletedAt   sql.NullTime
-	Reward      sql.NullString
-	CareType    sql.NullString
-	CarerGender sql.NullString
-	RewardType  sql.NullString
-	ThumbnailID sql.NullInt64
-}
-
-type SosPostsCondition struct {
-	ID             int32
-	SosPostID      sql.NullInt64
-	SosConditionID sql.NullInt64
+	LegacyID       int32
+	Title          sql.NullString
+	Content        sql.NullString
+	AuthorLegacyID sql.NullInt64
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      sql.NullTime
+	Reward         sql.NullString
+	CareType       sql.NullString
+	CarerGender    sql.NullString
+	RewardType     sql.NullString
+	ThumbnailID    uuid.NullUUID
+}
+
+type SosPostsCondition struct {
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	DeletedAt      sql.NullTime
+	ID             uuid.UUID
+	SosPostID      uuid.UUID
+	SosConditionID uuid.NullUUID
 }
 
 type SosPostsDate struct {
-	ID         int32
-	SosPostID  sql.NullInt64
-	SosDatesID sql.NullInt64
 	CreatedAt  sql.NullTime
 	UpdatedAt  sql.NullTime
 	DeletedAt  sql.NullTime
+	ID         uuid.UUID
+	SosPostID  uuid.UUID
+	SosDatesID uuid.UUID
 }
 
 type SosPostsPet struct {
-	ID        int32
-	SosPostID sql.NullInt64
-	PetID     sql.NullInt64
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt sql.NullTime
+	ID        uuid.UUID
+	SosPostID uuid.UUID
+	PetID     uuid.UUID
 }
 
 type User struct {
-	ID             int32
 	Email          string
 	Password       string
 	Nickname       string
@@ -136,37 +136,6 @@ type User struct {
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      sql.NullTime
-	ProfileImageID sql.NullInt64
-}
-
-type VCondition struct {
-	SosPostID      sql.NullInt64
-	ConditionsInfo json.RawMessage
-}
-
-type VMediaForSosPost struct {
-	SosPostID sql.NullInt64
-	MediaInfo json.RawMessage
-}
-
-type VPetsForSosPost struct {
-	SosPostID   sql.NullInt64
-	PetTypeList interface{}
-	PetsInfo    json.RawMessage
-}
-
-type VSosPost struct {
-	ID                  int32
-	Title               sql.NullString
-	Content             sql.NullString
-	Reward              sql.NullString
-	RewardType          sql.NullString
-	CareType            sql.NullString
-	CarerGender         sql.NullString
-	ThumbnailID         sql.NullInt64
-	AuthorID            sql.NullInt64
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
-	EarliestDateStartAt interface{}
-	Dates               json.RawMessage
+	ID             uuid.UUID
+	ProfileImageID uuid.NullUUID
 }

--- a/internal/infra/database/gen/models.go
+++ b/internal/infra/database/gen/models.go
@@ -6,20 +6,11 @@ package databasegen
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
 )
-
-type BasePost struct {
-	Title     sql.NullString
-	Content   sql.NullString
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt sql.NullTime
-	ID        uuid.UUID
-	AuthorID  uuid.UUID
-}
 
 type Breed struct {
 	Name      string
@@ -85,18 +76,18 @@ type SosDate struct {
 }
 
 type SosPost struct {
-	LegacyID       int32
-	Title          sql.NullString
-	Content        sql.NullString
-	AuthorLegacyID sql.NullInt64
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	DeletedAt      sql.NullTime
-	Reward         sql.NullString
-	CareType       sql.NullString
-	CarerGender    sql.NullString
-	RewardType     sql.NullString
-	ThumbnailID    uuid.NullUUID
+	ID          uuid.UUID
+	Title       sql.NullString
+	Content     sql.NullString
+	AuthorID    uuid.UUID
+	Reward      sql.NullString
+	CareType    sql.NullString
+	CarerGender sql.NullString
+	RewardType  sql.NullString
+	ThumbnailID uuid.NullUUID
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	DeletedAt   sql.NullTime
 }
 
 type SosPostsCondition struct {
@@ -138,4 +129,36 @@ type User struct {
 	DeletedAt      sql.NullTime
 	ID             uuid.UUID
 	ProfileImageID uuid.NullUUID
+}
+
+type VCondition struct {
+	SosPostID      uuid.UUID
+	ConditionsInfo json.RawMessage
+}
+
+type VMediaForSosPost struct {
+	SosPostID uuid.UUID
+	MediaInfo json.RawMessage
+}
+
+type VPetsForSosPost struct {
+	SosPostID   uuid.UUID
+	PetTypeList interface{}
+	PetsInfo    json.RawMessage
+}
+
+type VSosPost struct {
+	ID                  uuid.UUID
+	Title               sql.NullString
+	Content             sql.NullString
+	Reward              sql.NullString
+	RewardType          sql.NullString
+	CareType            sql.NullString
+	CarerGender         sql.NullString
+	ThumbnailID         uuid.NullUUID
+	AuthorID            uuid.UUID
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	EarliestDateStartAt interface{}
+	Dates               json.RawMessage
 }

--- a/internal/infra/database/gen/sos_posts.sql.go
+++ b/internal/infra/database/gen/sos_posts.sql.go
@@ -8,22 +8,19 @@ package databasegen
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"time"
 
-	"github.com/sqlc-dev/pqtype"
+	"github.com/google/uuid"
 )
 
 const deleteSOSPostConditionBySOSPostID = `-- name: DeleteSOSPostConditionBySOSPostID :exec
 UPDATE
     sos_posts_conditions
-SET
-    deleted_at = NOW()
-WHERE
-    sos_post_id = $1
+SET deleted_at = NOW()
+WHERE sos_post_id = $1
 `
 
-func (q *Queries) DeleteSOSPostConditionBySOSPostID(ctx context.Context, sosPostID sql.NullInt64) error {
+func (q *Queries) DeleteSOSPostConditionBySOSPostID(ctx context.Context, sosPostID uuid.UUID) error {
 	_, err := q.db.ExecContext(ctx, deleteSOSPostConditionBySOSPostID, sosPostID)
 	return err
 }
@@ -31,13 +28,11 @@ func (q *Queries) DeleteSOSPostConditionBySOSPostID(ctx context.Context, sosPost
 const deleteSOSPostDateBySOSPostID = `-- name: DeleteSOSPostDateBySOSPostID :exec
 UPDATE
     sos_posts_dates
-SET
-    deleted_at = NOW()
-WHERE
-    sos_post_id = $1
+SET deleted_at = NOW()
+WHERE sos_post_id = $1
 `
 
-func (q *Queries) DeleteSOSPostDateBySOSPostID(ctx context.Context, sosPostID sql.NullInt64) error {
+func (q *Queries) DeleteSOSPostDateBySOSPostID(ctx context.Context, sosPostID uuid.UUID) error {
 	_, err := q.db.ExecContext(ctx, deleteSOSPostDateBySOSPostID, sosPostID)
 	return err
 }
@@ -45,43 +40,140 @@ func (q *Queries) DeleteSOSPostDateBySOSPostID(ctx context.Context, sosPostID sq
 const deleteSOSPostPetBySOSPostID = `-- name: DeleteSOSPostPetBySOSPostID :exec
 UPDATE
     sos_posts_pets
-SET
-    deleted_at = NOW()
-WHERE
-    sos_post_id = $1
+SET deleted_at = NOW()
+WHERE sos_post_id = $1
 `
 
-func (q *Queries) DeleteSOSPostPetBySOSPostID(ctx context.Context, sosPostID sql.NullInt64) error {
+func (q *Queries) DeleteSOSPostPetBySOSPostID(ctx context.Context, sosPostID uuid.UUID) error {
 	_, err := q.db.ExecContext(ctx, deleteSOSPostPetBySOSPostID, sosPostID)
 	return err
 }
 
 const findDatesBySOSPostID = `-- name: FindDatesBySOSPostID :many
-SELECT
-    sos_dates.id,
-    sos_dates.date_start_at,
-    sos_dates.date_end_at,
-    sos_dates.created_at,
-    sos_dates.updated_at
-FROM
-    sos_dates
-        INNER JOIN
-    sos_posts_dates
-    ON sos_dates.id = sos_posts_dates.sos_dates_id
-WHERE
-    sos_posts_dates.sos_post_id = $1 AND
-    sos_posts_dates.deleted_at IS NULL
+
+
+
+
+SELECT sos_dates.id,
+       sos_dates.date_start_at,
+       sos_dates.date_end_at,
+       sos_dates.created_at,
+       sos_dates.updated_at
+FROM sos_dates
+         INNER JOIN
+     sos_posts_dates
+     ON sos_dates.id = sos_posts_dates.sos_dates_id
+WHERE sos_posts_dates.sos_post_id = $1
+  AND sos_posts_dates.deleted_at IS NULL
 `
 
 type FindDatesBySOSPostIDRow struct {
-	ID          int32
+	ID          uuid.UUID
 	DateStartAt sql.NullTime
 	DateEndAt   sql.NullTime
 	CreatedAt   sql.NullTime
 	UpdatedAt   sql.NullTime
 }
 
-func (q *Queries) FindDatesBySOSPostID(ctx context.Context, id sql.NullInt64) ([]FindDatesBySOSPostIDRow, error) {
+// -- name: FindSOSPosts :many
+// SELECT v_sos_posts.id,
+//
+//	v_sos_posts.title,
+//	v_sos_posts.content,
+//	v_sos_posts.reward,
+//	v_sos_posts.reward_type,
+//	v_sos_posts.care_type,
+//	v_sos_posts.carer_gender,
+//	v_sos_posts.thumbnail_id,
+//	v_sos_posts.author_id,
+//	v_sos_posts.created_at,
+//	v_sos_posts.updated_at,
+//	v_sos_posts.dates,
+//	v_pets_for_sos_posts.pets_info,
+//	v_media_for_sos_posts.media_info,
+//	v_conditions.conditions_info
+//
+// FROM v_sos_posts
+//
+//	LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+//	LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+//	LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+//
+// WHERE v_sos_posts.earliest_date_start_at >= sqlc.narg('earliest_date_start_at')
+//
+//	AND (sqlc.narg('pet_type') = 'all' OR NOT EXISTS
+//	  (SELECT 1
+//	   FROM unnest(pet_type_list) AS pet_type
+//	   WHERE pet_type <> sqlc.narg('pet_type')))
+//
+// ORDER BY CASE WHEN sqlc.narg('sort_by') = 'newest' THEN v_sos_posts.created_at END DESC,
+//
+//	CASE WHEN sqlc.narg('sort_by') = 'deadline' THEN v_sos_posts.earliest_date_start_at END
+//
+// LIMIT sqlc.narg('limit') OFFSET sqlc.narg('offset');
+// -- name: FindSOSPostsByAuthorID :many
+// SELECT v_sos_posts.id,
+//
+//	v_sos_posts.title,
+//	v_sos_posts.content,
+//	v_sos_posts.reward,
+//	v_sos_posts.reward_type,
+//	v_sos_posts.care_type,
+//	v_sos_posts.carer_gender,
+//	v_sos_posts.thumbnail_id,
+//	v_sos_posts.author_id,
+//	v_sos_posts.created_at,
+//	v_sos_posts.updated_at,
+//	v_sos_posts.dates,
+//	v_pets_for_sos_posts.pets_info,
+//	v_media_for_sos_posts.media_info,
+//	v_conditions.conditions_info
+//
+// FROM v_sos_posts
+//
+//	LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+//	LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+//	LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+//
+// WHERE v_sos_posts.earliest_date_start_at >= sqlc.narg('earliest_date_start_at')
+//
+//	AND v_sos_posts.author_id = sqlc.narg('author_id')
+//	AND (sqlc.narg('pet_type') = 'all' OR NOT EXISTS
+//	  (SELECT 1
+//	   FROM unnest(pet_type_list) AS pet_type
+//	   WHERE pet_type <> sqlc.narg('pet_type')))
+//
+// ORDER BY CASE WHEN sqlc.narg('sort_by') = 'newest' THEN v_sos_posts.created_at END DESC,
+//
+//	CASE WHEN sqlc.narg('sort_by') = 'deadline' THEN v_sos_posts.earliest_date_start_at END
+//
+// LIMIT sqlc.narg('limit') OFFSET sqlc.narg('offset');
+// -- name: FindSOSPostByID :one
+// SELECT v_sos_posts.id,
+//
+//	v_sos_posts.title,
+//	v_sos_posts.content,
+//	v_sos_posts.reward,
+//	v_sos_posts.reward_type,
+//	v_sos_posts.care_type,
+//	v_sos_posts.carer_gender,
+//	v_sos_posts.thumbnail_id,
+//	v_sos_posts.author_id,
+//	v_sos_posts.created_at,
+//	v_sos_posts.updated_at,
+//	v_sos_posts.dates,
+//	v_pets_for_sos_posts.pets_info,
+//	v_media_for_sos_posts.media_info,
+//	v_conditions.conditions_info
+//
+// FROM v_sos_posts
+//
+//	LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+//	LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+//	LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+//
+// WHERE v_sos_posts.id = sqlc.narg('id');
+func (q *Queries) FindDatesBySOSPostID(ctx context.Context, id uuid.NullUUID) ([]FindDatesBySOSPostIDRow, error) {
 	rows, err := q.db.QueryContext(ctx, findDatesBySOSPostID, id)
 	if err != nil {
 		return nil, err
@@ -110,305 +202,25 @@ func (q *Queries) FindDatesBySOSPostID(ctx context.Context, id sql.NullInt64) ([
 	return items, nil
 }
 
-const findSOSPostByID = `-- name: FindSOSPostByID :one
-SELECT
-    v_sos_posts.id,
-    v_sos_posts.title,
-    v_sos_posts.content,
-    v_sos_posts.reward,
-    v_sos_posts.reward_type,
-    v_sos_posts.care_type,
-    v_sos_posts.carer_gender,
-    v_sos_posts.thumbnail_id,
-    v_sos_posts.author_id,
-    v_sos_posts.created_at,
-    v_sos_posts.updated_at,
-    v_sos_posts.dates,
-    v_pets_for_sos_posts.pets_info,
-    v_media_for_sos_posts.media_info,
-    v_conditions.conditions_info
-FROM
-    v_sos_posts
-        LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-        LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-        LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-WHERE
-    v_sos_posts.id = $1
-`
-
-type FindSOSPostByIDRow struct {
-	ID             int32
-	Title          sql.NullString
-	Content        sql.NullString
-	Reward         sql.NullString
-	RewardType     sql.NullString
-	CareType       sql.NullString
-	CarerGender    sql.NullString
-	ThumbnailID    sql.NullInt64
-	AuthorID       sql.NullInt64
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	Dates          json.RawMessage
-	PetsInfo       pqtype.NullRawMessage
-	MediaInfo      pqtype.NullRawMessage
-	ConditionsInfo pqtype.NullRawMessage
-}
-
-func (q *Queries) FindSOSPostByID(ctx context.Context, id sql.NullInt32) (FindSOSPostByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, findSOSPostByID, id)
-	var i FindSOSPostByIDRow
-	err := row.Scan(
-		&i.ID,
-		&i.Title,
-		&i.Content,
-		&i.Reward,
-		&i.RewardType,
-		&i.CareType,
-		&i.CarerGender,
-		&i.ThumbnailID,
-		&i.AuthorID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Dates,
-		&i.PetsInfo,
-		&i.MediaInfo,
-		&i.ConditionsInfo,
-	)
-	return i, err
-}
-
-const findSOSPosts = `-- name: FindSOSPosts :many
-SELECT
-    v_sos_posts.id,
-    v_sos_posts.title,
-    v_sos_posts.content,
-    v_sos_posts.reward,
-    v_sos_posts.reward_type,
-    v_sos_posts.care_type,
-    v_sos_posts.carer_gender,
-    v_sos_posts.thumbnail_id,
-    v_sos_posts.author_id,
-    v_sos_posts.created_at,
-    v_sos_posts.updated_at,
-    v_sos_posts.dates,
-    v_pets_for_sos_posts.pets_info,
-    v_media_for_sos_posts.media_info,
-    v_conditions.conditions_info
-FROM
-    v_sos_posts
-        LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-        LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-        LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-WHERE
-    v_sos_posts.earliest_date_start_at >= $1
-  AND ($2 = 'all' OR NOT EXISTS
-    (SELECT 1
-     FROM unnest(pet_type_list) AS pet_type
-     WHERE pet_type <> $2))
-ORDER BY
-    CASE WHEN $3 = 'newest' THEN v_sos_posts.created_at END DESC,
-    CASE WHEN $3 = 'deadline' THEN v_sos_posts.earliest_date_start_at END
-LIMIT $5
-    OFFSET $4
-`
-
-type FindSOSPostsParams struct {
-	EarliestDateStartAt interface{}
-	PetType             interface{}
-	SortBy              interface{}
-	Offset              sql.NullInt32
-	Limit               sql.NullInt32
-}
-
-type FindSOSPostsRow struct {
-	ID             int32
-	Title          sql.NullString
-	Content        sql.NullString
-	Reward         sql.NullString
-	RewardType     sql.NullString
-	CareType       sql.NullString
-	CarerGender    sql.NullString
-	ThumbnailID    sql.NullInt64
-	AuthorID       sql.NullInt64
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	Dates          json.RawMessage
-	PetsInfo       pqtype.NullRawMessage
-	MediaInfo      pqtype.NullRawMessage
-	ConditionsInfo pqtype.NullRawMessage
-}
-
-func (q *Queries) FindSOSPosts(ctx context.Context, arg FindSOSPostsParams) ([]FindSOSPostsRow, error) {
-	rows, err := q.db.QueryContext(ctx, findSOSPosts,
-		arg.EarliestDateStartAt,
-		arg.PetType,
-		arg.SortBy,
-		arg.Offset,
-		arg.Limit,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []FindSOSPostsRow
-	for rows.Next() {
-		var i FindSOSPostsRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Title,
-			&i.Content,
-			&i.Reward,
-			&i.RewardType,
-			&i.CareType,
-			&i.CarerGender,
-			&i.ThumbnailID,
-			&i.AuthorID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.Dates,
-			&i.PetsInfo,
-			&i.MediaInfo,
-			&i.ConditionsInfo,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const findSOSPostsByAuthorID = `-- name: FindSOSPostsByAuthorID :many
-SELECT
-    v_sos_posts.id,
-    v_sos_posts.title,
-    v_sos_posts.content,
-    v_sos_posts.reward,
-    v_sos_posts.reward_type,
-    v_sos_posts.care_type,
-    v_sos_posts.carer_gender,
-    v_sos_posts.thumbnail_id,
-    v_sos_posts.author_id,
-    v_sos_posts.created_at,
-    v_sos_posts.updated_at,
-    v_sos_posts.dates,
-    v_pets_for_sos_posts.pets_info,
-    v_media_for_sos_posts.media_info,
-    v_conditions.conditions_info
-FROM
-    v_sos_posts
-        LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-        LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-        LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-WHERE
-    v_sos_posts.earliest_date_start_at >= $1
-  AND v_sos_posts.author_id = $2
-  AND ($3 = 'all' OR NOT EXISTS
-    (SELECT 1
-     FROM unnest(pet_type_list) AS pet_type
-     WHERE pet_type <> $3))
-ORDER BY
-    CASE WHEN $4 = 'newest' THEN v_sos_posts.created_at END DESC,
-    CASE WHEN $4 = 'deadline' THEN v_sos_posts.earliest_date_start_at END
-LIMIT $6
-    OFFSET $5
-`
-
-type FindSOSPostsByAuthorIDParams struct {
-	EarliestDateStartAt interface{}
-	AuthorID            sql.NullInt64
-	PetType             interface{}
-	SortBy              interface{}
-	Offset              sql.NullInt32
-	Limit               sql.NullInt32
-}
-
-type FindSOSPostsByAuthorIDRow struct {
-	ID             int32
-	Title          sql.NullString
-	Content        sql.NullString
-	Reward         sql.NullString
-	RewardType     sql.NullString
-	CareType       sql.NullString
-	CarerGender    sql.NullString
-	ThumbnailID    sql.NullInt64
-	AuthorID       sql.NullInt64
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	Dates          json.RawMessage
-	PetsInfo       pqtype.NullRawMessage
-	MediaInfo      pqtype.NullRawMessage
-	ConditionsInfo pqtype.NullRawMessage
-}
-
-func (q *Queries) FindSOSPostsByAuthorID(ctx context.Context, arg FindSOSPostsByAuthorIDParams) ([]FindSOSPostsByAuthorIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, findSOSPostsByAuthorID,
-		arg.EarliestDateStartAt,
-		arg.AuthorID,
-		arg.PetType,
-		arg.SortBy,
-		arg.Offset,
-		arg.Limit,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []FindSOSPostsByAuthorIDRow
-	for rows.Next() {
-		var i FindSOSPostsByAuthorIDRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Title,
-			&i.Content,
-			&i.Reward,
-			&i.RewardType,
-			&i.CareType,
-			&i.CarerGender,
-			&i.ThumbnailID,
-			&i.AuthorID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.Dates,
-			&i.PetsInfo,
-			&i.MediaInfo,
-			&i.ConditionsInfo,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const insertSOSDate = `-- name: InsertSOSDate :one
 INSERT INTO sos_dates
-(date_start_at,
+(id,
+ date_start_at,
  date_end_at,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 RETURNING id, date_start_at, date_end_at, created_at, updated_at
 `
 
 type InsertSOSDateParams struct {
+	ID          uuid.UUID
 	DateStartAt sql.NullTime
 	DateEndAt   sql.NullTime
 }
 
 type InsertSOSDateRow struct {
-	ID          int32
+	ID          uuid.UUID
 	DateStartAt sql.NullTime
 	DateEndAt   sql.NullTime
 	CreatedAt   sql.NullTime
@@ -416,7 +228,7 @@ type InsertSOSDateRow struct {
 }
 
 func (q *Queries) InsertSOSDate(ctx context.Context, arg InsertSOSDateParams) (InsertSOSDateRow, error) {
-	row := q.db.QueryRowContext(ctx, insertSOSDate, arg.DateStartAt, arg.DateEndAt)
+	row := q.db.QueryRowContext(ctx, insertSOSDate, arg.ID, arg.DateStartAt, arg.DateEndAt)
 	var i InsertSOSDateRow
 	err := row.Scan(
 		&i.ID,
@@ -430,98 +242,109 @@ func (q *Queries) InsertSOSDate(ctx context.Context, arg InsertSOSDateParams) (I
 
 const linkResourceMedia = `-- name: LinkResourceMedia :exec
 INSERT INTO resource_media
-(media_id,
+(id,
+ media_id,
  resource_id,
  resource_type,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, NOW(), NOW())
+VALUES ($1, $2, $3, $4, NOW(), NOW())
 `
 
 type LinkResourceMediaParams struct {
-	MediaID      sql.NullInt64
-	ResourceID   sql.NullInt64
+	ID           uuid.UUID
+	MediaID      uuid.UUID
+	ResourceID   uuid.UUID
 	ResourceType sql.NullString
 }
 
 func (q *Queries) LinkResourceMedia(ctx context.Context, arg LinkResourceMediaParams) error {
-	_, err := q.db.ExecContext(ctx, linkResourceMedia, arg.MediaID, arg.ResourceID, arg.ResourceType)
+	_, err := q.db.ExecContext(ctx, linkResourceMedia,
+		arg.ID,
+		arg.MediaID,
+		arg.ResourceID,
+		arg.ResourceType,
+	)
 	return err
 }
 
 const linkSOSPostCondition = `-- name: LinkSOSPostCondition :exec
 INSERT INTO sos_posts_conditions
-(sos_post_id,
+(id,
+ sos_post_id,
  sos_condition_id,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 `
 
 type LinkSOSPostConditionParams struct {
-	SosPostID      sql.NullInt64
-	SosConditionID sql.NullInt64
+	ID             uuid.UUID
+	SosPostID      uuid.UUID
+	SosConditionID uuid.NullUUID
 }
 
 func (q *Queries) LinkSOSPostCondition(ctx context.Context, arg LinkSOSPostConditionParams) error {
-	_, err := q.db.ExecContext(ctx, linkSOSPostCondition, arg.SosPostID, arg.SosConditionID)
+	_, err := q.db.ExecContext(ctx, linkSOSPostCondition, arg.ID, arg.SosPostID, arg.SosConditionID)
 	return err
 }
 
 const linkSOSPostDate = `-- name: LinkSOSPostDate :exec
 INSERT INTO sos_posts_dates
-(sos_post_id,
+(id,
+ sos_post_id,
  sos_dates_id,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 `
 
 type LinkSOSPostDateParams struct {
-	SosPostID  sql.NullInt64
-	SosDatesID sql.NullInt64
+	ID         uuid.UUID
+	SosPostID  uuid.UUID
+	SosDatesID uuid.UUID
 }
 
 func (q *Queries) LinkSOSPostDate(ctx context.Context, arg LinkSOSPostDateParams) error {
-	_, err := q.db.ExecContext(ctx, linkSOSPostDate, arg.SosPostID, arg.SosDatesID)
+	_, err := q.db.ExecContext(ctx, linkSOSPostDate, arg.ID, arg.SosPostID, arg.SosDatesID)
 	return err
 }
 
 const linkSOSPostPet = `-- name: LinkSOSPostPet :exec
 INSERT INTO sos_posts_pets
-(sos_post_id,
+(id,
+ sos_post_id,
  pet_id,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 `
 
 type LinkSOSPostPetParams struct {
-	SosPostID sql.NullInt64
-	PetID     sql.NullInt64
+	ID        uuid.UUID
+	SosPostID uuid.UUID
+	PetID     uuid.UUID
 }
 
 func (q *Queries) LinkSOSPostPet(ctx context.Context, arg LinkSOSPostPetParams) error {
-	_, err := q.db.ExecContext(ctx, linkSOSPostPet, arg.SosPostID, arg.PetID)
+	_, err := q.db.ExecContext(ctx, linkSOSPostPet, arg.ID, arg.SosPostID, arg.PetID)
 	return err
 }
 
 const updateSOSPost = `-- name: UpdateSOSPost :one
 UPDATE
     sos_posts
-SET
-    title = $1,
-    content = $2,
-    reward = $3,
-    care_type = $4,
+SET title        = $1,
+    content      = $2,
+    reward       = $3,
+    care_type    = $4,
     carer_gender = $5,
-    reward_type = $6,
+    reward_type  = $6,
     thumbnail_id = $7,
-    updated_at = NOW()
-WHERE
-    id = $8
+    updated_at   = NOW()
+WHERE legacy_id = $8
 RETURNING
-    id, author_id, title, content, reward, care_type, carer_gender, reward_type, thumbnail_id, created_at, updated_at
+    legacy_id, author_legacy_id, title, content, reward, care_type, carer_gender, reward_type, thumbnail_id, created_at, updated_at
 `
 
 type UpdateSOSPostParams struct {
@@ -531,22 +354,22 @@ type UpdateSOSPostParams struct {
 	CareType    sql.NullString
 	CarerGender sql.NullString
 	RewardType  sql.NullString
-	ThumbnailID sql.NullInt64
-	ID          int32
+	ThumbnailID uuid.NullUUID
+	LegacyID    int32
 }
 
 type UpdateSOSPostRow struct {
-	ID          int32
-	AuthorID    sql.NullInt64
-	Title       sql.NullString
-	Content     sql.NullString
-	Reward      sql.NullString
-	CareType    sql.NullString
-	CarerGender sql.NullString
-	RewardType  sql.NullString
-	ThumbnailID sql.NullInt64
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	LegacyID       int32
+	AuthorLegacyID sql.NullInt64
+	Title          sql.NullString
+	Content        sql.NullString
+	Reward         sql.NullString
+	CareType       sql.NullString
+	CarerGender    sql.NullString
+	RewardType     sql.NullString
+	ThumbnailID    uuid.NullUUID
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 func (q *Queries) UpdateSOSPost(ctx context.Context, arg UpdateSOSPostParams) (UpdateSOSPostRow, error) {
@@ -558,12 +381,12 @@ func (q *Queries) UpdateSOSPost(ctx context.Context, arg UpdateSOSPostParams) (U
 		arg.CarerGender,
 		arg.RewardType,
 		arg.ThumbnailID,
-		arg.ID,
+		arg.LegacyID,
 	)
 	var i UpdateSOSPostRow
 	err := row.Scan(
-		&i.ID,
-		&i.AuthorID,
+		&i.LegacyID,
+		&i.AuthorLegacyID,
 		&i.Title,
 		&i.Content,
 		&i.Reward,
@@ -579,7 +402,8 @@ func (q *Queries) UpdateSOSPost(ctx context.Context, arg UpdateSOSPostParams) (U
 
 const writeSOSPost = `-- name: WriteSOSPost :one
 INSERT INTO sos_posts
-(author_id,
+(legacy_id,
+ author_legacy_id,
  title,
  content,
  reward,
@@ -589,38 +413,40 @@ INSERT INTO sos_posts
  thumbnail_id,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
-RETURNING id, author_id, title, content, reward, care_type, carer_gender, reward_type, thumbnail_id, created_at, updated_at
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
+RETURNING legacy_id, author_legacy_id, title, content, reward, care_type, carer_gender, reward_type, thumbnail_id, created_at, updated_at
 `
 
 type WriteSOSPostParams struct {
-	AuthorID    sql.NullInt64
-	Title       sql.NullString
-	Content     sql.NullString
-	Reward      sql.NullString
-	CareType    sql.NullString
-	CarerGender sql.NullString
-	RewardType  sql.NullString
-	ThumbnailID sql.NullInt64
+	LegacyID       int32
+	AuthorLegacyID sql.NullInt64
+	Title          sql.NullString
+	Content        sql.NullString
+	Reward         sql.NullString
+	CareType       sql.NullString
+	CarerGender    sql.NullString
+	RewardType     sql.NullString
+	ThumbnailID    uuid.NullUUID
 }
 
 type WriteSOSPostRow struct {
-	ID          int32
-	AuthorID    sql.NullInt64
-	Title       sql.NullString
-	Content     sql.NullString
-	Reward      sql.NullString
-	CareType    sql.NullString
-	CarerGender sql.NullString
-	RewardType  sql.NullString
-	ThumbnailID sql.NullInt64
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	LegacyID       int32
+	AuthorLegacyID sql.NullInt64
+	Title          sql.NullString
+	Content        sql.NullString
+	Reward         sql.NullString
+	CareType       sql.NullString
+	CarerGender    sql.NullString
+	RewardType     sql.NullString
+	ThumbnailID    uuid.NullUUID
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 func (q *Queries) WriteSOSPost(ctx context.Context, arg WriteSOSPostParams) (WriteSOSPostRow, error) {
 	row := q.db.QueryRowContext(ctx, writeSOSPost,
-		arg.AuthorID,
+		arg.LegacyID,
+		arg.AuthorLegacyID,
 		arg.Title,
 		arg.Content,
 		arg.Reward,
@@ -631,8 +457,8 @@ func (q *Queries) WriteSOSPost(ctx context.Context, arg WriteSOSPostParams) (Wri
 	)
 	var i WriteSOSPostRow
 	err := row.Scan(
-		&i.ID,
-		&i.AuthorID,
+		&i.LegacyID,
+		&i.AuthorLegacyID,
 		&i.Title,
 		&i.Content,
 		&i.Reward,

--- a/internal/infra/database/gen/users.sql.go
+++ b/internal/infra/database/gen/users.sql.go
@@ -9,11 +9,14 @@ import (
 	"context"
 	"database/sql"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const createUser = `-- name: CreateUser :one
 INSERT INTO users
-(email,
+(id,
+ email,
  nickname,
  fullname,
  password,
@@ -22,26 +25,27 @@ INSERT INTO users
  fb_uid,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
 RETURNING id, email, nickname, fullname, profile_image_id, fb_provider_type, fb_uid, created_at, updated_at
 `
 
 type CreateUserParams struct {
+	ID             uuid.UUID
 	Email          string
 	Nickname       string
 	Fullname       string
 	Password       string
-	ProfileImageID sql.NullInt64
+	ProfileImageID uuid.NullUUID
 	FbProviderType sql.NullString
 	FbUid          sql.NullString
 }
 
 type CreateUserRow struct {
-	ID             int32
+	ID             uuid.UUID
 	Email          string
 	Nickname       string
 	Fullname       string
-	ProfileImageID sql.NullInt64
+	ProfileImageID uuid.NullUUID
 	FbProviderType sql.NullString
 	FbUid          sql.NullString
 	CreatedAt      time.Time
@@ -50,6 +54,7 @@ type CreateUserRow struct {
 
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateUserRow, error) {
 	row := q.db.QueryRowContext(ctx, createUser,
+		arg.ID,
 		arg.Email,
 		arg.Nickname,
 		arg.Fullname,
@@ -129,7 +134,7 @@ LIMIT 1
 `
 
 type FindUserParams struct {
-	ID             sql.NullInt32
+	ID             uuid.NullUUID
 	Nickname       sql.NullString
 	Email          sql.NullString
 	FbUid          sql.NullString
@@ -137,7 +142,7 @@ type FindUserParams struct {
 }
 
 type FindUserRow struct {
-	ID              int32
+	ID              uuid.UUID
 	Email           string
 	Nickname        string
 	Fullname        string
@@ -194,7 +199,7 @@ LIMIT $1 OFFSET $2
 type FindUsersParams struct {
 	Limit          int32
 	Offset         int32
-	ID             sql.NullInt32
+	ID             uuid.NullUUID
 	Nickname       sql.NullString
 	Email          sql.NullString
 	FbUid          sql.NullString
@@ -202,7 +207,7 @@ type FindUsersParams struct {
 }
 
 type FindUsersRow struct {
-	ID              int32
+	ID              uuid.UUID
 	Nickname        string
 	ProfileImageUrl sql.NullString
 }
@@ -260,16 +265,16 @@ RETURNING
 
 type UpdateUserByFbUIDParams struct {
 	Nickname       string
-	ProfileImageID sql.NullInt64
+	ProfileImageID uuid.NullUUID
 	FbUid          sql.NullString
 }
 
 type UpdateUserByFbUIDRow struct {
-	ID             int32
+	ID             uuid.UUID
 	Email          string
 	Nickname       string
 	Fullname       string
-	ProfileImageID sql.NullInt64
+	ProfileImageID uuid.NullUUID
 	FbProviderType sql.NullString
 	FbUid          sql.NullString
 	CreatedAt      time.Time

--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"context"
-	"fmt"
-	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	"io"
+
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 
 	"github.com/google/uuid"
 
@@ -45,8 +45,6 @@ func (s *MediaService) UploadMedia(
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Println("created", created)
 
 	return created, nil
 }

--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -2,11 +2,14 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	"io"
+
+	"github.com/google/uuid"
 
 	bucketinfra "github.com/pet-sitter/pets-next-door-api/internal/infra/bucket"
 
-	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
@@ -43,6 +46,8 @@ func (s *MediaService) UploadMedia(
 		return nil, err
 	}
 
+	fmt.Println("created", created)
+
 	return created, nil
 }
 
@@ -56,6 +61,7 @@ func (s *MediaService) CreateMedia(
 	}
 
 	created, err2 := databasegen.New(s.conn).CreateMedia(ctx, databasegen.CreateMediaParams{
+		ID:        datatype.NewUUIDV7(),
 		MediaType: mediaType.String(),
 		Url:       url,
 	})
@@ -69,9 +75,9 @@ func (s *MediaService) CreateMedia(
 	return media.ToDetailViewFromCreated(created), nil
 }
 
-func (s *MediaService) FindMediaByID(ctx context.Context, id int64) (*media.DetailView, *pnd.AppError) {
+func (s *MediaService) FindMediaByID(ctx context.Context, id uuid.UUID) (*media.DetailView, *pnd.AppError) {
 	mediaData, err := databasegen.New(s.conn).FindSingleMedia(ctx, databasegen.FindSingleMediaParams{
-		ID: utils.Int64ToNullInt32(id),
+		ID: uuid.NullUUID{UUID: id, Valid: true},
 	})
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)

--- a/internal/service/sos_condition_service.go
+++ b/internal/service/sos_condition_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"

--- a/internal/service/sos_condition_service.go
+++ b/internal/service/sos_condition_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 
 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
 
@@ -32,7 +33,7 @@ func (service *SOSConditionService) InitConditions(ctx context.Context) (soscond
 	conditionList := make([]databasegen.SosCondition, len(soscondition.AvailableNames))
 	for idx, conditionName := range soscondition.AvailableNames {
 		created, err := databasegen.New(tx).CreateSOSCondition(ctx, databasegen.CreateSOSConditionParams{
-			ID:   int32(idx + 1),
+			ID:   datatype.NewUUIDV7(),
 			Name: utils.StrToNullStr(conditionName.String()),
 		})
 		if err != nil {

--- a/internal/service/sos_post_service.go
+++ b/internal/service/sos_post_service.go
@@ -1,540 +1,545 @@
 package service
 
-import (
-	"context"
-	"time"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/resourcemedia"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-
-	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
-	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
-
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
-)
-
-type SOSPostService struct {
-	conn *database.DB
-}
-
-func NewSOSPostService(conn *database.DB) *SOSPostService {
-	return &SOSPostService{
-		conn: conn,
-	}
-}
-
-func (service *SOSPostService) WriteSOSPost(
-	ctx context.Context, fbUID string, request *sospost.WriteSOSPostRequest,
-) (*sospost.DetailView, *pnd.AppError) {
-	tx, err := service.conn.BeginTx(ctx)
-	defer tx.Rollback()
-	if err != nil {
-		return nil, err
-	}
-	q := databasegen.New(tx)
-
-	userData, err2 := q.FindUser(ctx, databasegen.FindUserParams{
-		FbUid: utils.StrToNullStr(fbUID),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	thumbnailID := setThumbnailID(request.ImageIDs)
-	sosPost, err := service.createSOSPost(ctx, q, int64(userData.ID), request, thumbnailID)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := service.saveAllLinks(ctx, q, request, int(sosPost.ID)); err != nil {
-		return nil, err
-	}
-
-	mediaData, err2 := q.FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
-		ResourceID:   utils.IntToNullInt64(int(sosPost.ID)),
-		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	conditionList, err2 := q.FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
-		SosPostID: utils.IntToNullInt64(int(sosPost.ID)),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	petRows, err2 := q.FindPetsBySOSPostID(ctx, utils.IntToNullInt64(int(sosPost.ID)))
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	dates, err2 := q.FindDatesBySOSPostID(ctx, utils.IntToNullInt64(int(sosPost.ID)))
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	return sospost.CreateDetailView(
-		sosPost,
-		media.ToListViewFromResourceMediaRows(mediaData),
-		soscondition.ToListViewFromSOSPostConditions(conditionList),
-		pet.ToDetailViewList(petRows),
-		sospost.ToListViewFromSOSDateRows(dates),
-	), nil
-}
-
-func (service *SOSPostService) createSOSPost(
-	ctx context.Context, q *databasegen.Queries, authorID int64, request *sospost.WriteSOSPostRequest, thumbnailID *int64,
-) (databasegen.WriteSOSPostRow, *pnd.AppError) {
-	params := databasegen.WriteSOSPostParams{
-		AuthorID:    utils.IntToNullInt64(int(authorID)),
-		Title:       utils.StrToNullStr(request.Title),
-		Content:     utils.StrToNullStr(request.Content),
-		Reward:      utils.StrToNullStr(request.Reward),
-		CareType:    utils.StrToNullStr(string(request.CareType)),
-		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
-		RewardType:  utils.StrToNullStr(request.RewardType.String()),
-	}
-
-	if thumbnailID != nil {
-		params.ThumbnailID = utils.IntToNullInt64(int(*thumbnailID))
-	}
-
-	sosPost, err := q.WriteSOSPost(ctx, params)
-	if err != nil {
-		return databasegen.WriteSOSPostRow{}, pnd.FromPostgresError(err)
-	}
-
-	return sosPost, nil
-}
-
-func (service *SOSPostService) saveAllLinks(
-	ctx context.Context, q *databasegen.Queries, request *sospost.WriteSOSPostRequest, sosPostID int,
-) *pnd.AppError {
-	if err := service.SaveSOSDates(ctx, q, request.Dates, sosPostID); err != nil {
-		return err
-	}
-	if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, sosPostID); err != nil {
-		return err
-	}
-	if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, sosPostID); err != nil {
-		return err
-	}
-	return service.SaveLinkPets(ctx, q, request.PetIDs, sosPostID)
-}
-
-func (service *SOSPostService) FindSOSPosts(
-	ctx context.Context, page, size int, sortBy, filterType string,
-) (*sospost.FindSOSPostListView, *pnd.AppError) {
-	tx, err := service.conn.BeginTx(ctx)
-	defer tx.Rollback()
-	if err != nil {
-		return nil, err
-	}
-
-	sosPosts, err2 := databasegen.New(tx).FindSOSPosts(ctx, databasegen.FindSOSPostsParams{
-		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
-		PetType:             utils.StrToNullStr(filterType),
-		SortBy:              utils.StrToNullStr(sortBy),
-		Limit:               utils.IntToNullInt32(size + 1),
-		Offset:              utils.IntToNullInt32((page - 1) * size),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	sosPostInfoList := sospost.ToInfoListFromFindRow(sosPosts, page, size)
-	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
-
-	for _, sosPost := range sosPostInfoList.Items {
-		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-			ID:             utils.IntToNullInt32(sosPost.AuthorID),
-			IncludeDeleted: true,
-		})
-		if err != nil {
-			return nil, pnd.FromPostgresError(err)
-		}
-		sosPostView := sosPost.ToFindSOSPostInfoView(
-			&user.WithoutPrivateInfo{
-				ID:              int64(author.ID),
-				Nickname:        author.Nickname,
-				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
-			},
-			media.ToListViewFromViewListForSOSPost(sosPost.Media),
-			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
-			sosPost.Pets.ToDetailViewList(),
-			sosPost.Dates.ToSOSDateViewList(),
-		)
-		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
-	}
-
-	return sosPostViews, nil
-}
-
-func (service *SOSPostService) FindSOSPostsByAuthorID(
-	ctx context.Context, authorID, page, size int, sortBy, filterType string,
-) (*sospost.FindSOSPostListView, *pnd.AppError) {
-	tx, err := service.conn.BeginTx(ctx)
-	defer tx.Rollback()
-	if err != nil {
-		return nil, err
-	}
-
-	sosPosts, err2 := databasegen.New(tx).FindSOSPostsByAuthorID(ctx, databasegen.FindSOSPostsByAuthorIDParams{
-		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
-		PetType:             utils.StrToNullStr(filterType),
-		AuthorID:            utils.IntToNullInt64(authorID),
-		SortBy:              utils.StrToNullStr(sortBy),
-		Limit:               utils.IntToNullInt32(size + 1),
-		Offset:              utils.IntToNullInt32((page - 1) * size),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	sosPostInfoList := sospost.ToInfoListFromFindAuthorIDRow(sosPosts, page, size)
-	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
-
-	for _, sosPost := range sosPostInfoList.Items {
-		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-			ID:             utils.IntToNullInt32(sosPost.AuthorID),
-			IncludeDeleted: true,
-		})
-		if err != nil {
-			return nil, pnd.FromPostgresError(err)
-		}
-
-		sosPostView := sosPost.ToFindSOSPostInfoView(
-			&user.WithoutPrivateInfo{
-				ID:              int64(author.ID),
-				Nickname:        author.Nickname,
-				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
-			},
-			media.ToListViewFromViewListForSOSPost(sosPost.Media),
-			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
-			sosPost.Pets.ToDetailViewList(),
-			sosPost.Dates.ToSOSDateViewList(),
-		)
-
-		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
-	}
-	return sosPostViews, nil
-}
-
-func (service *SOSPostService) FindSOSPostByID(ctx context.Context, id int) (*sospost.FindSOSPostView, *pnd.AppError) {
-	tx, err := service.conn.BeginTx(ctx)
-	defer tx.Rollback()
-	if err != nil {
-		return nil, err
-	}
-
-	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, utils.IntToNullInt32(id))
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
-
-	author, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-		ID:             utils.IntToNullInt32(sosPostInfo.AuthorID),
-		IncludeDeleted: true,
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	return sosPostInfo.ToFindSOSPostInfoView(
-		&user.WithoutPrivateInfo{
-			ID:              int64(author.ID),
-			Nickname:        author.Nickname,
-			ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
-		},
-		media.ToListViewFromViewListForSOSPost(sosPostInfo.Media),
-		soscondition.ToListViewFromViewForSOSPost(sosPostInfo.Conditions),
-		sosPostInfo.Pets.ToDetailViewList(),
-		sosPostInfo.Dates.ToSOSDateViewList(),
-	), nil
-}
-
-func (service *SOSPostService) UpdateSOSPost(
-	ctx context.Context, request *sospost.UpdateSOSPostRequest,
-) (*sospost.DetailView, *pnd.AppError) {
-	tx, err := service.conn.BeginTx(ctx)
-	defer tx.Rollback()
-	if err != nil {
-		return nil, err
-	}
-	q := databasegen.New(tx)
-
-	if err2 := service.updateAllLinks(ctx, q, request); err2 != nil {
-		return nil, err2
-	}
-
-	thumbnailID := setThumbnailID(request.ImageIDs)
-	updateSOSPost, err := service.updateSOSPost(ctx, q, request, thumbnailID)
-	if err != nil {
-		return nil, err
-	}
-
-	mediaData, err2 := databasegen.New(tx).FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
-		ResourceID:   utils.IntToNullInt64(int(updateSOSPost.ID)),
-		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	conditionList, err2 := databasegen.New(tx).FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
-		SosPostID: utils.IntToNullInt64(int(updateSOSPost.ID)),
-	})
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	petRows, err2 := databasegen.New(tx).FindPetsBySOSPostID(ctx, utils.IntToNullInt64(int(updateSOSPost.ID)))
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	dates, err2 := q.FindDatesBySOSPostID(ctx, utils.IntToNullInt64(request.ID))
-	if err2 != nil {
-		return nil, pnd.FromPostgresError(err2)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	return sospost.UpdateDetailView(
-		updateSOSPost,
-		media.ToListViewFromResourceMediaRows(mediaData),
-		soscondition.ToListViewFromSOSPostConditions(conditionList),
-		pet.ToDetailViewList(petRows),
-		sospost.ToListViewFromSOSDateRows(dates),
-	), nil
-}
-
-func (service *SOSPostService) updateSOSPost(
-	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest, thumbnailID *int64,
-) (databasegen.UpdateSOSPostRow, *pnd.AppError) {
-	params := databasegen.UpdateSOSPostParams{
-		ID:          int32(request.ID),
-		Title:       utils.StrToNullStr(request.Title),
-		Content:     utils.StrToNullStr(request.Content),
-		Reward:      utils.StrToNullStr(request.Reward),
-		CareType:    utils.StrToNullStr(string(request.CareType)),
-		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
-		RewardType:  utils.StrToNullStr(request.RewardType.String()),
-	}
-
-	if thumbnailID != nil {
-		params.ThumbnailID = utils.IntToNullInt64(int(*thumbnailID))
-	}
-
-	updateSOSPost, err := q.UpdateSOSPost(ctx, params)
-	if err != nil {
-		return databasegen.UpdateSOSPostRow{}, pnd.FromPostgresError(err)
-	}
-
-	return updateSOSPost, nil
-}
-
-func (service *SOSPostService) updateAllLinks(
-	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest,
-) *pnd.AppError {
-	if err := service.DeleteLinkSOSPostDates(ctx, q, request.ID); err != nil {
-		return err
-	}
-	if err := service.SaveSOSDates(ctx, q, request.Dates, request.ID); err != nil {
-		return err
-	}
-
-	if err := service.DeleteLinkSOSPostImages(ctx, q, request.ID); err != nil {
-		return err
-	}
-	if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, request.ID); err != nil {
-		return err
-	}
-
-	if err := service.DeleteLinkSOSPostConditions(ctx, q, request.ID); err != nil {
-		return err
-	}
-	if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, request.ID); err != nil {
-		return err
-	}
-
-	if err := service.DeleteLinkSOSPostPets(ctx, q, request.ID); err != nil {
-		return err
-	}
-	return service.SaveLinkPets(ctx, q, request.PetIDs, request.ID)
-}
-
-func (service *SOSPostService) CheckUpdatePermission(
-	ctx context.Context, fbUID string, sosPostID int,
-) (bool, *pnd.AppError) {
-	tx, err := service.conn.BeginTx(ctx)
-	defer tx.Rollback()
-	if err != nil {
-		return false, err
-	}
-
-	userData, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-		FbUid: utils.StrToNullStr(fbUID),
-	})
-	if err2 != nil {
-		return false, pnd.FromPostgresError(err2)
-	}
-
-	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, utils.IntToNullInt32(sosPostID))
-	if err2 != nil {
-		return false, pnd.FromPostgresError(err2)
-	}
-	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
-
-	if err := tx.Commit(); err != nil {
-		return false, err
-	}
-
-	return int(userData.ID) == sosPostInfo.AuthorID, nil
-}
-
-func (service *SOSPostService) SaveSOSDates(
-	ctx context.Context, tx *databasegen.Queries, dates []sospost.SOSDateView, sosPostID int,
-) *pnd.AppError {
-	for _, date := range dates {
-		dateStartAt, err := utils.StrToNullTime(date.DateStartAt)
-		if err != nil {
-			return err
-		}
-		dateEndAt, err := utils.StrToNullTime(date.DateEndAt)
-		if err != nil {
-			return err
-		}
-
-		d, err2 := databasegen.New(service.conn).InsertSOSDate(ctx, databasegen.InsertSOSDateParams{
-			DateStartAt: dateStartAt,
-			DateEndAt:   dateEndAt,
-		})
-		if err2 != nil {
-			return pnd.FromPostgresError(err2)
-		}
-
-		err3 := tx.LinkSOSPostDate(ctx, databasegen.LinkSOSPostDateParams{
-			SosPostID:  utils.IntToNullInt64(sosPostID),
-			SosDatesID: utils.IntToNullInt64(int(d.ID)),
-		})
-		if err3 != nil {
-			return pnd.FromPostgresError(err3)
-		}
-	}
-	return nil
-}
-
-func (service *SOSPostService) SaveLinkSOSPostImage(
-	ctx context.Context, tx *databasegen.Queries, imageIDs []int64, sosPostID int,
-) *pnd.AppError {
-	for _, mediaID := range imageIDs {
-		err := tx.LinkResourceMedia(ctx, databasegen.LinkResourceMediaParams{
-			MediaID:      utils.IntToNullInt64(int(mediaID)),
-			ResourceID:   utils.IntToNullInt64(sosPostID),
-			ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
-		})
-		if err != nil {
-			return pnd.FromPostgresError(err)
-		}
-	}
-	return nil
-}
-
-func (service *SOSPostService) SaveLinkConditions(
-	ctx context.Context, tx *databasegen.Queries, conditionIDs []int, sosPostID int,
-) *pnd.AppError {
-	for _, conditionID := range conditionIDs {
-		err := tx.LinkSOSPostCondition(ctx, databasegen.LinkSOSPostConditionParams{
-			SosPostID:      utils.IntToNullInt64(sosPostID),
-			SosConditionID: utils.IntToNullInt64(conditionID),
-		})
-		if err != nil {
-			return pnd.FromPostgresError(err)
-		}
-	}
-	return nil
-}
-
-func (service *SOSPostService) SaveLinkPets(
-	ctx context.Context, tx *databasegen.Queries, petIDs []int64, sosPostID int,
-) *pnd.AppError {
-	for _, petID := range petIDs {
-		err := tx.LinkSOSPostPet(ctx, databasegen.LinkSOSPostPetParams{
-			SosPostID: utils.IntToNullInt64(sosPostID),
-			PetID:     utils.IntToNullInt64(int(petID)),
-		})
-		if err != nil {
-			return pnd.FromPostgresError(err)
-		}
-	}
-	return nil
-}
-
-func (service *SOSPostService) DeleteLinkSOSPostDates(
-	ctx context.Context, tx *databasegen.Queries, sosPostID int,
-) *pnd.AppError {
-	err := tx.DeleteSOSPostDateBySOSPostID(ctx, utils.IntPtrToNullInt64(&sosPostID))
-	if err != nil {
-		return pnd.FromPostgresError(err)
-	}
-	return nil
-}
-
-func (service *SOSPostService) DeleteLinkSOSPostImages(
-	ctx context.Context, tx *databasegen.Queries, sosPostID int,
-) *pnd.AppError {
-	err := tx.DeleteResourceMediaByResourceID(ctx, utils.IntToNullInt64(sosPostID))
-	if err != nil {
-		return pnd.FromPostgresError(err)
-	}
-	return nil
-}
-
-func (service *SOSPostService) DeleteLinkSOSPostConditions(
-	ctx context.Context, tx *databasegen.Queries, sosPostID int,
-) *pnd.AppError {
-	err := tx.DeleteSOSPostConditionBySOSPostID(ctx, utils.IntToNullInt64(sosPostID))
-	if err != nil {
-		return pnd.FromPostgresError(err)
-	}
-	return nil
-}
-
-func (service *SOSPostService) DeleteLinkSOSPostPets(
-	ctx context.Context, tx *databasegen.Queries, sosPostID int,
-) *pnd.AppError {
-	err := tx.DeleteSOSPostPetBySOSPostID(ctx, utils.IntToNullInt64(sosPostID))
-	if err != nil {
-		return pnd.FromPostgresError(err)
-	}
-	return nil
-}
-
-func setThumbnailID(imageIDs []int64) *int64 {
-	if len(imageIDs) > 0 {
-		return &imageIDs[0]
-	}
-	return nil
-}
+// import (
+// 	"github.com/google/uuid"
+// 	pnd "github.com/pet-sitter/pets-next-door-api/api"
+// 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
+// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
+// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/resourcemedia"
+// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
+// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
+// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
+// 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
+// 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
+// 	"log"
+// 	"time"
+// )
+//
+// type SOSPostService struct {
+// 	conn *database.DB
+// }
+//
+// func NewSOSPostService(conn *database.DB) *SOSPostService {
+// 	return &SOSPostService{
+// 		conn: conn,
+// 	}
+// }
+//
+// func (service *SOSPostService) WriteSOSPost(
+// 	ctx context.Context, fbUID string, request *sospost.WriteSOSPostRequest,
+// ) (*sospost.DetailView, *pnd.AppError) {
+// 	tx, err := service.conn.BeginTx(ctx)
+// 	defer tx.Rollback()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	q := databasegen.New(tx)
+//
+// 	userData, err2 := q.FindUser(ctx, databasegen.FindUserParams{
+// 		FbUid: utils.StrToNullStr(fbUID),
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	thumbnailID := setThumbnailID(request.ImageIDs)
+// 	sosPost, err := service.createSOSPost(ctx, q, userData.ID, request, thumbnailID)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	//if err := service.saveAllLinks(ctx, q, request, sosPost.ID); err != nil {
+// 	//	return nil, err
+// 	//}
+//
+// 	mediaData, err2 := q.FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
+// 		//ResourceID:   sosPost.ID,
+// 		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	conditionList, err2 := q.FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
+// 		//SosPostID: sosPost.ID,
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	//petRows, err2 := q.FindPetsBySOSPostID(ctx, sosPost.ID)
+// 	//if err2 != nil {
+// 	//	return nil, pnd.FromPostgresError(err2)
+// 	//}
+//
+// 	//dates, err2 := q.FindDatesBySOSPostID(ctx, sosPost.ID)
+// 	//if err2 != nil {
+// 	//	return nil, pnd.FromPostgresError(err2)
+// 	//}
+//
+// 	if err := tx.Commit(); err != nil {
+// 		return nil, err
+// 	}
+//
+// 	return sospost.CreateDetailView(
+// 		sosPost,
+// 		media.ToListViewFromResourceMediaRows(mediaData),
+// 		soscondition.ToListViewFromSOSPostConditions(conditionList),
+// 		//pet.ToDetailViewList(petRows),
+// 		nil,
+// 		//sospost.ToListViewFromSOSDateRows(dates),
+// 		nil,
+// 	), nil
+// }
+//
+// func (service *SOSPostService) createSOSPost(
+// 	ctx context.Context, q *databasegen.Queries, authorID uuid.UUID,
+//  request *sospost.WriteSOSPostRequest, thumbnailID uuid.NullUUID,
+// ) (databasegen.WriteSOSPostRow, *pnd.AppError) {
+// 	params := databasegen.WriteSOSPostParams{
+// 		//AuthorID:    authorID,
+// 		Title:       utils.StrToNullStr(request.Title),
+// 		Content:     utils.StrToNullStr(request.Content),
+// 		Reward:      utils.StrToNullStr(request.Reward),
+// 		CareType:    utils.StrToNullStr(string(request.CareType)),
+// 		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
+// 		RewardType:  utils.StrToNullStr(request.RewardType.String()),
+// 	}
+//
+// 	if thumbnailID.Valid {
+// 		params.ThumbnailID = thumbnailID
+// 	}
+//
+// 	sosPost, err := q.WriteSOSPost(ctx, params)
+// 	if err != nil {
+// 		return databasegen.WriteSOSPostRow{}, pnd.FromPostgresError(err)
+// 	}
+//
+// 	return sosPost, nil
+// }
+//
+// func (service *SOSPostService) saveAllLinks(
+// 	ctx context.Context, q *databasegen.Queries, request *sospost.WriteSOSPostRequest, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// if err := service.SaveSOSDates(ctx, q, request.Dates, sosPostID); err != nil {
+// 	return err
+// }
+// if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, sosPostID); err != nil {
+// 	return err
+// }
+// if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, sosPostID); err != nil {
+// 	return err
+// }
+// return service.SaveLinkPets(ctx, q, request.PetIDs, sosPostID)
+// }
+//
+// func (service *SOSPostService) FindSOSPosts(
+// 	ctx context.Context, page, size int, sortBy, filterType string,
+// ) (*sospost.FindSOSPostListView, *pnd.AppError) {
+// 	tx, err := service.conn.BeginTx(ctx)
+// 	defer tx.Rollback()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	sosPosts, err2 := databasegen.New(tx).FindSOSPosts(ctx, databasegen.FindSOSPostsParams{
+// 		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
+// 		PetType:             utils.StrToNullStr(filterType),
+// 		SortBy:              utils.StrToNullStr(sortBy),
+// 		Limit:               utils.IntToNullInt32(size + 1),
+// 		Offset:              utils.IntToNullInt32((page - 1) * size),
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	sosPostInfoList := sospost.ToInfoListFromFindRow(sosPosts, page, size)
+// 	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
+//
+// 	for _, sosPost := range sosPostInfoList.Items {
+// 		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+// 			//ID:             sosPost.AuthorID,
+// 			IncludeDeleted: true,
+// 		})
+// 		if err != nil {
+// 			return nil, pnd.FromPostgresError(err)
+// 		}
+// 		sosPostView := sosPost.ToFindSOSPostInfoView(
+// 			&user.WithoutPrivateInfo{
+// 				ID:              author.ID,
+// 				Nickname:        author.Nickname,
+// 				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
+// 			},
+// 			media.ToListViewFromViewListForSOSPost(sosPost.Media),
+// 			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
+// 			sosPost.Pets.ToDetailViewList(),
+// 			sosPost.Dates.ToSOSDateViewList(),
+// 		)
+// 		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
+// 	}
+//
+// 	return sosPostViews, nil
+// }
+//
+// func (service *SOSPostService) FindSOSPostsByAuthorID(
+// 	ctx context.Context, authorID, page, size int, sortBy, filterType string,
+// ) (*sospost.FindSOSPostListView, *pnd.AppError) {
+// 	tx, err := service.conn.BeginTx(ctx)
+// 	defer tx.Rollback()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	sosPosts, err2 := databasegen.New(tx).FindSOSPostsByAuthorID(ctx, databasegen.FindSOSPostsByAuthorIDParams{
+// 		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
+// 		PetType:             utils.StrToNullStr(filterType),
+// 		AuthorID:            utils.IntToNullInt64(authorID),
+// 		SortBy:              utils.StrToNullStr(sortBy),
+// 		Limit:               utils.IntToNullInt32(size + 1),
+// 		Offset:              utils.IntToNullInt32((page - 1) * size),
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	sosPostInfoList := sospost.ToInfoListFromFindAuthorIDRow(sosPosts, page, size)
+// 	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
+//
+// 	for _, sosPost := range sosPostInfoList.Items {
+// 		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+// 			//ID:             sosPost.AuthorID,
+// 			IncludeDeleted: true,
+// 		})
+// 		if err != nil {
+// 			return nil, pnd.FromPostgresError(err)
+// 		}
+//
+// 		sosPostView := sosPost.ToFindSOSPostInfoView(
+// 			&user.WithoutPrivateInfo{
+// 				ID:              author.ID,
+// 				Nickname:        author.Nickname,
+// 				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
+// 			},
+// 			media.ToListViewFromViewListForSOSPost(sosPost.Media),
+// 			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
+// 			sosPost.Pets.ToDetailViewList(),
+// 			sosPost.Dates.ToSOSDateViewList(),
+// 		)
+//
+// 		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
+// 	}
+// 	return sosPostViews, nil
+// }
+//
+// func (service *SOSPostService) FindSOSPostByID(
+//     ctx context.Context, id int
+// ) (*sospost.FindSOSPostView, *pnd.AppError) {
+// 	tx, err := service.conn.BeginTx(ctx)
+// 	defer tx.Rollback()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, utils.IntToNullInt32(id))
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+// 	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
+//
+// 	author, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+// 		//ID:             sosPostInfo.AuthorID,
+// 		IncludeDeleted: true,
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	if err := tx.Commit(); err != nil {
+// 		return nil, err
+// 	}
+//
+// 	return sosPostInfo.ToFindSOSPostInfoView(
+// 		&user.WithoutPrivateInfo{
+// 			ID:              author.ID,
+// 			Nickname:        author.Nickname,
+// 			ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
+// 		},
+// 		media.ToListViewFromViewListForSOSPost(sosPostInfo.Media),
+// 		soscondition.ToListViewFromViewForSOSPost(sosPostInfo.Conditions),
+// 		sosPostInfo.Pets.ToDetailViewList(),
+// 		sosPostInfo.Dates.ToSOSDateViewList(),
+// 	), nil
+// }
+//
+// func (service *SOSPostService) UpdateSOSPost(
+// 	ctx context.Context, request *sospost.UpdateSOSPostRequest,
+// ) (*sospost.DetailView, *pnd.AppError) {
+// 	tx, err := service.conn.BeginTx(ctx)
+// 	defer tx.Rollback()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	q := databasegen.New(tx)
+//
+// 	if err2 := service.updateAllLinks(ctx, q, request); err2 != nil {
+// 		return nil, err2
+// 	}
+//
+// 	thumbnailID := setThumbnailID(request.ImageIDs)
+// 	updateSOSPost, err := service.updateSOSPost(ctx, q, request, thumbnailID)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	mediaData, err2 := databasegen.New(tx).FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
+// 		//ResourceID: updateSOSPost.ID),
+// 		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	conditionList, err2 := databasegen.New(tx).FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
+// 		//SosPostID: updateSOSPost.ID),
+// 	})
+// 	if err2 != nil {
+// 		return nil, pnd.FromPostgresError(err2)
+// 	}
+//
+// petRows, err2 := databasegen.New(tx).FindPetsBySOSPostID(ctx, updateSOSPost.ID)
+// if err2 != nil {
+// 	return nil, pnd.FromPostgresError(err2)
+// }
+//
+// dates, err2 := q.FindDatesBySOSPostID(ctx, request.ID)
+// if err2 != nil {
+// 	return nil, pnd.FromPostgresError(err2)
+// }
+//
+// 	if err := tx.Commit(); err != nil {
+// 		return nil, err
+// 	}
+//
+// 	return sospost.UpdateDetailView(
+// 		updateSOSPost,
+// 		media.ToListViewFromResourceMediaRows(mediaData),
+// 		soscondition.ToListViewFromSOSPostConditions(conditionList),
+// 		//pet.ToDetailViewList(petRows),
+// 		nil,
+// 		//sospost.ToListViewFromSOSDateRows(dates),
+// 		nil,
+// 	), nil
+// }
+//
+// func (service *SOSPostService) updateSOSPost(
+// 	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest, thumbnailID uuid.NullUUID,
+// ) (databasegen.UpdateSOSPostRow, *pnd.AppError) {
+// 	params := databasegen.UpdateSOSPostParams{
+// 		//ID:          request.ID,
+// 		Title:       utils.StrToNullStr(request.Title),
+// 		Content:     utils.StrToNullStr(request.Content),
+// 		Reward:      utils.StrToNullStr(request.Reward),
+// 		CareType:    utils.StrToNullStr(string(request.CareType)),
+// 		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
+// 		RewardType:  utils.StrToNullStr(request.RewardType.String()),
+// 	}
+//
+// 	if thumbnailID.Valid {
+// 		params.ThumbnailID = thumbnailID
+// 	}
+//
+// 	updateSOSPost, err := q.UpdateSOSPost(ctx, params)
+// 	if err != nil {
+// 		return databasegen.UpdateSOSPostRow{}, pnd.FromPostgresError(err)
+// 	}
+//
+// 	return updateSOSPost, nil
+// }
+//
+// func (service *SOSPostService) updateAllLinks(
+// 	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest,
+// ) *pnd.AppError {
+// 	if err := service.DeleteLinkSOSPostDates(ctx, q, request.ID); err != nil {
+// 		return err
+// 	}
+// if err := service.SaveSOSDates(ctx, q, request.Dates, request.ID); err != nil {
+// 	return err
+// }
+//
+// if err := service.DeleteLinkSOSPostImages(ctx, q, request.ID); err != nil {
+// 	return err
+// }
+// if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, request.ID); err != nil {
+// 	return err
+// }
+//
+// if err := service.DeleteLinkSOSPostConditions(ctx, q, request.ID); err != nil {
+// 	return err
+// }
+// if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, request.ID); err != nil {
+// 	return err
+// }
+//
+// if err := service.DeleteLinkSOSPostPets(ctx, q, request.ID); err != nil {
+// 	return err
+// }
+// return service.SaveLinkPets(ctx, q, request.PetIDs, request.ID)
+// }
+//
+// func (service *SOSPostService) CheckUpdatePermission(
+// 	ctx context.Context, fbUID string, sosPostID int,
+// ) (bool, *pnd.AppError) {
+// 	tx, err := service.conn.BeginTx(ctx)
+// 	defer tx.Rollback()
+// 	if err != nil {
+// 		return false, err
+// 	}
+//
+// 	userData, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+// 		FbUid: utils.StrToNullStr(fbUID),
+// 	})
+// 	if err2 != nil {
+// 		return false, pnd.FromPostgresError(err2)
+// 	}
+//
+// 	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, utils.IntToNullInt32(sosPostID))
+// 	if err2 != nil {
+// 		return false, pnd.FromPostgresError(err2)
+// 	}
+// 	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
+//
+// 	if err := tx.Commit(); err != nil {
+// 		return false, err
+// 	}
+//
+// 	return userData.ID == sosPostInfo.AuthorID, nil
+// }
+//
+// func (service *SOSPostService) SaveSOSDates(
+// 	ctx context.Context, tx *databasegen.Queries, dates []sospost.SOSDateView, sosPostID int,
+// ) *pnd.AppError {
+// for _, date := range dates {
+// dateStartAt, err := utils.StrToNullTime(date.DateStartAt)
+// if err != nil {
+// 	return err
+// }
+// dateEndAt, err := utils.StrToNullTime(date.DateEndAt)
+// if err != nil {
+// 	return err
+// }
+//
+// d, err2 := databasegen.New(service.conn).InsertSOSDate(ctx, databasegen.InsertSOSDateParams{
+// 	DateStartAt: dateStartAt,
+// 	DateEndAt:   dateEndAt,
+// })
+// if err2 != nil {
+// 	return pnd.FromPostgresError(err2)
+// }
+//
+// err3 := tx.LinkSOSPostDate(ctx, databasegen.LinkSOSPostDateParams{
+// SosPostID:  sosPostID,
+// SosDatesID: d.ID,
+// })
+// if err3 != nil {
+// 	return pnd.FromPostgresError(err3)
+// }
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) SaveLinkSOSPostImage(
+// 	ctx context.Context, tx *databasegen.Queries, imageIDs []uuid.UUID, sosPostID int,
+// ) *pnd.AppError {
+// 	for _, mediaID := range imageIDs {
+// 		log.Default().Println("mediaID", mediaID)
+// 		err := tx.LinkResourceMedia(ctx, databasegen.LinkResourceMediaParams{
+// 			//MediaID:      mediaID,
+// 			//ResourceID:   sosPostID,
+// 			ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
+// 		})
+// 		if err != nil {
+// 			return pnd.FromPostgresError(err)
+// 		}
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) SaveLinkConditions(
+// 	ctx context.Context, tx *databasegen.Queries, conditionIDs []int, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// 	for _, conditionID := range conditionIDs {
+// 		log.Default().Println("conditionID", conditionID)
+// 		err := tx.LinkSOSPostCondition(ctx, databasegen.LinkSOSPostConditionParams{
+// 			SosPostID: sosPostID,
+// 			//SosConditionID: conditionID,
+// 		})
+// 		if err != nil {
+// 			return pnd.FromPostgresError(err)
+// 		}
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) SaveLinkPets(
+// 	ctx context.Context, tx *databasegen.Queries, petIDs []int64, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// 	for _, petID := range petIDs {
+// 		log.Default().Println("petID", petID)
+// 		err := tx.LinkSOSPostPet(ctx, databasegen.LinkSOSPostPetParams{
+// 			SosPostID: sosPostID,
+// 			//PetID:     petID,
+// 		})
+// 		if err != nil {
+// 			return pnd.FromPostgresError(err)
+// 		}
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) DeleteLinkSOSPostDates(
+// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// 	err := tx.DeleteSOSPostDateBySOSPostID(ctx, sosPostID)
+// 	if err != nil {
+// 		return pnd.FromPostgresError(err)
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) DeleteLinkSOSPostImages(
+// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// 	err := tx.DeleteResourceMediaByResourceID(ctx, sosPostID)
+// 	if err != nil {
+// 		return pnd.FromPostgresError(err)
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) DeleteLinkSOSPostConditions(
+// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// 	err := tx.DeleteSOSPostConditionBySOSPostID(ctx, sosPostID)
+// 	if err != nil {
+// 		return pnd.FromPostgresError(err)
+// 	}
+// 	return nil
+// }
+//
+// func (service *SOSPostService) DeleteLinkSOSPostPets(
+// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+// ) *pnd.AppError {
+// 	err := tx.DeleteSOSPostPetBySOSPostID(ctx, sosPostID)
+// 	if err != nil {
+// 		return pnd.FromPostgresError(err)
+// 	}
+// 	return nil
+// }
+//
+// func setThumbnailID(imageIDs []uuid.UUID) uuid.NullUUID {
+// 	if len(imageIDs) > 0 {
+// 		return uuid.NullUUID{UUID: imageIDs[0], Valid: true}
+// 	}
+// 	return uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+// }
+//

--- a/internal/service/sos_post_service.go
+++ b/internal/service/sos_post_service.go
@@ -1,545 +1,550 @@
 package service
 
-// import (
-// 	"github.com/google/uuid"
-// 	pnd "github.com/pet-sitter/pets-next-door-api/api"
-// 	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
-// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
-// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/resourcemedia"
-// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
-// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
-// 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
-// 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
-// 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
-// 	"log"
-// 	"time"
-// )
-//
-// type SOSPostService struct {
-// 	conn *database.DB
-// }
-//
-// func NewSOSPostService(conn *database.DB) *SOSPostService {
-// 	return &SOSPostService{
-// 		conn: conn,
-// 	}
-// }
-//
-// func (service *SOSPostService) WriteSOSPost(
-// 	ctx context.Context, fbUID string, request *sospost.WriteSOSPostRequest,
-// ) (*sospost.DetailView, *pnd.AppError) {
-// 	tx, err := service.conn.BeginTx(ctx)
-// 	defer tx.Rollback()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	q := databasegen.New(tx)
-//
-// 	userData, err2 := q.FindUser(ctx, databasegen.FindUserParams{
-// 		FbUid: utils.StrToNullStr(fbUID),
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	thumbnailID := setThumbnailID(request.ImageIDs)
-// 	sosPost, err := service.createSOSPost(ctx, q, userData.ID, request, thumbnailID)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	//if err := service.saveAllLinks(ctx, q, request, sosPost.ID); err != nil {
-// 	//	return nil, err
-// 	//}
-//
-// 	mediaData, err2 := q.FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
-// 		//ResourceID:   sosPost.ID,
-// 		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	conditionList, err2 := q.FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
-// 		//SosPostID: sosPost.ID,
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	//petRows, err2 := q.FindPetsBySOSPostID(ctx, sosPost.ID)
-// 	//if err2 != nil {
-// 	//	return nil, pnd.FromPostgresError(err2)
-// 	//}
-//
-// 	//dates, err2 := q.FindDatesBySOSPostID(ctx, sosPost.ID)
-// 	//if err2 != nil {
-// 	//	return nil, pnd.FromPostgresError(err2)
-// 	//}
-//
-// 	if err := tx.Commit(); err != nil {
-// 		return nil, err
-// 	}
-//
-// 	return sospost.CreateDetailView(
-// 		sosPost,
-// 		media.ToListViewFromResourceMediaRows(mediaData),
-// 		soscondition.ToListViewFromSOSPostConditions(conditionList),
-// 		//pet.ToDetailViewList(petRows),
-// 		nil,
-// 		//sospost.ToListViewFromSOSDateRows(dates),
-// 		nil,
-// 	), nil
-// }
-//
-// func (service *SOSPostService) createSOSPost(
-// 	ctx context.Context, q *databasegen.Queries, authorID uuid.UUID,
-//  request *sospost.WriteSOSPostRequest, thumbnailID uuid.NullUUID,
-// ) (databasegen.WriteSOSPostRow, *pnd.AppError) {
-// 	params := databasegen.WriteSOSPostParams{
-// 		//AuthorID:    authorID,
-// 		Title:       utils.StrToNullStr(request.Title),
-// 		Content:     utils.StrToNullStr(request.Content),
-// 		Reward:      utils.StrToNullStr(request.Reward),
-// 		CareType:    utils.StrToNullStr(string(request.CareType)),
-// 		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
-// 		RewardType:  utils.StrToNullStr(request.RewardType.String()),
-// 	}
-//
-// 	if thumbnailID.Valid {
-// 		params.ThumbnailID = thumbnailID
-// 	}
-//
-// 	sosPost, err := q.WriteSOSPost(ctx, params)
-// 	if err != nil {
-// 		return databasegen.WriteSOSPostRow{}, pnd.FromPostgresError(err)
-// 	}
-//
-// 	return sosPost, nil
-// }
-//
-// func (service *SOSPostService) saveAllLinks(
-// 	ctx context.Context, q *databasegen.Queries, request *sospost.WriteSOSPostRequest, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// if err := service.SaveSOSDates(ctx, q, request.Dates, sosPostID); err != nil {
-// 	return err
-// }
-// if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, sosPostID); err != nil {
-// 	return err
-// }
-// if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, sosPostID); err != nil {
-// 	return err
-// }
-// return service.SaveLinkPets(ctx, q, request.PetIDs, sosPostID)
-// }
-//
-// func (service *SOSPostService) FindSOSPosts(
-// 	ctx context.Context, page, size int, sortBy, filterType string,
-// ) (*sospost.FindSOSPostListView, *pnd.AppError) {
-// 	tx, err := service.conn.BeginTx(ctx)
-// 	defer tx.Rollback()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	sosPosts, err2 := databasegen.New(tx).FindSOSPosts(ctx, databasegen.FindSOSPostsParams{
-// 		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
-// 		PetType:             utils.StrToNullStr(filterType),
-// 		SortBy:              utils.StrToNullStr(sortBy),
-// 		Limit:               utils.IntToNullInt32(size + 1),
-// 		Offset:              utils.IntToNullInt32((page - 1) * size),
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	sosPostInfoList := sospost.ToInfoListFromFindRow(sosPosts, page, size)
-// 	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
-//
-// 	for _, sosPost := range sosPostInfoList.Items {
-// 		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-// 			//ID:             sosPost.AuthorID,
-// 			IncludeDeleted: true,
-// 		})
-// 		if err != nil {
-// 			return nil, pnd.FromPostgresError(err)
-// 		}
-// 		sosPostView := sosPost.ToFindSOSPostInfoView(
-// 			&user.WithoutPrivateInfo{
-// 				ID:              author.ID,
-// 				Nickname:        author.Nickname,
-// 				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
-// 			},
-// 			media.ToListViewFromViewListForSOSPost(sosPost.Media),
-// 			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
-// 			sosPost.Pets.ToDetailViewList(),
-// 			sosPost.Dates.ToSOSDateViewList(),
-// 		)
-// 		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
-// 	}
-//
-// 	return sosPostViews, nil
-// }
-//
-// func (service *SOSPostService) FindSOSPostsByAuthorID(
-// 	ctx context.Context, authorID, page, size int, sortBy, filterType string,
-// ) (*sospost.FindSOSPostListView, *pnd.AppError) {
-// 	tx, err := service.conn.BeginTx(ctx)
-// 	defer tx.Rollback()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	sosPosts, err2 := databasegen.New(tx).FindSOSPostsByAuthorID(ctx, databasegen.FindSOSPostsByAuthorIDParams{
-// 		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
-// 		PetType:             utils.StrToNullStr(filterType),
-// 		AuthorID:            utils.IntToNullInt64(authorID),
-// 		SortBy:              utils.StrToNullStr(sortBy),
-// 		Limit:               utils.IntToNullInt32(size + 1),
-// 		Offset:              utils.IntToNullInt32((page - 1) * size),
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	sosPostInfoList := sospost.ToInfoListFromFindAuthorIDRow(sosPosts, page, size)
-// 	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
-//
-// 	for _, sosPost := range sosPostInfoList.Items {
-// 		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-// 			//ID:             sosPost.AuthorID,
-// 			IncludeDeleted: true,
-// 		})
-// 		if err != nil {
-// 			return nil, pnd.FromPostgresError(err)
-// 		}
-//
-// 		sosPostView := sosPost.ToFindSOSPostInfoView(
-// 			&user.WithoutPrivateInfo{
-// 				ID:              author.ID,
-// 				Nickname:        author.Nickname,
-// 				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
-// 			},
-// 			media.ToListViewFromViewListForSOSPost(sosPost.Media),
-// 			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
-// 			sosPost.Pets.ToDetailViewList(),
-// 			sosPost.Dates.ToSOSDateViewList(),
-// 		)
-//
-// 		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
-// 	}
-// 	return sosPostViews, nil
-// }
-//
-// func (service *SOSPostService) FindSOSPostByID(
-//     ctx context.Context, id int
-// ) (*sospost.FindSOSPostView, *pnd.AppError) {
-// 	tx, err := service.conn.BeginTx(ctx)
-// 	defer tx.Rollback()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, utils.IntToNullInt32(id))
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-// 	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
-//
-// 	author, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-// 		//ID:             sosPostInfo.AuthorID,
-// 		IncludeDeleted: true,
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	if err := tx.Commit(); err != nil {
-// 		return nil, err
-// 	}
-//
-// 	return sosPostInfo.ToFindSOSPostInfoView(
-// 		&user.WithoutPrivateInfo{
-// 			ID:              author.ID,
-// 			Nickname:        author.Nickname,
-// 			ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
-// 		},
-// 		media.ToListViewFromViewListForSOSPost(sosPostInfo.Media),
-// 		soscondition.ToListViewFromViewForSOSPost(sosPostInfo.Conditions),
-// 		sosPostInfo.Pets.ToDetailViewList(),
-// 		sosPostInfo.Dates.ToSOSDateViewList(),
-// 	), nil
-// }
-//
-// func (service *SOSPostService) UpdateSOSPost(
-// 	ctx context.Context, request *sospost.UpdateSOSPostRequest,
-// ) (*sospost.DetailView, *pnd.AppError) {
-// 	tx, err := service.conn.BeginTx(ctx)
-// 	defer tx.Rollback()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	q := databasegen.New(tx)
-//
-// 	if err2 := service.updateAllLinks(ctx, q, request); err2 != nil {
-// 		return nil, err2
-// 	}
-//
-// 	thumbnailID := setThumbnailID(request.ImageIDs)
-// 	updateSOSPost, err := service.updateSOSPost(ctx, q, request, thumbnailID)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	mediaData, err2 := databasegen.New(tx).FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
-// 		//ResourceID: updateSOSPost.ID),
-// 		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	conditionList, err2 := databasegen.New(tx).FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
-// 		//SosPostID: updateSOSPost.ID),
-// 	})
-// 	if err2 != nil {
-// 		return nil, pnd.FromPostgresError(err2)
-// 	}
-//
-// petRows, err2 := databasegen.New(tx).FindPetsBySOSPostID(ctx, updateSOSPost.ID)
-// if err2 != nil {
-// 	return nil, pnd.FromPostgresError(err2)
-// }
-//
-// dates, err2 := q.FindDatesBySOSPostID(ctx, request.ID)
-// if err2 != nil {
-// 	return nil, pnd.FromPostgresError(err2)
-// }
-//
-// 	if err := tx.Commit(); err != nil {
-// 		return nil, err
-// 	}
-//
-// 	return sospost.UpdateDetailView(
-// 		updateSOSPost,
-// 		media.ToListViewFromResourceMediaRows(mediaData),
-// 		soscondition.ToListViewFromSOSPostConditions(conditionList),
-// 		//pet.ToDetailViewList(petRows),
-// 		nil,
-// 		//sospost.ToListViewFromSOSDateRows(dates),
-// 		nil,
-// 	), nil
-// }
-//
-// func (service *SOSPostService) updateSOSPost(
-// 	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest, thumbnailID uuid.NullUUID,
-// ) (databasegen.UpdateSOSPostRow, *pnd.AppError) {
-// 	params := databasegen.UpdateSOSPostParams{
-// 		//ID:          request.ID,
-// 		Title:       utils.StrToNullStr(request.Title),
-// 		Content:     utils.StrToNullStr(request.Content),
-// 		Reward:      utils.StrToNullStr(request.Reward),
-// 		CareType:    utils.StrToNullStr(string(request.CareType)),
-// 		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
-// 		RewardType:  utils.StrToNullStr(request.RewardType.String()),
-// 	}
-//
-// 	if thumbnailID.Valid {
-// 		params.ThumbnailID = thumbnailID
-// 	}
-//
-// 	updateSOSPost, err := q.UpdateSOSPost(ctx, params)
-// 	if err != nil {
-// 		return databasegen.UpdateSOSPostRow{}, pnd.FromPostgresError(err)
-// 	}
-//
-// 	return updateSOSPost, nil
-// }
-//
-// func (service *SOSPostService) updateAllLinks(
-// 	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest,
-// ) *pnd.AppError {
-// 	if err := service.DeleteLinkSOSPostDates(ctx, q, request.ID); err != nil {
-// 		return err
-// 	}
-// if err := service.SaveSOSDates(ctx, q, request.Dates, request.ID); err != nil {
-// 	return err
-// }
-//
-// if err := service.DeleteLinkSOSPostImages(ctx, q, request.ID); err != nil {
-// 	return err
-// }
-// if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, request.ID); err != nil {
-// 	return err
-// }
-//
-// if err := service.DeleteLinkSOSPostConditions(ctx, q, request.ID); err != nil {
-// 	return err
-// }
-// if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, request.ID); err != nil {
-// 	return err
-// }
-//
-// if err := service.DeleteLinkSOSPostPets(ctx, q, request.ID); err != nil {
-// 	return err
-// }
-// return service.SaveLinkPets(ctx, q, request.PetIDs, request.ID)
-// }
-//
-// func (service *SOSPostService) CheckUpdatePermission(
-// 	ctx context.Context, fbUID string, sosPostID int,
-// ) (bool, *pnd.AppError) {
-// 	tx, err := service.conn.BeginTx(ctx)
-// 	defer tx.Rollback()
-// 	if err != nil {
-// 		return false, err
-// 	}
-//
-// 	userData, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
-// 		FbUid: utils.StrToNullStr(fbUID),
-// 	})
-// 	if err2 != nil {
-// 		return false, pnd.FromPostgresError(err2)
-// 	}
-//
-// 	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, utils.IntToNullInt32(sosPostID))
-// 	if err2 != nil {
-// 		return false, pnd.FromPostgresError(err2)
-// 	}
-// 	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
-//
-// 	if err := tx.Commit(); err != nil {
-// 		return false, err
-// 	}
-//
-// 	return userData.ID == sosPostInfo.AuthorID, nil
-// }
-//
-// func (service *SOSPostService) SaveSOSDates(
-// 	ctx context.Context, tx *databasegen.Queries, dates []sospost.SOSDateView, sosPostID int,
-// ) *pnd.AppError {
-// for _, date := range dates {
-// dateStartAt, err := utils.StrToNullTime(date.DateStartAt)
-// if err != nil {
-// 	return err
-// }
-// dateEndAt, err := utils.StrToNullTime(date.DateEndAt)
-// if err != nil {
-// 	return err
-// }
-//
-// d, err2 := databasegen.New(service.conn).InsertSOSDate(ctx, databasegen.InsertSOSDateParams{
-// 	DateStartAt: dateStartAt,
-// 	DateEndAt:   dateEndAt,
-// })
-// if err2 != nil {
-// 	return pnd.FromPostgresError(err2)
-// }
-//
-// err3 := tx.LinkSOSPostDate(ctx, databasegen.LinkSOSPostDateParams{
-// SosPostID:  sosPostID,
-// SosDatesID: d.ID,
-// })
-// if err3 != nil {
-// 	return pnd.FromPostgresError(err3)
-// }
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) SaveLinkSOSPostImage(
-// 	ctx context.Context, tx *databasegen.Queries, imageIDs []uuid.UUID, sosPostID int,
-// ) *pnd.AppError {
-// 	for _, mediaID := range imageIDs {
-// 		log.Default().Println("mediaID", mediaID)
-// 		err := tx.LinkResourceMedia(ctx, databasegen.LinkResourceMediaParams{
-// 			//MediaID:      mediaID,
-// 			//ResourceID:   sosPostID,
-// 			ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
-// 		})
-// 		if err != nil {
-// 			return pnd.FromPostgresError(err)
-// 		}
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) SaveLinkConditions(
-// 	ctx context.Context, tx *databasegen.Queries, conditionIDs []int, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// 	for _, conditionID := range conditionIDs {
-// 		log.Default().Println("conditionID", conditionID)
-// 		err := tx.LinkSOSPostCondition(ctx, databasegen.LinkSOSPostConditionParams{
-// 			SosPostID: sosPostID,
-// 			//SosConditionID: conditionID,
-// 		})
-// 		if err != nil {
-// 			return pnd.FromPostgresError(err)
-// 		}
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) SaveLinkPets(
-// 	ctx context.Context, tx *databasegen.Queries, petIDs []int64, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// 	for _, petID := range petIDs {
-// 		log.Default().Println("petID", petID)
-// 		err := tx.LinkSOSPostPet(ctx, databasegen.LinkSOSPostPetParams{
-// 			SosPostID: sosPostID,
-// 			//PetID:     petID,
-// 		})
-// 		if err != nil {
-// 			return pnd.FromPostgresError(err)
-// 		}
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) DeleteLinkSOSPostDates(
-// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// 	err := tx.DeleteSOSPostDateBySOSPostID(ctx, sosPostID)
-// 	if err != nil {
-// 		return pnd.FromPostgresError(err)
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) DeleteLinkSOSPostImages(
-// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// 	err := tx.DeleteResourceMediaByResourceID(ctx, sosPostID)
-// 	if err != nil {
-// 		return pnd.FromPostgresError(err)
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) DeleteLinkSOSPostConditions(
-// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// 	err := tx.DeleteSOSPostConditionBySOSPostID(ctx, sosPostID)
-// 	if err != nil {
-// 		return pnd.FromPostgresError(err)
-// 	}
-// 	return nil
-// }
-//
-// func (service *SOSPostService) DeleteLinkSOSPostPets(
-// 	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
-// ) *pnd.AppError {
-// 	err := tx.DeleteSOSPostPetBySOSPostID(ctx, sosPostID)
-// 	if err != nil {
-// 		return pnd.FromPostgresError(err)
-// 	}
-// 	return nil
-// }
-//
-// func setThumbnailID(imageIDs []uuid.UUID) uuid.NullUUID {
-// 	if len(imageIDs) > 0 {
-// 		return uuid.NullUUID{UUID: imageIDs[0], Valid: true}
-// 	}
-// 	return uuid.NullUUID{UUID: uuid.Nil, Valid: false}
-// }
-//
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+	pnd "github.com/pet-sitter/pets-next-door-api/api"
+	utils "github.com/pet-sitter/pets-next-door-api/internal/common"
+	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/resourcemedia"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
+	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
+	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
+)
+
+type SOSPostService struct {
+	conn *database.DB
+}
+
+func NewSOSPostService(conn *database.DB) *SOSPostService {
+	return &SOSPostService{
+		conn: conn,
+	}
+}
+
+func (service *SOSPostService) WriteSOSPost(
+	ctx context.Context, fbUID string, request *sospost.WriteSOSPostRequest,
+) (*sospost.DetailView, *pnd.AppError) {
+	tx, err := service.conn.BeginTx(ctx)
+	defer tx.Rollback()
+	if err != nil {
+		return nil, err
+	}
+	q := databasegen.New(tx)
+
+	userData, err2 := q.FindUser(ctx, databasegen.FindUserParams{
+		FbUid: utils.StrToNullStr(fbUID),
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	thumbnailID := setThumbnailID(request.ImageIDs)
+	sosPost, err := service.createSOSPost(ctx, q, userData.ID, request, thumbnailID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := service.saveAllLinks(ctx, q, request, sosPost.ID); err != nil {
+		return nil, err
+	}
+
+	mediaData, err2 := q.FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
+		ResourceID:   uuid.NullUUID{UUID: sosPost.ID, Valid: true},
+		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	conditionList, err2 := q.FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
+		SosPostID: sosPost.ID,
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	petRows, err2 := q.FindPetsBySOSPostID(ctx, sosPost.ID)
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	dates, err2 := q.FindDatesBySOSPostID(ctx, uuid.NullUUID{UUID: sosPost.ID, Valid: true})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return sospost.CreateDetailView(
+		sosPost,
+		media.ToListViewFromResourceMediaRows(mediaData),
+		soscondition.ToListViewFromSOSPostConditions(conditionList),
+		pet.ToDetailViewList(petRows),
+		sospost.ToListViewFromSOSDateRows(dates),
+	), nil
+}
+
+func (service *SOSPostService) createSOSPost(
+	ctx context.Context, q *databasegen.Queries, authorID uuid.UUID,
+	request *sospost.WriteSOSPostRequest, thumbnailID uuid.NullUUID,
+) (databasegen.WriteSOSPostRow, *pnd.AppError) {
+	params := databasegen.WriteSOSPostParams{
+		ID:          datatype.NewUUIDV7(),
+		AuthorID:    authorID,
+		Title:       utils.StrToNullStr(request.Title),
+		Content:     utils.StrToNullStr(request.Content),
+		Reward:      utils.StrToNullStr(request.Reward),
+		CareType:    utils.StrToNullStr(string(request.CareType)),
+		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
+		RewardType:  utils.StrToNullStr(request.RewardType.String()),
+	}
+
+	if thumbnailID.Valid {
+		params.ThumbnailID = thumbnailID
+	}
+
+	sosPost, err := q.WriteSOSPost(ctx, params)
+	if err != nil {
+		return databasegen.WriteSOSPostRow{}, pnd.FromPostgresError(err)
+	}
+
+	return sosPost, nil
+}
+
+func (service *SOSPostService) saveAllLinks(
+	ctx context.Context, q *databasegen.Queries, request *sospost.WriteSOSPostRequest, sosPostID uuid.UUID,
+) *pnd.AppError {
+	if err := service.SaveSOSDates(ctx, q, request.Dates, sosPostID); err != nil {
+		return err
+	}
+	if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, sosPostID); err != nil {
+		return err
+	}
+	if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, sosPostID); err != nil {
+		return err
+	}
+	return service.SaveLinkPets(ctx, q, request.PetIDs, sosPostID)
+}
+
+func (service *SOSPostService) FindSOSPosts(
+	ctx context.Context, page, size int, sortBy, filterType string,
+) (*sospost.FindSOSPostListView, *pnd.AppError) {
+	tx, err := service.conn.BeginTx(ctx)
+	defer tx.Rollback()
+	if err != nil {
+		return nil, err
+	}
+
+	sosPosts, err2 := databasegen.New(tx).FindSOSPosts(ctx, databasegen.FindSOSPostsParams{
+		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
+		PetType:             utils.StrToNullStr(filterType),
+		SortBy:              utils.StrToNullStr(sortBy),
+		Limit:               utils.IntToNullInt32(size + 1),
+		Offset:              utils.IntToNullInt32((page - 1) * size),
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	sosPostInfoList := sospost.ToInfoListFromFindRow(sosPosts, page, size)
+	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
+
+	for _, sosPost := range sosPostInfoList.Items {
+		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+			ID:             uuid.NullUUID{UUID: sosPost.AuthorID, Valid: true},
+			IncludeDeleted: true,
+		})
+		if err != nil {
+			return nil, pnd.FromPostgresError(err)
+		}
+		sosPostView := sosPost.ToFindSOSPostInfoView(
+			&user.WithoutPrivateInfo{
+				ID:              author.ID,
+				Nickname:        author.Nickname,
+				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
+			},
+			media.ToListViewFromViewListForSOSPost(sosPost.Media),
+			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
+			sosPost.Pets.ToDetailViewList(),
+			sosPost.Dates.ToSOSDateViewList(),
+		)
+		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
+	}
+
+	return sosPostViews, nil
+}
+
+func (service *SOSPostService) FindSOSPostsByAuthorID(
+	ctx context.Context, authorID uuid.UUID, page, size int, sortBy, filterType string,
+) (*sospost.FindSOSPostListView, *pnd.AppError) {
+	tx, err := service.conn.BeginTx(ctx)
+	defer tx.Rollback()
+	if err != nil {
+		return nil, err
+	}
+
+	sosPosts, err2 := databasegen.New(tx).FindSOSPostsByAuthorID(ctx, databasegen.FindSOSPostsByAuthorIDParams{
+		EarliestDateStartAt: utils.FormatDateString(time.Now().String()),
+		PetType:             utils.StrToNullStr(filterType),
+		AuthorID:            uuid.NullUUID{UUID: authorID, Valid: true},
+		SortBy:              utils.StrToNullStr(sortBy),
+		Limit:               utils.IntToNullInt32(size + 1),
+		Offset:              utils.IntToNullInt32((page - 1) * size),
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	sosPostInfoList := sospost.ToInfoListFromFindAuthorIDRow(sosPosts, page, size)
+	sosPostViews := sospost.FromEmptySOSPostInfoList(sosPostInfoList)
+
+	for _, sosPost := range sosPostInfoList.Items {
+		author, err := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+			ID:             uuid.NullUUID{UUID: sosPost.AuthorID, Valid: true},
+			IncludeDeleted: true,
+		})
+		if err != nil {
+			return nil, pnd.FromPostgresError(err)
+		}
+
+		sosPostView := sosPost.ToFindSOSPostInfoView(
+			&user.WithoutPrivateInfo{
+				ID:              author.ID,
+				Nickname:        author.Nickname,
+				ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
+			},
+			media.ToListViewFromViewListForSOSPost(sosPost.Media),
+			soscondition.ToListViewFromViewForSOSPost(sosPost.Conditions),
+			sosPost.Pets.ToDetailViewList(),
+			sosPost.Dates.ToSOSDateViewList(),
+		)
+
+		sosPostViews.Items = append(sosPostViews.Items, *sosPostView)
+	}
+	return sosPostViews, nil
+}
+
+func (service *SOSPostService) FindSOSPostByID(
+	ctx context.Context, id uuid.UUID,
+) (*sospost.FindSOSPostView, *pnd.AppError) {
+	tx, err := service.conn.BeginTx(ctx)
+	defer tx.Rollback()
+	if err != nil {
+		return nil, err
+	}
+
+	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, uuid.NullUUID{UUID: id, Valid: true})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
+
+	author, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+		ID:             uuid.NullUUID{UUID: sosPostInfo.AuthorID, Valid: true},
+		IncludeDeleted: true,
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return sosPostInfo.ToFindSOSPostInfoView(
+		&user.WithoutPrivateInfo{
+			ID:              author.ID,
+			Nickname:        author.Nickname,
+			ProfileImageURL: utils.NullStrToStrPtr(author.ProfileImageUrl),
+		},
+		media.ToListViewFromViewListForSOSPost(sosPostInfo.Media),
+		soscondition.ToListViewFromViewForSOSPost(sosPostInfo.Conditions),
+		sosPostInfo.Pets.ToDetailViewList(),
+		sosPostInfo.Dates.ToSOSDateViewList(),
+	), nil
+}
+
+func (service *SOSPostService) UpdateSOSPost(
+	ctx context.Context, request *sospost.UpdateSOSPostRequest,
+) (*sospost.DetailView, *pnd.AppError) {
+	tx, err := service.conn.BeginTx(ctx)
+	defer tx.Rollback()
+	if err != nil {
+		return nil, err
+	}
+	q := databasegen.New(tx)
+
+	if err2 := service.updateAllLinks(ctx, q, request); err2 != nil {
+		return nil, err2
+	}
+
+	thumbnailID := setThumbnailID(request.ImageIDs)
+	updateSOSPost, err := service.updateSOSPost(ctx, q, request, thumbnailID)
+	if err != nil {
+		return nil, err
+	}
+
+	mediaData, err2 := databasegen.New(tx).FindResourceMedia(ctx, databasegen.FindResourceMediaParams{
+		ResourceID:   uuid.NullUUID{UUID: updateSOSPost.ID, Valid: true},
+		ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	conditionList, err2 := databasegen.New(tx).FindSOSPostConditions(ctx, databasegen.FindSOSPostConditionsParams{
+		SosPostID: updateSOSPost.ID,
+	})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	petRows, err2 := databasegen.New(tx).FindPetsBySOSPostID(ctx, updateSOSPost.ID)
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	dates, err2 := q.FindDatesBySOSPostID(ctx, uuid.NullUUID{UUID: request.ID, Valid: true})
+	if err2 != nil {
+		return nil, pnd.FromPostgresError(err2)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return sospost.UpdateDetailView(
+		updateSOSPost,
+		media.ToListViewFromResourceMediaRows(mediaData),
+		soscondition.ToListViewFromSOSPostConditions(conditionList),
+		pet.ToDetailViewList(petRows),
+		sospost.ToListViewFromSOSDateRows(dates),
+	), nil
+}
+
+func (service *SOSPostService) updateSOSPost(
+	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest, thumbnailID uuid.NullUUID,
+) (databasegen.UpdateSOSPostRow, *pnd.AppError) {
+	params := databasegen.UpdateSOSPostParams{
+		ID:          request.ID,
+		Title:       utils.StrToNullStr(request.Title),
+		Content:     utils.StrToNullStr(request.Content),
+		Reward:      utils.StrToNullStr(request.Reward),
+		CareType:    utils.StrToNullStr(string(request.CareType)),
+		CarerGender: utils.StrToNullStr(request.CarerGender.String()),
+		RewardType:  utils.StrToNullStr(request.RewardType.String()),
+	}
+
+	if thumbnailID.Valid {
+		params.ThumbnailID = thumbnailID
+	}
+
+	updateSOSPost, err := q.UpdateSOSPost(ctx, params)
+	if err != nil {
+		return databasegen.UpdateSOSPostRow{}, pnd.FromPostgresError(err)
+	}
+
+	return updateSOSPost, nil
+}
+
+func (service *SOSPostService) updateAllLinks(
+	ctx context.Context, q *databasegen.Queries, request *sospost.UpdateSOSPostRequest,
+) *pnd.AppError {
+	if err := service.DeleteLinkSOSPostDates(ctx, q, request.ID); err != nil {
+		return err
+	}
+	if err := service.SaveSOSDates(ctx, q, request.Dates, request.ID); err != nil {
+		return err
+	}
+
+	if err := service.DeleteLinkSOSPostImages(ctx, q, request.ID); err != nil {
+		return err
+	}
+	if err := service.SaveLinkSOSPostImage(ctx, q, request.ImageIDs, request.ID); err != nil {
+		return err
+	}
+
+	if err := service.DeleteLinkSOSPostConditions(ctx, q, request.ID); err != nil {
+		return err
+	}
+	if err := service.SaveLinkConditions(ctx, q, request.ConditionIDs, request.ID); err != nil {
+		return err
+	}
+
+	if err := service.DeleteLinkSOSPostPets(ctx, q, request.ID); err != nil {
+		return err
+	}
+	return service.SaveLinkPets(ctx, q, request.PetIDs, request.ID)
+}
+
+func (service *SOSPostService) CheckUpdatePermission(
+	ctx context.Context, fbUID string, sosPostID uuid.UUID,
+) (bool, *pnd.AppError) {
+	tx, err := service.conn.BeginTx(ctx)
+	defer tx.Rollback()
+	if err != nil {
+		return false, err
+	}
+
+	userData, err2 := databasegen.New(tx).FindUser(ctx, databasegen.FindUserParams{
+		FbUid: utils.StrToNullStr(fbUID),
+	})
+	if err2 != nil {
+		return false, pnd.FromPostgresError(err2)
+	}
+
+	sosPost, err2 := databasegen.New(tx).FindSOSPostByID(ctx, uuid.NullUUID{UUID: sosPostID, Valid: true})
+	if err2 != nil {
+		return false, pnd.FromPostgresError(err2)
+	}
+	sosPostInfo := sospost.ToInfoFromFindByIDRow(sosPost)
+
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+
+	return userData.ID == sosPostInfo.AuthorID, nil
+}
+
+func (service *SOSPostService) SaveSOSDates(
+	ctx context.Context, tx *databasegen.Queries, dates []sospost.SOSDateView, sosPostID uuid.UUID,
+) *pnd.AppError {
+	for _, date := range dates {
+		dateStartAt, err := utils.StrToNullTime(date.DateStartAt)
+		if err != nil {
+			return err
+		}
+		dateEndAt, err := utils.StrToNullTime(date.DateEndAt)
+		if err != nil {
+			return err
+		}
+
+		d, err2 := databasegen.New(service.conn).InsertSOSDate(ctx, databasegen.InsertSOSDateParams{
+			ID:          datatype.NewUUIDV7(),
+			DateStartAt: dateStartAt,
+			DateEndAt:   dateEndAt,
+		})
+		if err2 != nil {
+			return pnd.FromPostgresError(err2)
+		}
+
+		err3 := tx.LinkSOSPostDate(ctx, databasegen.LinkSOSPostDateParams{
+			ID:         datatype.NewUUIDV7(),
+			SosPostID:  sosPostID,
+			SosDatesID: d.ID,
+		})
+		if err3 != nil {
+			return pnd.FromPostgresError(err3)
+		}
+	}
+	return nil
+}
+
+func (service *SOSPostService) SaveLinkSOSPostImage(
+	ctx context.Context, tx *databasegen.Queries, imageIDs []uuid.UUID, sosPostID uuid.UUID,
+) *pnd.AppError {
+	for _, mediaID := range imageIDs {
+		log.Default().Println("mediaID", mediaID)
+		err := tx.LinkResourceMedia(ctx, databasegen.LinkResourceMediaParams{
+			ID:           datatype.NewUUIDV7(),
+			MediaID:      mediaID,
+			ResourceID:   sosPostID,
+			ResourceType: utils.StrToNullStr(resourcemedia.SOSResourceType.String()),
+		})
+		if err != nil {
+			return pnd.FromPostgresError(err)
+		}
+	}
+	return nil
+}
+
+func (service *SOSPostService) SaveLinkConditions(
+	ctx context.Context, tx *databasegen.Queries, conditionIDs []uuid.UUID, sosPostID uuid.UUID,
+) *pnd.AppError {
+	for _, conditionID := range conditionIDs {
+		log.Default().Println("conditionID", conditionID)
+		err := tx.LinkSOSPostCondition(ctx, databasegen.LinkSOSPostConditionParams{
+			ID:             datatype.NewUUIDV7(),
+			SosPostID:      sosPostID,
+			SosConditionID: uuid.NullUUID{UUID: conditionID, Valid: true},
+		})
+		if err != nil {
+			return pnd.FromPostgresError(err)
+		}
+	}
+	return nil
+}
+
+func (service *SOSPostService) SaveLinkPets(
+	ctx context.Context, tx *databasegen.Queries, petIDs []uuid.UUID, sosPostID uuid.UUID,
+) *pnd.AppError {
+	for _, petID := range petIDs {
+		log.Default().Println("petID", petID)
+		err := tx.LinkSOSPostPet(ctx, databasegen.LinkSOSPostPetParams{
+			ID:        datatype.NewUUIDV7(),
+			SosPostID: sosPostID,
+			PetID:     petID,
+		})
+		if err != nil {
+			return pnd.FromPostgresError(err)
+		}
+	}
+	return nil
+}
+
+func (service *SOSPostService) DeleteLinkSOSPostDates(
+	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+) *pnd.AppError {
+	err := tx.DeleteSOSPostDateBySOSPostID(ctx, sosPostID)
+	if err != nil {
+		return pnd.FromPostgresError(err)
+	}
+	return nil
+}
+
+func (service *SOSPostService) DeleteLinkSOSPostImages(
+	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+) *pnd.AppError {
+	err := tx.DeleteResourceMediaByResourceID(ctx, sosPostID)
+	if err != nil {
+		return pnd.FromPostgresError(err)
+	}
+	return nil
+}
+
+func (service *SOSPostService) DeleteLinkSOSPostConditions(
+	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+) *pnd.AppError {
+	err := tx.DeleteSOSPostConditionBySOSPostID(ctx, sosPostID)
+	if err != nil {
+		return pnd.FromPostgresError(err)
+	}
+	return nil
+}
+
+func (service *SOSPostService) DeleteLinkSOSPostPets(
+	ctx context.Context, tx *databasegen.Queries, sosPostID uuid.UUID,
+) *pnd.AppError {
+	err := tx.DeleteSOSPostPetBySOSPostID(ctx, sosPostID)
+	if err != nil {
+		return pnd.FromPostgresError(err)
+	}
+	return nil
+}
+
+func setThumbnailID(imageIDs []uuid.UUID) uuid.NullUUID {
+	if len(imageIDs) > 0 {
+		return uuid.NullUUID{UUID: imageIDs[0], Valid: true}
+	}
+	return uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+}

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -1,428 +1,509 @@
 package service_test
 
-// func setUp(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
-// 	t.Helper()
-// 	db, tearDown := tests.SetUp(t)
-//
-// 	conditionService := service.NewSOSConditionService(db)
-// 	if _, err2 := conditionService.InitConditions(ctx); err2 != nil {
-// 		t.Errorf("InitConditions failed: %v", err2)
-// 	}
-//
-// 	return db, tearDown
-// }
-//
-// func TestCreateSOSPost(t *testing.T) {
-// 	t.Run("돌봄 급구 게시글을 작성한다", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
-// 		addPets, _ := userService.AddPetsToOwner(
-// 			ctx,
-// 			owner.FirebaseUID,
-// 			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 			}},
-// 		)
-//
-// 		// when
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-// 		sosPostData := tests.NewDummyWriteSOSPostRequest(
-// 			[]int64{sosPostImage.ID, sosPostImage2.ID},
-// 			[]int64{addPets.Pets[0].ID},
-// 			0,
-// 		)
-// 		created, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, tests.NewDummyWriteSOSPostRequest(
-// 			[]int64{sosPostImage.ID, sosPostImage2.ID},
-// 			[]int64{addPets.Pets[0].ID},
-// 			0,
-// 		))
-//
-// 		// then
-// 		found, _ := sosPostService.FindSOSPostByID(ctx, created.ID)
-// 		asserts.ConditionIDEquals(t, sosPostData.ConditionIDs, found.Conditions)
-// 		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
-// 		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-// 		asserts.DatesEquals(t, sosPostData.Dates, found.Dates)
-// 		writtenAndFoundSOSPostEquals(t, *sosPostData, *found)
-// 		assert.Equal(t, owner.ID, int64(created.AuthorID))
-// 	})
-// }
-//
-// func TestFindSOSPosts(t *testing.T) {
-// 	t.Run("전체 돌봄 급구 게시글을 조회한다", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-//
-// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-// 		owner, _ := userService.RegisterUser(ctx, userRequest)
-// 		addPets, _ := userService.AddPetsToOwner(
-// 			ctx,
-// 			owner.FirebaseUID,
-// 			pet.AddPetsToOwnerRequest{
-// 				Pets: []pet.AddPetRequest{
-// 					*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 				},
-// 			},
-// 		)
-//
-// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-// 		petIDs := []int64{addPets.Pets[0].ID}
-// 		conditionIDs := []int{1, 2}
-//
-// 		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
-// 		var sosPosts []sospost.DetailView
-// 		for i := 1; i < 4; i++ {
-// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, petIDs, i)
-// 			sosPost, _ := sosPostService.WriteSOSPost(
-// 				ctx, owner.FirebaseUID, request,
-// 			)
-// 			sosPosts = append(sosPosts, *sosPost)
-// 			sosPostRequests = append(sosPostRequests, *request)
-// 		}
-//
-// 		// when
-// 		foundList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
-// 		if err != nil {
-// 			t.Errorf("got %v want %v", err, nil)
-// 		}
-//
-// 		// then
-// 		for i, found := range foundList.Items {
-// 			idx := len(foundList.Items) - i - 1
-// 			asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
-// 			assertPetEquals(t, addPets.Pets[0], found.Pets[0])
-// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-// 			assert.Equal(t, owner.ID, found.Author.ID)
-// 			asserts.DatesEquals(t, sosPosts[idx].Dates, found.Dates)
-// 			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], found)
-// 		}
-// 	})
-//
-// 	t.Run("전체 돌봄 급구 게시글의 정렬기준을 'deadline'으로 조회한다", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-//
-// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-// 		owner, _ := userService.RegisterUser(ctx, userRequest)
-// 		uid := owner.FirebaseUID
-// 		addPetRequest, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
-// 			Pets: []pet.AddPetRequest{
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeCat, pet.GenderMale, "munchkin"),
-// 			},
-// 		})
-//
-// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-// 		conditionIDs := []int{1, 2}
-//
-// 		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
-// 		for i := 1; i < 4; i++ {
-// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{addPetRequest.Pets[i-1].ID}, i)
-// 			sosPostService.WriteSOSPost(ctx, uid, request)
-// 			sosPostRequests = append(sosPostRequests, *request)
-// 		}
-//
-// 		// when
-// 		sosPostList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
-//
-// 		// then
-// 		for i, sosPost := range sosPostList.Items {
-// 			idx := len(sosPostList.Items) - i - 1
-// 			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
-// 			assertPetEquals(t, addPetRequest.Pets[i-1], sosPost.Pets[i-1])
-// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
-// 			assert.Equal(t, owner.ID, sosPost.Author.ID)
-// 			asserts.DatesEquals(t, sosPostRequests[idx].Dates, sosPost.Dates)
-// 			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], sosPost)
-// 		}
-// 	})
-//
-// 	t.Run("전체 돌봄 급구 게시글 중 반려동물이 'dog'인 경우만 조회한다", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
-//
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-// 		uid := owner.FirebaseUID
-// 		petList, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
-// 			Pets: []pet.AddPetRequest{
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeCat, pet.GenderMale, "munchkin"),
-// 			},
-// 		})
-//
-// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-// 		conditionIDs := []int{1, 2}
-//
-// 		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
-// 		// 강아지인 경우
-// 		for i := 1; i < 3; i++ {
-// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[i-1].ID}, i)
-// 			sosPostService.WriteSOSPost(ctx, uid, request)
-// 			writeRequests = append(writeRequests, *request)
-// 		}
-//
-// 		// 고양이인 경우
-// 		request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[2].ID}, 3)
-// 		sosPostService.WriteSOSPost(ctx, uid, request)
-// 		writeRequests = append(writeRequests, *request)
-//
-// 		// 강아지, 고양이인 경우
-// 		request = tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[1].ID, petList.Pets[2].ID}, 4)
-// 		sosPostService.WriteSOSPost(ctx, uid, request)
-// 		writeRequests = append(writeRequests, *request)
-//
-// 		// when
-// 		foundList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
-//
-// 		// then
-// 		for i, sosPost := range foundList.Items {
-// 			idx := len(foundList.Items) - i - 1
-// 			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
-// 			assertPetEquals(t, petList.Pets[i-1], sosPost.Pets[i-1])
-// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
-// 			assert.Equal(t, owner.ID, sosPost.Author.ID)
-// 			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
-// 			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
-// 		}
-// 	})
-//
-// 	t.Run("작성자 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-//
-// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-// 		owner, _ := userService.RegisterUser(ctx, userRequest)
-// 		author := &user.WithoutPrivateInfo{
-// 			ID:              owner.ID,
-// 			ProfileImageURL: owner.ProfileImageURL,
-// 			Nickname:        owner.Nickname,
-// 		}
-// 		petList, _ := userService.AddPetsToOwner(
-// 			ctx,
-// 			owner.FirebaseUID,
-// 			pet.AddPetsToOwnerRequest{
-// 				Pets: []pet.AddPetRequest{
-// 					*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 				},
-// 			},
-// 		)
-//
-// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-// 		conditionIDs := []int{1, 2}
-//
-// 		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
-// 		for i := 1; i < 4; i++ {
-// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[0].ID}, i)
-// 			sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
-// 			writeRequests = append(writeRequests, *request)
-// 		}
-//
-// 		// when
-// 		foundList, _ := sosPostService.FindSOSPostsByAuthorID(ctx, int(owner.ID), 1, 3, "newest", "all")
-//
-// 		// then
-// 		for i, sosPost := range foundList.Items {
-// 			idx := len(foundList.Items) - i - 1
-// 			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
-// 			assertPetEquals(t, petList.Pets[0], sosPost.Pets[0])
-// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
-// 			assert.Equal(t, author.ID, sosPost.Author.ID)
-// 			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
-// 			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
-// 		}
-// 	})
-// }
-//
-// func TestFindSOSPostByID(t *testing.T) {
-// 	t.Run("게시글 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-//
-// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-// 		owner, _ := userService.RegisterUser(ctx, userRequest)
-// 		author := &user.WithoutPrivateInfo{
-// 			ID:              owner.ID,
-// 			ProfileImageURL: owner.ProfileImageURL,
-// 			Nickname:        owner.Nickname,
-// 		}
-// 		addPets, _ := userService.AddPetsToOwner(
-// 			ctx,
-// 			owner.FirebaseUID,
-// 			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 			}},
-// 		)
-//
-// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-// 		conditionIDs := []int{1, 2}
-//
-// 		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
-// 		writtenIDs := make([]int64, 0)
-// 		for i := 1; i < 4; i++ {
-// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{addPets.Pets[0].ID}, i)
-// 			sosPost, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
-// 			writeRequests = append(writeRequests, *request)
-// 			writtenIDs = append(writtenIDs, int64(sosPost.ID))
-// 		}
-//
-// 		// when
-// 		found, _ := sosPostService.FindSOSPostByID(ctx, int(writtenIDs[0]))
-//
-// 		// then
-// 		asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
-// 		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
-// 		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-// 		assert.Equal(t, author.ID, found.Author.ID)
-// 		asserts.DatesEquals(t, writeRequests[0].Dates, found.Dates)
-// 		writtenAndFoundSOSPostEquals(t, writeRequests[0], *found)
-// 	})
-// }
-//
-// func TestUpdateSOSPost(t *testing.T) {
-// 	t.Run("돌봄 급구 게시글을 수정합니다.", func(t *testing.T) {
-// 		ctx := context.Background()
-// 		db, tearDown := setUp(ctx, t)
-// 		defer tearDown(t)
-// 		mediaService := tests.NewMockMediaService(db)
-// 		userService := tests.NewMockUserService(db)
-// 		sosPostService := tests.NewMockSOSPostService(db)
-//
-// 		// given
-// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-//
-// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-// 		owner, _ := userService.RegisterUser(ctx, userRequest)
-// 		addPets, _ := userService.AddPetsToOwner(
-// 			ctx,
-// 			owner.FirebaseUID,
-// 			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
-// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-// 			}},
-// 		)
-//
-// 		sosPost, _ := sosPostService.WriteSOSPost(
-// 			ctx, owner.FirebaseUID,
-//			tests.NewDummyWriteSOSPostRequest([]int64{sosPostImage.ID}, []int64{addPets.Pets[0].ID}, 1),
-// 		)
-//
-// 		// when
-// 		updateRequest := &sospost.UpdateSOSPostRequest{
-// 			ID:       sosPost.ID,
-// 			Title:    "Title2",
-// 			Content:  "Content2",
-// 			ImageIDs: []int64{sosPostImage.ID, sosPostImage2.ID},
-// 			Reward:   "Reward2",
-// 			Dates: []sospost.SOSDateView{
-// 				{"2024-04-10", "2024-04-20"},
-// 				{"2024-05-10", "2024-05-20"},
-// 			},
-// 			CareType:     sospost.CareTypeFoster,
-// 			CarerGender:  sospost.CarerGenderMale,
-// 			RewardType:   sospost.RewardTypeFee,
-// 			ConditionIDs: []int{1, 2},
-// 			PetIDs:       []int64{addPets.Pets[0].ID},
-// 		}
-// 		updated, _ := sosPostService.UpdateSOSPost(ctx, updateRequest)
-//
-// 		// then
-// 		found, _ := sosPostService.FindSOSPostByID(ctx, sosPost.ID)
-// 		asserts.ConditionIDEquals(t, updateRequest.ConditionIDs, found.Conditions)
-// 		assertPetEquals(t, sosPost.Pets[0], found.Pets[0])
-// 		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-// 		asserts.DatesEquals(t, updateRequest.Dates, found.Dates)
-// 		assert.Equal(t, updateRequest.Title, found.Title)
-// 		assert.Equal(t, updateRequest.Content, found.Content)
-// 		assert.Equal(t, updateRequest.Reward, found.Reward)
-// 		assert.Equal(t, updateRequest.CareType, found.CareType)
-// 		assert.Equal(t, updateRequest.CarerGender, found.CarerGender)
-// 		assert.Equal(t, updateRequest.RewardType, found.RewardType)
-// 		assert.Equal(t, &updateRequest.ImageIDs[0], found.ThumbnailID)
-// 		assert.Equal(t, int64(updated.AuthorID), owner.ID)
-// 	})
-// }
-//
-// func assertPetEquals(t *testing.T, want, got pet.DetailView) {
-// 	t.Helper()
-//
-// 	assert.Equal(t, want.ID, got.ID)
-// 	assert.Equal(t, want.Name, got.Name)
-// 	assert.Equal(t, want.PetType, got.PetType)
-// 	assert.Equal(t, want.Sex, got.Sex)
-// 	assert.Equal(t, want.Neutered, got.Neutered)
-// 	assert.Equal(t, want.Breed, got.Breed)
-// 	assert.Equal(t, want.BirthDate, got.BirthDate)
-// 	assert.Equal(t, want.WeightInKg.String(), got.WeightInKg.String())
-// 	assert.Equal(t, want.Remarks, got.Remarks)
-// 	assert.Equal(t, want.ProfileImageURL, got.ProfileImageURL)
-// }
-//
-// func writtenAndFoundSOSPostEquals(t *testing.T, want sospost.WriteSOSPostRequest, got sospost.FindSOSPostView) {
-// 	t.Helper()
-//
-// 	assert.Equal(t, want.Title, got.Title)
-// 	assert.Equal(t, want.Content, got.Content)
-// 	assert.Equal(t, want.Reward, got.Reward)
-// 	assert.Equal(t, want.CareType, got.CareType)
-// 	assert.Equal(t, want.CarerGender, got.CarerGender)
-// 	assert.Equal(t, want.RewardType, got.RewardType)
-// 	assert.Equal(t, &want.ImageIDs[0], got.ThumbnailID)
-// }
-//
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
+	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
+	"github.com/pet-sitter/pets-next-door-api/internal/service"
+	"github.com/pet-sitter/pets-next-door-api/internal/tests"
+	"github.com/pet-sitter/pets-next-door-api/internal/tests/asserts"
+	"github.com/stretchr/testify/assert"
+)
+
+func setUp(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
+	t.Helper()
+	db, tearDown := tests.SetUp(t)
+
+	conditionService := service.NewSOSConditionService(db)
+	if _, err2 := conditionService.InitConditions(ctx); err2 != nil {
+		t.Errorf("InitConditions failed: %v", err2)
+	}
+
+	return db, tearDown
+}
+
+func TestCreateSOSPost(t *testing.T) {
+	t.Run("돌봄 급구 게시글을 작성한다", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		owner, _ := userService.RegisterUser(
+			ctx,
+			tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true}),
+		)
+		addPets, _ := userService.AddPetsToOwner(
+			ctx,
+			owner.FirebaseUID,
+			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true},
+					commonvo.PetTypeDog, pet.GenderMale,
+					"poodle",
+				),
+			}},
+		)
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+
+		// when
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+		sosPostData := tests.NewDummyWriteSOSPostRequest(
+			[]uuid.UUID{sosPostImage.ID, sosPostImage2.ID},
+			[]uuid.UUID{addPets.Pets[0].ID},
+			0,
+			conditionIDs,
+		)
+		created, err := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, tests.NewDummyWriteSOSPostRequest(
+			[]uuid.UUID{sosPostImage.ID, sosPostImage2.ID},
+			[]uuid.UUID{addPets.Pets[0].ID},
+			0,
+			conditionIDs,
+		))
+		if err != nil {
+			t.Errorf("got %v want %v", err, nil)
+		}
+
+		// then
+		found, err := sosPostService.FindSOSPostByID(ctx, created.ID)
+		if err != nil {
+			t.Errorf("got %v want %v", err, nil)
+		}
+		asserts.ConditionIDEquals(t, sosPostData.ConditionIDs, found.Conditions)
+		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
+		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+		asserts.DatesEquals(t, sosPostData.Dates, found.Dates)
+		writtenAndFoundSOSPostEquals(t, *sosPostData, *found)
+		assert.Equal(t, owner.ID, created.AuthorID)
+	})
+}
+
+func TestFindSOSPosts(t *testing.T) {
+	t.Run("전체 돌봄 급구 게시글을 조회한다", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
+		owner, _ := userService.RegisterUser(ctx, userRequest)
+		addPets, _ := userService.AddPetsToOwner(
+			ctx,
+			owner.FirebaseUID,
+			pet.AddPetsToOwnerRequest{
+				Pets: []pet.AddPetRequest{
+					*tests.NewDummyAddPetRequest(
+						uuid.NullUUID{UUID: profileImage.ID, Valid: true},
+						commonvo.PetTypeDog,
+						pet.GenderMale,
+						"poodle",
+					),
+				},
+			},
+		)
+
+		imageIDs := []uuid.UUID{sosPostImage.ID, sosPostImage2.ID}
+		petIDs := []uuid.UUID{addPets.Pets[0].ID}
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+
+		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
+		var sosPosts []sospost.DetailView
+		for i := 1; i < 4; i++ {
+			request := tests.NewDummyWriteSOSPostRequest(imageIDs, petIDs, i, conditionIDs)
+			sosPost, _ := sosPostService.WriteSOSPost(
+				ctx, owner.FirebaseUID, request,
+			)
+			sosPosts = append(sosPosts, *sosPost)
+			sosPostRequests = append(sosPostRequests, *request)
+		}
+
+		// when
+		foundList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
+		if err != nil {
+			t.Errorf("got %v want %v", err, nil)
+		}
+
+		// then
+		for i, found := range foundList.Items {
+			idx := len(foundList.Items) - i - 1
+			asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
+			assertPetEquals(t, addPets.Pets[0], found.Pets[0])
+			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+			assert.Equal(t, owner.ID, found.Author.ID)
+			asserts.DatesEquals(t, sosPosts[idx].Dates, found.Dates)
+			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], found)
+		}
+	})
+
+	t.Run("전체 돌봄 급구 게시글의 정렬기준을 'deadline'으로 조회한다", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
+		owner, _ := userService.RegisterUser(ctx, userRequest)
+		uid := owner.FirebaseUID
+		addPetRequest, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
+			Pets: []pet.AddPetRequest{
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true},
+					commonvo.PetTypeDog,
+					pet.GenderMale,
+					"poodle",
+				),
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true},
+					commonvo.PetTypeDog,
+					pet.GenderMale,
+					"poodle",
+				),
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true},
+					commonvo.PetTypeCat,
+					pet.GenderMale,
+					"munchkin",
+				),
+			},
+		})
+
+		imageIDs := []uuid.UUID{sosPostImage.ID, sosPostImage2.ID}
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+
+		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
+		for i := 1; i < 4; i++ {
+			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []uuid.UUID{addPetRequest.Pets[i-1].ID}, i, conditionIDs)
+			sosPostService.WriteSOSPost(ctx, uid, request)
+			sosPostRequests = append(sosPostRequests, *request)
+		}
+
+		// when
+		sosPostList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
+
+		// then
+		for i, sosPost := range sosPostList.Items {
+			idx := len(sosPostList.Items) - i - 1
+			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
+			assertPetEquals(t, addPetRequest.Pets[i-1], sosPost.Pets[i-1])
+			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
+			assert.Equal(t, owner.ID, sosPost.Author.ID)
+			asserts.DatesEquals(t, sosPostRequests[idx].Dates, sosPost.Dates)
+			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], sosPost)
+		}
+	})
+
+	t.Run("전체 돌봄 급구 게시글 중 반려동물이 'dog'인 경우만 조회한다", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		owner, _ := userService.RegisterUser(
+			ctx,
+			tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true}),
+		)
+
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+		uid := owner.FirebaseUID
+		petList, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
+			Pets: []pet.AddPetRequest{
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true}, commonvo.PetTypeDog, pet.GenderMale, "poodle",
+				),
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true}, commonvo.PetTypeDog, pet.GenderMale, "poodle",
+				),
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true}, commonvo.PetTypeCat, pet.GenderMale, "munchkin",
+				),
+			},
+		})
+
+		imageIDs := []uuid.UUID{sosPostImage.ID, sosPostImage2.ID}
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+
+		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
+		// 강아지인 경우
+		for i := 1; i < 3; i++ {
+			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []uuid.UUID{petList.Pets[i-1].ID}, i, conditionIDs)
+			sosPostService.WriteSOSPost(ctx, uid, request)
+			writeRequests = append(writeRequests, *request)
+		}
+
+		// 고양이인 경우
+		request := tests.NewDummyWriteSOSPostRequest(imageIDs, []uuid.UUID{petList.Pets[2].ID}, 3, conditionIDs)
+		sosPostService.WriteSOSPost(ctx, uid, request)
+		writeRequests = append(writeRequests, *request)
+
+		// 강아지, 고양이인 경우
+		request = tests.NewDummyWriteSOSPostRequest(
+			imageIDs,
+			[]uuid.UUID{petList.Pets[1].ID, petList.Pets[2].ID},
+			4,
+			conditionIDs,
+		)
+		sosPostService.WriteSOSPost(ctx, uid, request)
+		writeRequests = append(writeRequests, *request)
+
+		// when
+		foundList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
+
+		// then
+		for i, sosPost := range foundList.Items {
+			idx := len(foundList.Items) - i - 1
+			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
+			assertPetEquals(t, petList.Pets[i-1], sosPost.Pets[i-1])
+			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
+			assert.Equal(t, owner.ID, sosPost.Author.ID)
+			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
+			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
+		}
+	})
+
+	t.Run("작성자 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
+		owner, _ := userService.RegisterUser(ctx, userRequest)
+		author := &user.WithoutPrivateInfo{
+			ID:              owner.ID,
+			ProfileImageURL: owner.ProfileImageURL,
+			Nickname:        owner.Nickname,
+		}
+		petList, _ := userService.AddPetsToOwner(
+			ctx,
+			owner.FirebaseUID,
+			pet.AddPetsToOwnerRequest{
+				Pets: []pet.AddPetRequest{
+					*tests.NewDummyAddPetRequest(
+						uuid.NullUUID{UUID: profileImage.ID, Valid: true}, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+				},
+			},
+		)
+
+		imageIDs := []uuid.UUID{sosPostImage.ID, sosPostImage2.ID}
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+
+		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
+		for i := 1; i < 4; i++ {
+			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []uuid.UUID{petList.Pets[0].ID}, i, conditionIDs)
+			sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
+			writeRequests = append(writeRequests, *request)
+		}
+
+		// when
+		foundList, _ := sosPostService.FindSOSPostsByAuthorID(ctx, owner.ID, 1, 3, "newest", "all")
+
+		// then
+		for i, sosPost := range foundList.Items {
+			idx := len(foundList.Items) - i - 1
+			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
+			assertPetEquals(t, petList.Pets[0], sosPost.Pets[0])
+			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
+			assert.Equal(t, author.ID, sosPost.Author.ID)
+			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
+			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
+		}
+	})
+}
+
+func TestFindSOSPostByID(t *testing.T) {
+	t.Run("게시글 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
+		owner, _ := userService.RegisterUser(ctx, userRequest)
+		author := &user.WithoutPrivateInfo{
+			ID:              owner.ID,
+			ProfileImageURL: owner.ProfileImageURL,
+			Nickname:        owner.Nickname,
+		}
+		addPets, _ := userService.AddPetsToOwner(
+			ctx,
+			owner.FirebaseUID,
+			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true}, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+			}},
+		)
+
+		imageIDs := []uuid.UUID{sosPostImage.ID, sosPostImage2.ID}
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+
+		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
+		writtenIDs := make([]uuid.UUID, 0)
+		for i := 1; i < 4; i++ {
+			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []uuid.UUID{addPets.Pets[0].ID}, i, conditionIDs)
+			sosPost, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
+			writeRequests = append(writeRequests, *request)
+			writtenIDs = append(writtenIDs, sosPost.ID)
+		}
+
+		// when
+		found, _ := sosPostService.FindSOSPostByID(ctx, writtenIDs[0])
+
+		// then
+		asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
+		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
+		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+		assert.Equal(t, author.ID, found.Author.ID)
+		asserts.DatesEquals(t, writeRequests[0].Dates, found.Dates)
+		writtenAndFoundSOSPostEquals(t, writeRequests[0], *found)
+	})
+}
+
+func TestUpdateSOSPost(t *testing.T) {
+	t.Run("돌봄 급구 게시글을 수정합니다.", func(t *testing.T) {
+		ctx := context.Background()
+		db, tearDown := setUp(ctx, t)
+		defer tearDown(t)
+		mediaService := tests.NewMockMediaService(db)
+		userService := tests.NewMockUserService(db)
+		sosPostService := tests.NewMockSOSPostService(db)
+
+		// given
+		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
+		owner, _ := userService.RegisterUser(ctx, userRequest)
+		addPets, _ := userService.AddPetsToOwner(
+			ctx,
+			owner.FirebaseUID,
+			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: profileImage.ID, Valid: true},
+					commonvo.PetTypeDog,
+					pet.GenderMale,
+					"poodle",
+				),
+			}},
+		)
+
+		conditions, _ := service.NewSOSConditionService(db).FindConditions(ctx)
+		conditionIDs := []uuid.UUID{conditions[0].ID, conditions[1].ID}
+		sosPost, _ := sosPostService.WriteSOSPost(
+			ctx, owner.FirebaseUID,
+			tests.NewDummyWriteSOSPostRequest([]uuid.UUID{sosPostImage.ID}, []uuid.UUID{addPets.Pets[0].ID}, 1, conditionIDs),
+		)
+
+		// when
+		updateRequest := &sospost.UpdateSOSPostRequest{
+			ID:       sosPost.ID,
+			Title:    "Title2",
+			Content:  "Content2",
+			ImageIDs: []uuid.UUID{sosPostImage.ID, sosPostImage2.ID},
+			Reward:   "Reward2",
+			Dates: []sospost.SOSDateView{
+				{"2024-04-10", "2024-04-20"},
+				{"2024-05-10", "2024-05-20"},
+			},
+			CareType:     sospost.CareTypeFoster,
+			CarerGender:  sospost.CarerGenderMale,
+			RewardType:   sospost.RewardTypeFee,
+			ConditionIDs: conditionIDs,
+			PetIDs:       []uuid.UUID{addPets.Pets[0].ID},
+		}
+		updated, _ := sosPostService.UpdateSOSPost(ctx, updateRequest)
+
+		// then
+		found, _ := sosPostService.FindSOSPostByID(ctx, sosPost.ID)
+		asserts.ConditionIDEquals(t, updateRequest.ConditionIDs, found.Conditions)
+		assertPetEquals(t, sosPost.Pets[0], found.Pets[0])
+		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+		asserts.DatesEquals(t, updateRequest.Dates, found.Dates)
+		assert.Equal(t, updateRequest.Title, found.Title)
+		assert.Equal(t, updateRequest.Content, found.Content)
+		assert.Equal(t, updateRequest.Reward, found.Reward)
+		assert.Equal(t, updateRequest.CareType, found.CareType)
+		assert.Equal(t, updateRequest.CarerGender, found.CarerGender)
+		assert.Equal(t, updateRequest.RewardType, found.RewardType)
+		assert.Equal(t, updateRequest.ImageIDs[0], found.ThumbnailID.UUID)
+		assert.Equal(t, updated.AuthorID, owner.ID)
+	})
+}
+
+func assertPetEquals(t *testing.T, want, got pet.DetailView) {
+	t.Helper()
+
+	assert.Equal(t, want.ID, got.ID)
+	assert.Equal(t, want.Name, got.Name)
+	assert.Equal(t, want.PetType, got.PetType)
+	assert.Equal(t, want.Sex, got.Sex)
+	assert.Equal(t, want.Neutered, got.Neutered)
+	assert.Equal(t, want.Breed, got.Breed)
+	assert.Equal(t, want.BirthDate, got.BirthDate)
+	assert.Equal(t, want.WeightInKg.String(), got.WeightInKg.String())
+	assert.Equal(t, want.Remarks, got.Remarks)
+	assert.Equal(t, want.ProfileImageURL, got.ProfileImageURL)
+}
+
+func writtenAndFoundSOSPostEquals(t *testing.T, want sospost.WriteSOSPostRequest, got sospost.FindSOSPostView) {
+	t.Helper()
+
+	assert.Equal(t, want.Title, got.Title)
+	assert.Equal(t, want.Content, got.Content)
+	assert.Equal(t, want.Reward, got.Reward)
+	assert.Equal(t, want.CareType, got.CareType)
+	assert.Equal(t, want.CarerGender, got.CarerGender)
+	assert.Equal(t, want.RewardType, got.RewardType)
+	assert.Equal(t, want.ImageIDs[0], got.ThumbnailID.UUID)
+}

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -1,445 +1,428 @@
 package service_test
 
-import (
-	"context"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/tests/asserts"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
-
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
-	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
-	"github.com/pet-sitter/pets-next-door-api/internal/service"
-	"github.com/pet-sitter/pets-next-door-api/internal/tests"
-)
-
-func setUp(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
-	t.Helper()
-	db, tearDown := tests.SetUp(t)
-
-	conditionService := service.NewSOSConditionService(db)
-	if _, err2 := conditionService.InitConditions(ctx); err2 != nil {
-		t.Errorf("InitConditions failed: %v", err2)
-	}
-
-	return db, tearDown
-}
-
-func TestCreateSOSPost(t *testing.T) {
-	t.Run("돌봄 급구 게시글을 작성한다", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
-		addPets, _ := userService.AddPetsToOwner(
-			ctx,
-			owner.FirebaseUID,
-			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-			}},
-		)
-
-		// when
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-		sosPostData := tests.NewDummyWriteSOSPostRequest(
-			[]int64{sosPostImage.ID, sosPostImage2.ID},
-			[]int64{addPets.Pets[0].ID},
-			0,
-		)
-		created, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, tests.NewDummyWriteSOSPostRequest(
-			[]int64{sosPostImage.ID, sosPostImage2.ID},
-			[]int64{addPets.Pets[0].ID},
-			0,
-		))
-
-		// then
-		found, _ := sosPostService.FindSOSPostByID(ctx, created.ID)
-		asserts.ConditionIDEquals(t, sosPostData.ConditionIDs, found.Conditions)
-		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
-		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-		asserts.DatesEquals(t, sosPostData.Dates, found.Dates)
-		writtenAndFoundSOSPostEquals(t, *sosPostData, *found)
-		assert.Equal(t, owner.ID, int64(created.AuthorID))
-	})
-}
-
-func TestFindSOSPosts(t *testing.T) {
-	t.Run("전체 돌봄 급구 게시글을 조회한다", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-		owner, _ := userService.RegisterUser(ctx, userRequest)
-		addPets, _ := userService.AddPetsToOwner(
-			ctx,
-			owner.FirebaseUID,
-			pet.AddPetsToOwnerRequest{
-				Pets: []pet.AddPetRequest{
-					*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-				},
-			},
-		)
-
-		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-		petIDs := []int64{addPets.Pets[0].ID}
-		conditionIDs := []int{1, 2}
-
-		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
-		var sosPosts []sospost.DetailView
-		for i := 1; i < 4; i++ {
-			request := tests.NewDummyWriteSOSPostRequest(imageIDs, petIDs, i)
-			sosPost, _ := sosPostService.WriteSOSPost(
-				ctx, owner.FirebaseUID, request,
-			)
-			sosPosts = append(sosPosts, *sosPost)
-			sosPostRequests = append(sosPostRequests, *request)
-		}
-
-		// when
-		foundList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
-		if err != nil {
-			t.Errorf("got %v want %v", err, nil)
-		}
-
-		// then
-		for i, found := range foundList.Items {
-			idx := len(foundList.Items) - i - 1
-			asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
-			assertPetEquals(t, addPets.Pets[0], found.Pets[0])
-			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-			assert.Equal(t, owner.ID, found.Author.ID)
-			asserts.DatesEquals(t, sosPosts[idx].Dates, found.Dates)
-			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], found)
-		}
-	})
-
-	t.Run("전체 돌봄 급구 게시글의 정렬기준을 'deadline'으로 조회한다", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-		owner, _ := userService.RegisterUser(ctx, userRequest)
-		uid := owner.FirebaseUID
-		addPetRequest, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
-			Pets: []pet.AddPetRequest{
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeCat, pet.GenderMale, "munchkin"),
-			},
-		})
-
-		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-		conditionIDs := []int{1, 2}
-
-		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
-		for i := 1; i < 4; i++ {
-			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{addPetRequest.Pets[i-1].ID}, i)
-			sosPostService.WriteSOSPost(ctx, uid, request)
-			sosPostRequests = append(sosPostRequests, *request)
-		}
-
-		// when
-		sosPostList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
-
-		// then
-		for i, sosPost := range sosPostList.Items {
-			idx := len(sosPostList.Items) - i - 1
-			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
-			assertPetEquals(t, addPetRequest.Pets[i-1], sosPost.Pets[i-1])
-			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
-			assert.Equal(t, owner.ID, sosPost.Author.ID)
-			asserts.DatesEquals(t, sosPostRequests[idx].Dates, sosPost.Dates)
-			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], sosPost)
-		}
-	})
-
-	t.Run("전체 돌봄 급구 게시글 중 반려동물이 'dog'인 경우만 조회한다", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
-
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-		uid := owner.FirebaseUID
-		petList, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
-			Pets: []pet.AddPetRequest{
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeCat, pet.GenderMale, "munchkin"),
-			},
-		})
-
-		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-		conditionIDs := []int{1, 2}
-
-		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
-		// 강아지인 경우
-		for i := 1; i < 3; i++ {
-			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[i-1].ID}, i)
-			sosPostService.WriteSOSPost(ctx, uid, request)
-			writeRequests = append(writeRequests, *request)
-		}
-
-		// 고양이인 경우
-		request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[2].ID}, 3)
-		sosPostService.WriteSOSPost(ctx, uid, request)
-		writeRequests = append(writeRequests, *request)
-
-		// 강아지, 고양이인 경우
-		request = tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[1].ID, petList.Pets[2].ID}, 4)
-		sosPostService.WriteSOSPost(ctx, uid, request)
-		writeRequests = append(writeRequests, *request)
-
-		// when
-		foundList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
-
-		// then
-		for i, sosPost := range foundList.Items {
-			idx := len(foundList.Items) - i - 1
-			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
-			assertPetEquals(t, petList.Pets[i-1], sosPost.Pets[i-1])
-			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
-			assert.Equal(t, owner.ID, sosPost.Author.ID)
-			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
-			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
-		}
-	})
-
-	t.Run("작성자 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-		owner, _ := userService.RegisterUser(ctx, userRequest)
-		author := &user.WithoutPrivateInfo{
-			ID:              owner.ID,
-			ProfileImageURL: owner.ProfileImageURL,
-			Nickname:        owner.Nickname,
-		}
-		petList, _ := userService.AddPetsToOwner(
-			ctx,
-			owner.FirebaseUID,
-			pet.AddPetsToOwnerRequest{
-				Pets: []pet.AddPetRequest{
-					*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-				},
-			},
-		)
-
-		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-		conditionIDs := []int{1, 2}
-
-		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
-		for i := 1; i < 4; i++ {
-			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[0].ID}, i)
-			sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
-			writeRequests = append(writeRequests, *request)
-		}
-
-		// when
-		foundList, _ := sosPostService.FindSOSPostsByAuthorID(ctx, int(owner.ID), 1, 3, "newest", "all")
-
-		// then
-		for i, sosPost := range foundList.Items {
-			idx := len(foundList.Items) - i - 1
-			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
-			assertPetEquals(t, petList.Pets[0], sosPost.Pets[0])
-			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
-			assert.Equal(t, author.ID, sosPost.Author.ID)
-			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
-			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
-		}
-	})
-}
-
-func TestFindSOSPostByID(t *testing.T) {
-	t.Run("게시글 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-		owner, _ := userService.RegisterUser(ctx, userRequest)
-		author := &user.WithoutPrivateInfo{
-			ID:              owner.ID,
-			ProfileImageURL: owner.ProfileImageURL,
-			Nickname:        owner.Nickname,
-		}
-		addPets, _ := userService.AddPetsToOwner(
-			ctx,
-			owner.FirebaseUID,
-			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-			}},
-		)
-
-		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
-		conditionIDs := []int{1, 2}
-
-		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
-		writtenIDs := make([]int64, 0)
-		for i := 1; i < 4; i++ {
-			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{addPets.Pets[0].ID}, i)
-			sosPost, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
-			writeRequests = append(writeRequests, *request)
-			writtenIDs = append(writtenIDs, int64(sosPost.ID))
-		}
-
-		// when
-		found, _ := sosPostService.FindSOSPostByID(ctx, int(writtenIDs[0]))
-
-		// then
-		asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
-		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
-		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-		assert.Equal(t, author.ID, found.Author.ID)
-		asserts.DatesEquals(t, writeRequests[0].Dates, found.Dates)
-		writtenAndFoundSOSPostEquals(t, writeRequests[0], *found)
-	})
-}
-
-func TestUpdateSOSPost(t *testing.T) {
-	t.Run("돌봄 급구 게시글을 수정합니다.", func(t *testing.T) {
-		ctx := context.Background()
-		db, tearDown := setUp(ctx, t)
-		defer tearDown(t)
-		mediaService := tests.NewMockMediaService(db)
-		userService := tests.NewMockUserService(db)
-		sosPostService := tests.NewMockSOSPostService(db)
-
-		// given
-		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
-		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
-
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
-		owner, _ := userService.RegisterUser(ctx, userRequest)
-		addPets, _ := userService.AddPetsToOwner(
-			ctx,
-			owner.FirebaseUID,
-			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
-				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
-			}},
-		)
-
-		sosPost, _ := sosPostService.WriteSOSPost(
-			ctx, owner.FirebaseUID, tests.NewDummyWriteSOSPostRequest([]int64{sosPostImage.ID}, []int64{addPets.Pets[0].ID}, 1),
-		)
-
-		// when
-		updateRequest := &sospost.UpdateSOSPostRequest{
-			ID:       sosPost.ID,
-			Title:    "Title2",
-			Content:  "Content2",
-			ImageIDs: []int64{sosPostImage.ID, sosPostImage2.ID},
-			Reward:   "Reward2",
-			Dates: []sospost.SOSDateView{
-				{"2024-04-10", "2024-04-20"},
-				{"2024-05-10", "2024-05-20"},
-			},
-			CareType:     sospost.CareTypeFoster,
-			CarerGender:  sospost.CarerGenderMale,
-			RewardType:   sospost.RewardTypeFee,
-			ConditionIDs: []int{1, 2},
-			PetIDs:       []int64{addPets.Pets[0].ID},
-		}
-		updated, _ := sosPostService.UpdateSOSPost(ctx, updateRequest)
-
-		// then
-		found, _ := sosPostService.FindSOSPostByID(ctx, sosPost.ID)
-		asserts.ConditionIDEquals(t, updateRequest.ConditionIDs, found.Conditions)
-		assertPetEquals(t, sosPost.Pets[0], found.Pets[0])
-		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
-		asserts.DatesEquals(t, updateRequest.Dates, found.Dates)
-		assert.Equal(t, updateRequest.Title, found.Title)
-		assert.Equal(t, updateRequest.Content, found.Content)
-		assert.Equal(t, updateRequest.Reward, found.Reward)
-		assert.Equal(t, updateRequest.CareType, found.CareType)
-		assert.Equal(t, updateRequest.CarerGender, found.CarerGender)
-		assert.Equal(t, updateRequest.RewardType, found.RewardType)
-		assert.Equal(t, &updateRequest.ImageIDs[0], found.ThumbnailID)
-		assert.Equal(t, int64(updated.AuthorID), owner.ID)
-	})
-}
-
-func assertPetEquals(t *testing.T, want, got pet.DetailView) {
-	t.Helper()
-
-	assert.Equal(t, want.ID, got.ID)
-	assert.Equal(t, want.Name, got.Name)
-	assert.Equal(t, want.PetType, got.PetType)
-	assert.Equal(t, want.Sex, got.Sex)
-	assert.Equal(t, want.Neutered, got.Neutered)
-	assert.Equal(t, want.Breed, got.Breed)
-	assert.Equal(t, want.BirthDate, got.BirthDate)
-	assert.Equal(t, want.WeightInKg.String(), got.WeightInKg.String())
-	assert.Equal(t, want.Remarks, got.Remarks)
-	assert.Equal(t, want.ProfileImageURL, got.ProfileImageURL)
-}
-
-func writtenAndFoundSOSPostEquals(t *testing.T, want sospost.WriteSOSPostRequest, got sospost.FindSOSPostView) {
-	t.Helper()
-
-	assert.Equal(t, want.Title, got.Title)
-	assert.Equal(t, want.Content, got.Content)
-	assert.Equal(t, want.Reward, got.Reward)
-	assert.Equal(t, want.CareType, got.CareType)
-	assert.Equal(t, want.CarerGender, got.CarerGender)
-	assert.Equal(t, want.RewardType, got.RewardType)
-	assert.Equal(t, &want.ImageIDs[0], got.ThumbnailID)
-}
+// func setUp(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T)) {
+// 	t.Helper()
+// 	db, tearDown := tests.SetUp(t)
+//
+// 	conditionService := service.NewSOSConditionService(db)
+// 	if _, err2 := conditionService.InitConditions(ctx); err2 != nil {
+// 		t.Errorf("InitConditions failed: %v", err2)
+// 	}
+//
+// 	return db, tearDown
+// }
+//
+// func TestCreateSOSPost(t *testing.T) {
+// 	t.Run("돌봄 급구 게시글을 작성한다", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
+// 		addPets, _ := userService.AddPetsToOwner(
+// 			ctx,
+// 			owner.FirebaseUID,
+// 			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 			}},
+// 		)
+//
+// 		// when
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+// 		sosPostData := tests.NewDummyWriteSOSPostRequest(
+// 			[]int64{sosPostImage.ID, sosPostImage2.ID},
+// 			[]int64{addPets.Pets[0].ID},
+// 			0,
+// 		)
+// 		created, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, tests.NewDummyWriteSOSPostRequest(
+// 			[]int64{sosPostImage.ID, sosPostImage2.ID},
+// 			[]int64{addPets.Pets[0].ID},
+// 			0,
+// 		))
+//
+// 		// then
+// 		found, _ := sosPostService.FindSOSPostByID(ctx, created.ID)
+// 		asserts.ConditionIDEquals(t, sosPostData.ConditionIDs, found.Conditions)
+// 		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
+// 		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+// 		asserts.DatesEquals(t, sosPostData.Dates, found.Dates)
+// 		writtenAndFoundSOSPostEquals(t, *sosPostData, *found)
+// 		assert.Equal(t, owner.ID, int64(created.AuthorID))
+// 	})
+// }
+//
+// func TestFindSOSPosts(t *testing.T) {
+// 	t.Run("전체 돌봄 급구 게시글을 조회한다", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+//
+// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+// 		owner, _ := userService.RegisterUser(ctx, userRequest)
+// 		addPets, _ := userService.AddPetsToOwner(
+// 			ctx,
+// 			owner.FirebaseUID,
+// 			pet.AddPetsToOwnerRequest{
+// 				Pets: []pet.AddPetRequest{
+// 					*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 				},
+// 			},
+// 		)
+//
+// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
+// 		petIDs := []int64{addPets.Pets[0].ID}
+// 		conditionIDs := []int{1, 2}
+//
+// 		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
+// 		var sosPosts []sospost.DetailView
+// 		for i := 1; i < 4; i++ {
+// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, petIDs, i)
+// 			sosPost, _ := sosPostService.WriteSOSPost(
+// 				ctx, owner.FirebaseUID, request,
+// 			)
+// 			sosPosts = append(sosPosts, *sosPost)
+// 			sosPostRequests = append(sosPostRequests, *request)
+// 		}
+//
+// 		// when
+// 		foundList, err := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
+// 		if err != nil {
+// 			t.Errorf("got %v want %v", err, nil)
+// 		}
+//
+// 		// then
+// 		for i, found := range foundList.Items {
+// 			idx := len(foundList.Items) - i - 1
+// 			asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
+// 			assertPetEquals(t, addPets.Pets[0], found.Pets[0])
+// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+// 			assert.Equal(t, owner.ID, found.Author.ID)
+// 			asserts.DatesEquals(t, sosPosts[idx].Dates, found.Dates)
+// 			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], found)
+// 		}
+// 	})
+//
+// 	t.Run("전체 돌봄 급구 게시글의 정렬기준을 'deadline'으로 조회한다", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+//
+// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+// 		owner, _ := userService.RegisterUser(ctx, userRequest)
+// 		uid := owner.FirebaseUID
+// 		addPetRequest, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
+// 			Pets: []pet.AddPetRequest{
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeCat, pet.GenderMale, "munchkin"),
+// 			},
+// 		})
+//
+// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
+// 		conditionIDs := []int{1, 2}
+//
+// 		sosPostRequests := make([]sospost.WriteSOSPostRequest, 0)
+// 		for i := 1; i < 4; i++ {
+// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{addPetRequest.Pets[i-1].ID}, i)
+// 			sosPostService.WriteSOSPost(ctx, uid, request)
+// 			sosPostRequests = append(sosPostRequests, *request)
+// 		}
+//
+// 		// when
+// 		sosPostList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
+//
+// 		// then
+// 		for i, sosPost := range sosPostList.Items {
+// 			idx := len(sosPostList.Items) - i - 1
+// 			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
+// 			assertPetEquals(t, addPetRequest.Pets[i-1], sosPost.Pets[i-1])
+// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
+// 			assert.Equal(t, owner.ID, sosPost.Author.ID)
+// 			asserts.DatesEquals(t, sosPostRequests[idx].Dates, sosPost.Dates)
+// 			writtenAndFoundSOSPostEquals(t, sosPostRequests[idx], sosPost)
+// 		}
+// 	})
+//
+// 	t.Run("전체 돌봄 급구 게시글 중 반려동물이 'dog'인 경우만 조회한다", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
+//
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+// 		uid := owner.FirebaseUID
+// 		petList, _ := userService.AddPetsToOwner(ctx, uid, pet.AddPetsToOwnerRequest{
+// 			Pets: []pet.AddPetRequest{
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeCat, pet.GenderMale, "munchkin"),
+// 			},
+// 		})
+//
+// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
+// 		conditionIDs := []int{1, 2}
+//
+// 		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
+// 		// 강아지인 경우
+// 		for i := 1; i < 3; i++ {
+// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[i-1].ID}, i)
+// 			sosPostService.WriteSOSPost(ctx, uid, request)
+// 			writeRequests = append(writeRequests, *request)
+// 		}
+//
+// 		// 고양이인 경우
+// 		request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[2].ID}, 3)
+// 		sosPostService.WriteSOSPost(ctx, uid, request)
+// 		writeRequests = append(writeRequests, *request)
+//
+// 		// 강아지, 고양이인 경우
+// 		request = tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[1].ID, petList.Pets[2].ID}, 4)
+// 		sosPostService.WriteSOSPost(ctx, uid, request)
+// 		writeRequests = append(writeRequests, *request)
+//
+// 		// when
+// 		foundList, _ := sosPostService.FindSOSPosts(ctx, 1, 3, "newest", "all")
+//
+// 		// then
+// 		for i, sosPost := range foundList.Items {
+// 			idx := len(foundList.Items) - i - 1
+// 			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
+// 			assertPetEquals(t, petList.Pets[i-1], sosPost.Pets[i-1])
+// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
+// 			assert.Equal(t, owner.ID, sosPost.Author.ID)
+// 			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
+// 			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
+// 		}
+// 	})
+//
+// 	t.Run("작성자 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+//
+// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+// 		owner, _ := userService.RegisterUser(ctx, userRequest)
+// 		author := &user.WithoutPrivateInfo{
+// 			ID:              owner.ID,
+// 			ProfileImageURL: owner.ProfileImageURL,
+// 			Nickname:        owner.Nickname,
+// 		}
+// 		petList, _ := userService.AddPetsToOwner(
+// 			ctx,
+// 			owner.FirebaseUID,
+// 			pet.AddPetsToOwnerRequest{
+// 				Pets: []pet.AddPetRequest{
+// 					*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 				},
+// 			},
+// 		)
+//
+// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
+// 		conditionIDs := []int{1, 2}
+//
+// 		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
+// 		for i := 1; i < 4; i++ {
+// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{petList.Pets[0].ID}, i)
+// 			sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
+// 			writeRequests = append(writeRequests, *request)
+// 		}
+//
+// 		// when
+// 		foundList, _ := sosPostService.FindSOSPostsByAuthorID(ctx, int(owner.ID), 1, 3, "newest", "all")
+//
+// 		// then
+// 		for i, sosPost := range foundList.Items {
+// 			idx := len(foundList.Items) - i - 1
+// 			asserts.ConditionIDEquals(t, conditionIDs, sosPost.Conditions)
+// 			assertPetEquals(t, petList.Pets[0], sosPost.Pets[0])
+// 			asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, sosPost.Media)
+// 			assert.Equal(t, author.ID, sosPost.Author.ID)
+// 			asserts.DatesEquals(t, writeRequests[idx].Dates, sosPost.Dates)
+// 			writtenAndFoundSOSPostEquals(t, writeRequests[idx], sosPost)
+// 		}
+// 	})
+// }
+//
+// func TestFindSOSPostByID(t *testing.T) {
+// 	t.Run("게시글 ID로 돌봄 급구 게시글을 조회합니다.", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+//
+// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+// 		owner, _ := userService.RegisterUser(ctx, userRequest)
+// 		author := &user.WithoutPrivateInfo{
+// 			ID:              owner.ID,
+// 			ProfileImageURL: owner.ProfileImageURL,
+// 			Nickname:        owner.Nickname,
+// 		}
+// 		addPets, _ := userService.AddPetsToOwner(
+// 			ctx,
+// 			owner.FirebaseUID,
+// 			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 			}},
+// 		)
+//
+// 		imageIDs := []int64{sosPostImage.ID, sosPostImage2.ID}
+// 		conditionIDs := []int{1, 2}
+//
+// 		writeRequests := make([]sospost.WriteSOSPostRequest, 0)
+// 		writtenIDs := make([]int64, 0)
+// 		for i := 1; i < 4; i++ {
+// 			request := tests.NewDummyWriteSOSPostRequest(imageIDs, []int64{addPets.Pets[0].ID}, i)
+// 			sosPost, _ := sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
+// 			writeRequests = append(writeRequests, *request)
+// 			writtenIDs = append(writtenIDs, int64(sosPost.ID))
+// 		}
+//
+// 		// when
+// 		found, _ := sosPostService.FindSOSPostByID(ctx, int(writtenIDs[0]))
+//
+// 		// then
+// 		asserts.ConditionIDEquals(t, conditionIDs, found.Conditions)
+// 		assertPetEquals(t, addPets.Pets[0], found.Pets[0])
+// 		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+// 		assert.Equal(t, author.ID, found.Author.ID)
+// 		asserts.DatesEquals(t, writeRequests[0].Dates, found.Dates)
+// 		writtenAndFoundSOSPostEquals(t, writeRequests[0], *found)
+// 	})
+// }
+//
+// func TestUpdateSOSPost(t *testing.T) {
+// 	t.Run("돌봄 급구 게시글을 수정합니다.", func(t *testing.T) {
+// 		ctx := context.Background()
+// 		db, tearDown := setUp(ctx, t)
+// 		defer tearDown(t)
+// 		mediaService := tests.NewMockMediaService(db)
+// 		userService := tests.NewMockUserService(db)
+// 		sosPostService := tests.NewMockSOSPostService(db)
+//
+// 		// given
+// 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
+// 		sosPostImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image.jpg")
+// 		sosPostImage2, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "sos_post_image2.jpg")
+//
+// 		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+// 		owner, _ := userService.RegisterUser(ctx, userRequest)
+// 		addPets, _ := userService.AddPetsToOwner(
+// 			ctx,
+// 			owner.FirebaseUID,
+// 			pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{
+// 				*tests.NewDummyAddPetRequest(&profileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+// 			}},
+// 		)
+//
+// 		sosPost, _ := sosPostService.WriteSOSPost(
+// 			ctx, owner.FirebaseUID,
+//			tests.NewDummyWriteSOSPostRequest([]int64{sosPostImage.ID}, []int64{addPets.Pets[0].ID}, 1),
+// 		)
+//
+// 		// when
+// 		updateRequest := &sospost.UpdateSOSPostRequest{
+// 			ID:       sosPost.ID,
+// 			Title:    "Title2",
+// 			Content:  "Content2",
+// 			ImageIDs: []int64{sosPostImage.ID, sosPostImage2.ID},
+// 			Reward:   "Reward2",
+// 			Dates: []sospost.SOSDateView{
+// 				{"2024-04-10", "2024-04-20"},
+// 				{"2024-05-10", "2024-05-20"},
+// 			},
+// 			CareType:     sospost.CareTypeFoster,
+// 			CarerGender:  sospost.CarerGenderMale,
+// 			RewardType:   sospost.RewardTypeFee,
+// 			ConditionIDs: []int{1, 2},
+// 			PetIDs:       []int64{addPets.Pets[0].ID},
+// 		}
+// 		updated, _ := sosPostService.UpdateSOSPost(ctx, updateRequest)
+//
+// 		// then
+// 		found, _ := sosPostService.FindSOSPostByID(ctx, sosPost.ID)
+// 		asserts.ConditionIDEquals(t, updateRequest.ConditionIDs, found.Conditions)
+// 		assertPetEquals(t, sosPost.Pets[0], found.Pets[0])
+// 		asserts.MediaEquals(t, media.ListView{sosPostImage, sosPostImage2}, found.Media)
+// 		asserts.DatesEquals(t, updateRequest.Dates, found.Dates)
+// 		assert.Equal(t, updateRequest.Title, found.Title)
+// 		assert.Equal(t, updateRequest.Content, found.Content)
+// 		assert.Equal(t, updateRequest.Reward, found.Reward)
+// 		assert.Equal(t, updateRequest.CareType, found.CareType)
+// 		assert.Equal(t, updateRequest.CarerGender, found.CarerGender)
+// 		assert.Equal(t, updateRequest.RewardType, found.RewardType)
+// 		assert.Equal(t, &updateRequest.ImageIDs[0], found.ThumbnailID)
+// 		assert.Equal(t, int64(updated.AuthorID), owner.ID)
+// 	})
+// }
+//
+// func assertPetEquals(t *testing.T, want, got pet.DetailView) {
+// 	t.Helper()
+//
+// 	assert.Equal(t, want.ID, got.ID)
+// 	assert.Equal(t, want.Name, got.Name)
+// 	assert.Equal(t, want.PetType, got.PetType)
+// 	assert.Equal(t, want.Sex, got.Sex)
+// 	assert.Equal(t, want.Neutered, got.Neutered)
+// 	assert.Equal(t, want.Breed, got.Breed)
+// 	assert.Equal(t, want.BirthDate, got.BirthDate)
+// 	assert.Equal(t, want.WeightInKg.String(), got.WeightInKg.String())
+// 	assert.Equal(t, want.Remarks, got.Remarks)
+// 	assert.Equal(t, want.ProfileImageURL, got.ProfileImageURL)
+// }
+//
+// func writtenAndFoundSOSPostEquals(t *testing.T, want sospost.WriteSOSPostRequest, got sospost.FindSOSPostView) {
+// 	t.Helper()
+//
+// 	assert.Equal(t, want.Title, got.Title)
+// 	assert.Equal(t, want.Content, got.Content)
+// 	assert.Equal(t, want.Reward, got.Reward)
+// 	assert.Equal(t, want.CareType, got.CareType)
+// 	assert.Equal(t, want.CarerGender, got.CarerGender)
+// 	assert.Equal(t, want.RewardType, got.RewardType)
+// 	assert.Equal(t, &want.ImageIDs[0], got.ThumbnailID)
+// }
+//

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
@@ -29,7 +31,7 @@ func TestRegisterUser(t *testing.T) {
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
 
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
 
 		// When
 		created, _ := userService.RegisterUser(ctx, userRequest)
@@ -49,7 +51,7 @@ func TestRegisterUser(t *testing.T) {
 			Email:                "test@example.com",
 			Nickname:             "nickname",
 			Fullname:             "fullname",
-			ProfileImageID:       nil,
+			ProfileImageID:       uuid.NullUUID{},
 			FirebaseProviderType: user.FirebaseProviderTypeKakao,
 			FirebaseUID:          "uid",
 		}
@@ -70,7 +72,7 @@ func TestRegisterUser(t *testing.T) {
 
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
 		userService.RegisterUser(ctx, userRequest)
 
 		// When
@@ -97,7 +99,7 @@ func TestFindUsers(t *testing.T) {
 			Email:                "test@example.com",
 			Nickname:             targetNickname,
 			Fullname:             "fullname",
-			ProfileImageID:       &profileImage.ID,
+			ProfileImageID:       uuid.NullUUID{UUID: profileImage.ID, Valid: true},
 			FirebaseProviderType: user.FirebaseProviderTypeKakao,
 			FirebaseUID:          "uid",
 		}
@@ -108,7 +110,7 @@ func TestFindUsers(t *testing.T) {
 				Email:                fmt.Sprintf("test%d@example.com", i),
 				Nickname:             fmt.Sprintf("nickname%d", i),
 				Fullname:             fmt.Sprintf("fullname%d", i),
-				ProfileImageID:       &profileImage.ID,
+				ProfileImageID:       uuid.NullUUID{UUID: profileImage.ID, Valid: true},
 				FirebaseProviderType: user.FirebaseProviderTypeKakao,
 				FirebaseUID:          fmt.Sprintf("uid%d", i),
 			})
@@ -133,7 +135,7 @@ func TestFindUser(t *testing.T) {
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
 
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
 		created, _ := userService.RegisterUser(ctx, userRequest)
 
 		// When
@@ -153,7 +155,7 @@ func TestFindUser(t *testing.T) {
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
 
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
 		created, _ := userService.RegisterUser(ctx, userRequest)
 
 		// When
@@ -189,7 +191,7 @@ func TestFindUserProfile(t *testing.T) {
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
 
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
 		created, _ := userService.RegisterUser(ctx, userRequest)
 
 		// When
@@ -225,7 +227,7 @@ func TestExistsByEmail(t *testing.T) {
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
 
-		userRequest := tests.NewDummyRegisterUserRequest(&profileImage.ID)
+		userRequest := tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true})
 		userService.RegisterUser(ctx, userRequest)
 
 		// When
@@ -246,12 +248,20 @@ func TestUpdateUserByUID(t *testing.T) {
 
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		targetUser, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
+		targetUser, _ := userService.RegisterUser(
+			ctx,
+			tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true}),
+		)
 
 		// When
 		updatedNickname := "updated"
 		updatedProfileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "updated_profile_image.jpg")
-		userService.UpdateUserByUID(ctx, targetUser.FirebaseUID, updatedNickname, &updatedProfileImage.ID)
+		userService.UpdateUserByUID(
+			ctx,
+			targetUser.FirebaseUID,
+			updatedNickname,
+			uuid.NullUUID{UUID: updatedProfileImage.ID, Valid: true},
+		)
 
 		// Then
 		found, _ := userService.FindUser(ctx, user.FindUserParams{FbUID: &targetUser.FirebaseUID})
@@ -270,17 +280,28 @@ func TestAddPetsToOwner(t *testing.T) {
 
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		owner, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
+		owner, _ := userService.RegisterUser(
+			ctx,
+			tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true}),
+		)
 
 		petProfileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "pet_profile_image.jpg")
 		petsToAdd := pet.AddPetsToOwnerRequest{
 			Pets: []pet.AddPetRequest{
-				*tests.NewDummyAddPetRequest(&petProfileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle"),
+				*tests.NewDummyAddPetRequest(
+					uuid.NullUUID{UUID: petProfileImage.ID, Valid: true},
+					commonvo.PetTypeDog,
+					pet.GenderMale,
+					"poodle",
+				),
 			},
 		}
 
 		// When
-		created, _ := userService.AddPetsToOwner(ctx, owner.FirebaseUID, petsToAdd)
+		created, err := userService.AddPetsToOwner(ctx, owner.FirebaseUID, petsToAdd)
+		if err != nil {
+			t.Errorf("got %v want %v", err, nil)
+		}
 
 		// Then
 		assert.Equal(t, 1, len(created.Pets))
@@ -309,10 +330,17 @@ func TestUpdatePet(t *testing.T) {
 
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		registeredUser, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
+		registeredUser, _ := userService.RegisterUser(
+			ctx,
+			tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true}),
+		)
 
 		petProfileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "pet_profile_image.jpg")
-		petRequest := tests.NewDummyAddPetRequest(&petProfileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle")
+		petRequest := tests.NewDummyAddPetRequest(
+			uuid.NullUUID{UUID: petProfileImage.ID, Valid: true},
+			commonvo.PetTypeDog,
+			pet.GenderMale, "poodle",
+		)
 		createdPets, _ := userService.AddPetsToOwner(
 			ctx, registeredUser.FirebaseUID, pet.AddPetsToOwnerRequest{Pets: []pet.AddPetRequest{*petRequest}})
 		createdPet := createdPets.Pets[0]
@@ -327,7 +355,7 @@ func TestUpdatePet(t *testing.T) {
 			BirthDate:      birthDate.String(),
 			WeightInKg:     decimal.NewFromFloat(10.0),
 			Remarks:        "updated",
-			ProfileImageID: &updatedPetProfileImage.ID,
+			ProfileImageID: uuid.NullUUID{UUID: updatedPetProfileImage.ID, Valid: true},
 		}
 
 		_, err := userService.UpdatePet(ctx, registeredUser.FirebaseUID, createdPet.ID, updatedPetRequest)
@@ -336,7 +364,10 @@ func TestUpdatePet(t *testing.T) {
 		}
 
 		// Then
-		found, _ := userService.FindPets(ctx, pet.FindPetsParams{OwnerID: &registeredUser.ID})
+		found, _ := userService.FindPets(
+			ctx,
+			pet.FindPetsParams{OwnerID: uuid.NullUUID{UUID: registeredUser.ID, Valid: true}},
+		)
 		assert.Equal(t, 1, len(found.Pets))
 
 		want := updatedPetRequest
@@ -359,10 +390,18 @@ func TestDeletePet(t *testing.T) {
 
 		// Given
 		profileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "profile_image.jpg")
-		registeredUser, _ := userService.RegisterUser(ctx, tests.NewDummyRegisterUserRequest(&profileImage.ID))
+		registeredUser, _ := userService.RegisterUser(
+			ctx,
+			tests.NewDummyRegisterUserRequest(uuid.NullUUID{UUID: profileImage.ID, Valid: true}),
+		)
 
 		petProfileImage, _ := mediaService.UploadMedia(ctx, nil, media.TypeImage, "pet_profile_image.jpg")
-		petRequest := tests.NewDummyAddPetRequest(&petProfileImage.ID, commonvo.PetTypeDog, pet.GenderMale, "poodle")
+		petRequest := tests.NewDummyAddPetRequest(
+			uuid.NullUUID{UUID: petProfileImage.ID, Valid: true},
+			commonvo.PetTypeDog,
+			pet.GenderMale,
+			"poodle",
+		)
 		createdPets, _ := userService.AddPetsToOwner(
 			ctx,
 			registeredUser.FirebaseUID,
@@ -375,7 +414,7 @@ func TestDeletePet(t *testing.T) {
 
 		// Then
 		found, _ := userService.FindPets(ctx, pet.FindPetsParams{
-			OwnerID: &registeredUser.ID,
+			OwnerID: uuid.NullUUID{UUID: registeredUser.ID, Valid: true},
 		})
 		assert.Equal(t, 0, len(found.Pets))
 	})

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -225,7 +225,6 @@ func (service *UserService) AddPetsToOwner(
 			Remarks:        item.Remarks,
 			ProfileImageID: item.ProfileImageID,
 		}
-		fmt.Printf("petToCreate: %+v\n", petToCreate)
 		row, err := databasegen.New(service.conn).WithTx(tx.Tx).CreatePet(ctx, petToCreate)
 		if err != nil {
 			return nil, pnd.FromPostgresError(err)
@@ -241,7 +240,6 @@ func (service *UserService) AddPetsToOwner(
 		Ids: petIDs,
 	})
 	if err2 != nil {
-		fmt.Printf("여기가 문제인가? %v\n", err2)
 		return nil, pnd.FromPostgresError(err2)
 	}
 

--- a/internal/tests/asserts/sospost.go
+++ b/internal/tests/asserts/sospost.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
@@ -18,11 +20,11 @@ func DatesEquals(t *testing.T, want, got []sospost.SOSDateView) {
 	}
 }
 
-func ConditionIDEquals(t *testing.T, want []int, got soscondition.ListView) {
+func ConditionIDEquals(t *testing.T, want []uuid.UUID, got soscondition.ListView) {
 	t.Helper()
 
 	assert.Equal(t, len(want), len(got))
 	for i := range got {
-		assert.Equal(t, int64(want[i]), got[i].ID)
+		assert.Equal(t, want[i], got[i].ID)
 	}
 }

--- a/internal/tests/factories.go
+++ b/internal/tests/factories.go
@@ -1,7 +1,10 @@
 package tests
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
+	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
 
@@ -11,23 +14,14 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func randomUUID() uuid.UUID {
-	newUUID, _ := datatype.NewV7()
-	return newUUID
-}
-
-func randomUUIDStr() string {
-	return randomUUID().String()
-}
-
 func NewDummyRegisterUserRequest(profileImageID uuid.NullUUID) *user.RegisterUserRequest {
 	return &user.RegisterUserRequest{
-		Email:                randomUUIDStr() + "@example.com",
-		Nickname:             randomUUIDStr()[0:20],
-		Fullname:             randomUUIDStr()[0:20],
+		Email:                datatype.NewUUIDV7().String() + "@example.com",
+		Nickname:             datatype.NewUUIDV7().String()[0:20],
+		Fullname:             datatype.NewUUIDV7().String()[0:20],
 		ProfileImageID:       profileImageID,
 		FirebaseProviderType: user.FirebaseProviderTypeKakao,
-		FirebaseUID:          randomUUIDStr(),
+		FirebaseUID:          datatype.NewUUIDV7().String(),
 	}
 }
 
@@ -36,7 +30,7 @@ func NewDummyAddPetRequest(
 ) *pet.AddPetRequest {
 	birthDate, _ := datatype.ParseDate("2020-01-01")
 	return &pet.AddPetRequest{
-		Name:           randomUUIDStr()[0:20],
+		Name:           datatype.NewUUIDV7().String()[0:20],
 		PetType:        petType,
 		Sex:            gender,
 		Neutered:       true,
@@ -47,20 +41,25 @@ func NewDummyAddPetRequest(
 	}
 }
 
-// func NewDummyWriteSOSPostRequest(imageID, petIDs []uuid.UUID, sosPostCnt int) *sospost.WriteSOSPostRequest {
-// 	return &sospost.WriteSOSPostRequest{
-// 		Title:    fmt.Sprintf("Title%d", sosPostCnt),
-// 		Content:  fmt.Sprintf("Content%d", sosPostCnt),
-// 		ImageIDs: imageID,
-// 		Reward:   "Reward",
-// 		Dates: []sospost.SOSDateView{
-// 			{DateStartAt: fmt.Sprintf("2024-04-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-04-2%d", sosPostCnt)},
-// 			{DateStartAt: fmt.Sprintf("2024-05-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-05-2%d", sosPostCnt)},
-// 		},
-// 		CareType:     sospost.CareTypeFoster,
-// 		CarerGender:  sospost.CarerGenderMale,
-// 		RewardType:   sospost.RewardTypeFee,
-// 		ConditionIDs: []uuid.UUID{randomUUID(), randomUUID()},
-// 		PetIDs:       petIDs,
-// 	}
-// }
+func NewDummyWriteSOSPostRequest(
+	imageID,
+	petIDs []uuid.UUID,
+	sosPostCnt int,
+	conditionIDs []uuid.UUID,
+) *sospost.WriteSOSPostRequest {
+	return &sospost.WriteSOSPostRequest{
+		Title:    fmt.Sprintf("Title%d", sosPostCnt),
+		Content:  fmt.Sprintf("Content%d", sosPostCnt),
+		ImageIDs: imageID,
+		Reward:   "Reward",
+		Dates: []sospost.SOSDateView{
+			{DateStartAt: fmt.Sprintf("2024-04-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-04-2%d", sosPostCnt)},
+			{DateStartAt: fmt.Sprintf("2024-05-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-05-2%d", sosPostCnt)},
+		},
+		CareType:     sospost.CareTypeFoster,
+		CarerGender:  sospost.CarerGenderMale,
+		RewardType:   sospost.RewardTypeFee,
+		ConditionIDs: conditionIDs,
+		PetIDs:       petIDs,
+	}
+}

--- a/internal/tests/factories.go
+++ b/internal/tests/factories.go
@@ -1,39 +1,42 @@
 package tests
 
 import (
-	"fmt"
+	"github.com/google/uuid"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/datatype"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
-	"github.com/pet-sitter/pets-next-door-api/internal/domain/sospost"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/user"
 	"github.com/shopspring/decimal"
 )
 
-func randomUUID() string {
-	uuid, _ := datatype.NewV7()
-	return uuid.String()
+func randomUUID() uuid.UUID {
+	newUUID, _ := datatype.NewV7()
+	return newUUID
 }
 
-func NewDummyRegisterUserRequest(profileImageID *int64) *user.RegisterUserRequest {
+func randomUUIDStr() string {
+	return randomUUID().String()
+}
+
+func NewDummyRegisterUserRequest(profileImageID uuid.NullUUID) *user.RegisterUserRequest {
 	return &user.RegisterUserRequest{
-		Email:                randomUUID() + "@example.com",
-		Nickname:             randomUUID()[0:20],
-		Fullname:             randomUUID()[0:20],
+		Email:                randomUUIDStr() + "@example.com",
+		Nickname:             randomUUIDStr()[0:20],
+		Fullname:             randomUUIDStr()[0:20],
 		ProfileImageID:       profileImageID,
 		FirebaseProviderType: user.FirebaseProviderTypeKakao,
-		FirebaseUID:          randomUUID(),
+		FirebaseUID:          randomUUIDStr(),
 	}
 }
 
 func NewDummyAddPetRequest(
-	profileImageID *int64, petType commonvo.PetType, gender pet.Gender, breed string,
+	profileImageID uuid.NullUUID, petType commonvo.PetType, gender pet.Gender, breed string,
 ) *pet.AddPetRequest {
 	birthDate, _ := datatype.ParseDate("2020-01-01")
 	return &pet.AddPetRequest{
-		Name:           randomUUID()[0:20],
+		Name:           randomUUIDStr()[0:20],
 		PetType:        petType,
 		Sex:            gender,
 		Neutered:       true,
@@ -44,20 +47,20 @@ func NewDummyAddPetRequest(
 	}
 }
 
-func NewDummyWriteSOSPostRequest(imageID, petIDs []int64, sosPostCnt int) *sospost.WriteSOSPostRequest {
-	return &sospost.WriteSOSPostRequest{
-		Title:    fmt.Sprintf("Title%d", sosPostCnt),
-		Content:  fmt.Sprintf("Content%d", sosPostCnt),
-		ImageIDs: imageID,
-		Reward:   "Reward",
-		Dates: []sospost.SOSDateView{
-			{DateStartAt: fmt.Sprintf("2024-04-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-04-2%d", sosPostCnt)},
-			{DateStartAt: fmt.Sprintf("2024-05-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-05-2%d", sosPostCnt)},
-		},
-		CareType:     sospost.CareTypeFoster,
-		CarerGender:  sospost.CarerGenderMale,
-		RewardType:   sospost.RewardTypeFee,
-		ConditionIDs: []int{1, 2},
-		PetIDs:       petIDs,
-	}
-}
+// func NewDummyWriteSOSPostRequest(imageID, petIDs []uuid.UUID, sosPostCnt int) *sospost.WriteSOSPostRequest {
+// 	return &sospost.WriteSOSPostRequest{
+// 		Title:    fmt.Sprintf("Title%d", sosPostCnt),
+// 		Content:  fmt.Sprintf("Content%d", sosPostCnt),
+// 		ImageIDs: imageID,
+// 		Reward:   "Reward",
+// 		Dates: []sospost.SOSDateView{
+// 			{DateStartAt: fmt.Sprintf("2024-04-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-04-2%d", sosPostCnt)},
+// 			{DateStartAt: fmt.Sprintf("2024-05-1%d", sosPostCnt), DateEndAt: fmt.Sprintf("2024-05-2%d", sosPostCnt)},
+// 		},
+// 		CareType:     sospost.CareTypeFoster,
+// 		CarerGender:  sospost.CarerGenderMale,
+// 		RewardType:   sospost.RewardTypeFee,
+// 		ConditionIDs: []uuid.UUID{randomUUID(), randomUUID()},
+// 		PetIDs:       petIDs,
+// 	}
+// }

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -36,9 +36,13 @@ func NewMockUserService(db *database.DB) *service.UserService {
 	return service.NewUserService(db, NewMockMediaService(db))
 }
 
-// func NewMockSOSPostService(db *database.DB) *service.SOSPostService {
-// 	return service.NewSOSPostService(db)
-// }
+func NewMockSOSPostService(db *database.DB) *service.SOSPostService {
+	return service.NewSOSPostService(db)
+}
+
+func NewMockSOSConditionService(db *database.DB) *service.SOSConditionService {
+	return service.NewSOSConditionService(db)
+}
 
 func AddDummyPet(
 	t *testing.T,

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/commonvo"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
@@ -34,16 +36,16 @@ func NewMockUserService(db *database.DB) *service.UserService {
 	return service.NewUserService(db, NewMockMediaService(db))
 }
 
-func NewMockSOSPostService(db *database.DB) *service.SOSPostService {
-	return service.NewSOSPostService(db)
-}
+// func NewMockSOSPostService(db *database.DB) *service.SOSPostService {
+// 	return service.NewSOSPostService(db)
+// }
 
 func AddDummyPet(
 	t *testing.T,
 	ctx context.Context,
 	userService *service.UserService,
 	ownerUID string,
-	profileImageID *int64,
+	profileImageID uuid.NullUUID,
 ) *pet.DetailView {
 	t.Helper()
 	petList, err := userService.AddPetsToOwner(ctx, ownerUID, pet.AddPetsToOwnerRequest{

--- a/queries/breeds.sql
+++ b/queries/breeds.sql
@@ -1,9 +1,10 @@
 -- name: CreateBreed :one
-INSERT INTO breeds (name,
+INSERT INTO breeds (id,
+                    name,
                     pet_type,
                     created_at,
                     updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 RETURNING id, pet_type, name, created_at, updated_at;
 
 -- name: FindBreeds :many

--- a/queries/media.sql
+++ b/queries/media.sql
@@ -1,10 +1,11 @@
 -- name: CreateMedia :one
 INSERT INTO media
-(media_type,
+(id,
+ media_type,
  url,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 RETURNING id, media_type, url, created_at, updated_at;
 
 -- name: FindSingleMedia :one
@@ -17,4 +18,3 @@ FROM media
 WHERE (id = sqlc.narg('id') OR sqlc.narg('id') IS NULL)
   AND (sqlc.arg('include_deleted')::BOOLEAN = TRUE OR
        (sqlc.arg('include_deleted')::BOOLEAN = FALSE AND deleted_at IS NULL));
-

--- a/queries/pets.sql
+++ b/queries/pets.sql
@@ -1,6 +1,7 @@
 -- name: CreatePet :one
 INSERT INTO pets
-(owner_id,
+(id,
+ owner_id,
  name,
  pet_type,
  sex,
@@ -12,7 +13,7 @@ INSERT INTO pets
  profile_image_id,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
 RETURNING id, created_at, updated_at;
 
 -- name: FindPet :one
@@ -88,7 +89,7 @@ FROM pets
      media
      ON
          pets.profile_image_id = media.id
-WHERE pets.id = ANY (sqlc.arg('ids')::int[])
+WHERE pets.id = ANY (sqlc.arg('ids')::uuid[])
   AND (sqlc.arg('include_deleted')::boolean = TRUE OR
        (sqlc.arg('include_deleted')::boolean = FALSE AND pets.deleted_at IS NULL))
 ORDER BY pets.created_at DESC;

--- a/queries/resource_media.sql
+++ b/queries/resource_media.sql
@@ -1,11 +1,12 @@
 -- name: CreateResourceMedia :one
 INSERT INTO resource_media
-(resource_id,
+(id,
+ resource_id,
  media_id,
  resource_type,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, NOW(), NOW())
+VALUES ($1, $2, $3, $4, NOW(), NOW())
 RETURNING id, resource_id, media_id, resource_type, created_at, updated_at;
 
 -- name: FindResourceMedia :many
@@ -27,7 +28,5 @@ WHERE (rm.resource_id = sqlc.narg('resource_id') OR sqlc.narg('resource_id') IS 
 -- name: DeleteResourceMediaByResourceID :exec
 UPDATE
     resource_media
-SET
-    deleted_at = NOW()
-WHERE
-    resource_id = $1;
+SET deleted_at = NOW()
+WHERE resource_id = $1;

--- a/queries/sos_posts.sql
+++ b/queries/sos_posts.sql
@@ -1,6 +1,7 @@
 -- name: WriteSOSPost :one
 INSERT INTO sos_posts
-(author_id,
+(id,
+ author_id,
  title,
  content,
  reward,
@@ -10,199 +11,180 @@ INSERT INTO sos_posts
  thumbnail_id,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
 RETURNING id, author_id, title, content, reward, care_type, carer_gender, reward_type, thumbnail_id, created_at, updated_at;
 
 -- name: InsertSOSDate :one
 INSERT INTO sos_dates
-(date_start_at,
+(id,
+ date_start_at,
  date_end_at,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW())
+VALUES ($1, $2, $3, NOW(), NOW())
 RETURNING id, date_start_at, date_end_at, created_at, updated_at;
 
 -- name: LinkSOSPostDate :exec
 INSERT INTO sos_posts_dates
-(sos_post_id,
+(id,
+ sos_post_id,
  sos_dates_id,
- created_at,
- updated_at)
-VALUES ($1, $2, NOW(), NOW());
-
--- name: LinkResourceMedia :exec
-INSERT INTO resource_media
-(media_id,
- resource_id,
- resource_type,
  created_at,
  updated_at)
 VALUES ($1, $2, $3, NOW(), NOW());
 
+-- name: LinkResourceMedia :exec
+INSERT INTO resource_media
+(id,
+ media_id,
+ resource_id,
+ resource_type,
+ created_at,
+ updated_at)
+VALUES ($1, $2, $3, $4, NOW(), NOW());
+
 -- name: LinkSOSPostCondition :exec
 INSERT INTO sos_posts_conditions
-(sos_post_id,
+(id,
+ sos_post_id,
  sos_condition_id,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW());
+VALUES ($1, $2, $3, NOW(), NOW());
 
 -- name: LinkSOSPostPet :exec
 INSERT INTO sos_posts_pets
-(sos_post_id,
+(id,
+ sos_post_id,
  pet_id,
  created_at,
  updated_at)
-VALUES ($1, $2, NOW(), NOW());
+VALUES ($1, $2, $3, NOW(), NOW());
 
 -- name: FindSOSPosts :many
-SELECT
-    v_sos_posts.id,
-    v_sos_posts.title,
-    v_sos_posts.content,
-    v_sos_posts.reward,
-    v_sos_posts.reward_type,
-    v_sos_posts.care_type,
-    v_sos_posts.carer_gender,
-    v_sos_posts.thumbnail_id,
-    v_sos_posts.author_id,
-    v_sos_posts.created_at,
-    v_sos_posts.updated_at,
-    v_sos_posts.dates,
-    v_pets_for_sos_posts.pets_info,
-    v_media_for_sos_posts.media_info,
-    v_conditions.conditions_info
-FROM
-    v_sos_posts
-        LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-        LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-        LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-WHERE
-    v_sos_posts.earliest_date_start_at >= sqlc.narg('earliest_date_start_at')
+SELECT v_sos_posts.id,
+       v_sos_posts.title,
+       v_sos_posts.content,
+       v_sos_posts.reward,
+       v_sos_posts.reward_type,
+       v_sos_posts.care_type,
+       v_sos_posts.carer_gender,
+       v_sos_posts.thumbnail_id,
+       v_sos_posts.author_id,
+       v_sos_posts.created_at,
+       v_sos_posts.updated_at,
+       v_sos_posts.dates,
+       v_pets_for_sos_posts.pets_info,
+       v_media_for_sos_posts.media_info,
+       v_conditions.conditions_info
+FROM v_sos_posts
+         LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+         LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+         LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+WHERE v_sos_posts.earliest_date_start_at >= sqlc.narg('earliest_date_start_at')
   AND (sqlc.narg('pet_type') = 'all' OR NOT EXISTS
     (SELECT 1
      FROM unnest(pet_type_list) AS pet_type
      WHERE pet_type <> sqlc.narg('pet_type')))
-ORDER BY
-    CASE WHEN sqlc.narg('sort_by') = 'newest' THEN v_sos_posts.created_at END DESC,
-    CASE WHEN sqlc.narg('sort_by') = 'deadline' THEN v_sos_posts.earliest_date_start_at END
-LIMIT sqlc.narg('limit')
-    OFFSET sqlc.narg('offset');
+ORDER BY CASE WHEN sqlc.narg('sort_by') = 'newest' THEN v_sos_posts.created_at END DESC,
+         CASE WHEN sqlc.narg('sort_by') = 'deadline' THEN v_sos_posts.earliest_date_start_at END
+LIMIT sqlc.narg('limit') OFFSET sqlc.narg('offset');
 
 
 -- name: FindSOSPostsByAuthorID :many
-SELECT
-    v_sos_posts.id,
-    v_sos_posts.title,
-    v_sos_posts.content,
-    v_sos_posts.reward,
-    v_sos_posts.reward_type,
-    v_sos_posts.care_type,
-    v_sos_posts.carer_gender,
-    v_sos_posts.thumbnail_id,
-    v_sos_posts.author_id,
-    v_sos_posts.created_at,
-    v_sos_posts.updated_at,
-    v_sos_posts.dates,
-    v_pets_for_sos_posts.pets_info,
-    v_media_for_sos_posts.media_info,
-    v_conditions.conditions_info
-FROM
-    v_sos_posts
-        LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-        LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-        LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-WHERE
-    v_sos_posts.earliest_date_start_at >= sqlc.narg('earliest_date_start_at')
+SELECT v_sos_posts.id,
+       v_sos_posts.title,
+       v_sos_posts.content,
+       v_sos_posts.reward,
+       v_sos_posts.reward_type,
+       v_sos_posts.care_type,
+       v_sos_posts.carer_gender,
+       v_sos_posts.thumbnail_id,
+       v_sos_posts.author_id,
+       v_sos_posts.created_at,
+       v_sos_posts.updated_at,
+       v_sos_posts.dates,
+       v_pets_for_sos_posts.pets_info,
+       v_media_for_sos_posts.media_info,
+       v_conditions.conditions_info
+FROM v_sos_posts
+         LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+         LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+         LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+WHERE v_sos_posts.earliest_date_start_at >= sqlc.narg('earliest_date_start_at')
   AND v_sos_posts.author_id = sqlc.narg('author_id')
   AND (sqlc.narg('pet_type') = 'all' OR NOT EXISTS
     (SELECT 1
      FROM unnest(pet_type_list) AS pet_type
      WHERE pet_type <> sqlc.narg('pet_type')))
-ORDER BY
-    CASE WHEN sqlc.narg('sort_by') = 'newest' THEN v_sos_posts.created_at END DESC,
-    CASE WHEN sqlc.narg('sort_by') = 'deadline' THEN v_sos_posts.earliest_date_start_at END
-LIMIT sqlc.narg('limit')
-    OFFSET sqlc.narg('offset');
+ORDER BY CASE WHEN sqlc.narg('sort_by') = 'newest' THEN v_sos_posts.created_at END DESC,
+         CASE WHEN sqlc.narg('sort_by') = 'deadline' THEN v_sos_posts.earliest_date_start_at END
+LIMIT sqlc.narg('limit') OFFSET sqlc.narg('offset');
 
 -- name: FindSOSPostByID :one
-SELECT
-    v_sos_posts.id,
-    v_sos_posts.title,
-    v_sos_posts.content,
-    v_sos_posts.reward,
-    v_sos_posts.reward_type,
-    v_sos_posts.care_type,
-    v_sos_posts.carer_gender,
-    v_sos_posts.thumbnail_id,
-    v_sos_posts.author_id,
-    v_sos_posts.created_at,
-    v_sos_posts.updated_at,
-    v_sos_posts.dates,
-    v_pets_for_sos_posts.pets_info,
-    v_media_for_sos_posts.media_info,
-    v_conditions.conditions_info
-FROM
-    v_sos_posts
-        LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
-        LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
-        LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
-WHERE
-    v_sos_posts.id = sqlc.narg('id');
+SELECT v_sos_posts.id,
+       v_sos_posts.title,
+       v_sos_posts.content,
+       v_sos_posts.reward,
+       v_sos_posts.reward_type,
+       v_sos_posts.care_type,
+       v_sos_posts.carer_gender,
+       v_sos_posts.thumbnail_id,
+       v_sos_posts.author_id,
+       v_sos_posts.created_at,
+       v_sos_posts.updated_at,
+       v_sos_posts.dates,
+       v_pets_for_sos_posts.pets_info,
+       v_media_for_sos_posts.media_info,
+       v_conditions.conditions_info
+FROM v_sos_posts
+         LEFT JOIN v_pets_for_sos_posts ON v_sos_posts.id = v_pets_for_sos_posts.sos_post_id
+         LEFT JOIN v_media_for_sos_posts ON v_sos_posts.id = v_media_for_sos_posts.sos_post_id
+         LEFT JOIN v_conditions ON v_sos_posts.id = v_conditions.sos_post_id
+WHERE v_sos_posts.id = sqlc.narg('id');
 
 -- name: FindDatesBySOSPostID :many
-SELECT
-    sos_dates.id,
-    sos_dates.date_start_at,
-    sos_dates.date_end_at,
-    sos_dates.created_at,
-    sos_dates.updated_at
-FROM
-    sos_dates
-        INNER JOIN
-    sos_posts_dates
-    ON sos_dates.id = sos_posts_dates.sos_dates_id
-WHERE
-    sos_posts_dates.sos_post_id = sqlc.narg('id') AND
-    sos_posts_dates.deleted_at IS NULL;
+SELECT sos_dates.id,
+       sos_dates.date_start_at,
+       sos_dates.date_end_at,
+       sos_dates.created_at,
+       sos_dates.updated_at
+FROM sos_dates
+         INNER JOIN
+     sos_posts_dates
+     ON sos_dates.id = sos_posts_dates.sos_dates_id
+WHERE sos_posts_dates.sos_post_id = sqlc.narg('id')
+  AND sos_posts_dates.deleted_at IS NULL;
 
 -- name: UpdateSOSPost :one
 UPDATE
     sos_posts
-SET
-    title = $1,
-    content = $2,
-    reward = $3,
-    care_type = $4,
+SET title        = $1,
+    content      = $2,
+    reward       = $3,
+    care_type    = $4,
     carer_gender = $5,
-    reward_type = $6,
+    reward_type  = $6,
     thumbnail_id = $7,
-    updated_at = NOW()
-WHERE
-    id = $8
+    updated_at   = NOW()
+WHERE id = $8
 RETURNING
     id, author_id, title, content, reward, care_type, carer_gender, reward_type, thumbnail_id, created_at, updated_at;
 
 -- name: DeleteSOSPostDateBySOSPostID :exec
 UPDATE
     sos_posts_dates
-SET
-    deleted_at = NOW()
-WHERE
-    sos_post_id = $1;
+SET deleted_at = NOW()
+WHERE sos_post_id = $1;
 
 -- name: DeleteSOSPostConditionBySOSPostID :exec
 UPDATE
     sos_posts_conditions
-SET
-    deleted_at = NOW()
-WHERE
-    sos_post_id = $1;
+SET deleted_at = NOW()
+WHERE sos_post_id = $1;
 
 -- name: DeleteSOSPostPetBySOSPostID :exec
 UPDATE
     sos_posts_pets
-SET
-    deleted_at = NOW()
-WHERE
-    sos_post_id = $1;
+SET deleted_at = NOW()
+WHERE sos_post_id = $1;

--- a/queries/users.sql
+++ b/queries/users.sql
@@ -1,6 +1,7 @@
 -- name: CreateUser :one
 INSERT INTO users
-(email,
+(id,
+ email,
  nickname,
  fullname,
  password,
@@ -9,7 +10,7 @@ INSERT INTO users
  fb_uid,
  created_at,
  updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
 RETURNING id, email, nickname, fullname, profile_image_id, fb_provider_type, fb_uid, created_at, updated_at;
 
 -- name: FindUsers :many


### PR DESCRIPTION
## Tasks Done

`uuid` 필드 추가 및 마이그레이션합니다. PK와 FK 모두 대체하기 위한 필드입니다.

## Todo

### 1. DB 마이그레이션

- [x] uuid 필드 추가 및 마이그레이션 (pk, fk) (이번 PR입니다.)
- [ ] consider dual-writing on `id` and `uuid`, and `XXX_id` and `XXX_uuid`

### 2. 스키마 변경

- [x] `uuid` 필드를 `NOT NULL`, `PRIMARY KEY`로 변경
- [x] `uuid` 필드를 `id` 필드로 변경

## 영향도

클라이언트에서 `id` 타입을 integer에서 string으로 바꿔야 합니다.