### PR TITLE
refactor : 채팅 서비스의 UUID 사용을 하도록 수정하고, 조회 항목의 리펙토링을 진행합니다.

### DIFF
--- a/internal/domain/chat/model.go
+++ b/internal/domain/chat/model.go
@@ -69,7 +69,7 @@ type Message struct {
 }
 
 type MessageCursorView struct {
-	HasNext *bool     `field:"hasNext" json:"hasNext"`
-	HasPrev *bool     `field:"hasPrev" json:"hasPrev"`
+	HasNext bool      `field:"hasNext" json:"hasNext"`
+	HasPrev bool      `field:"hasPrev" json:"hasPrev"`
 	Items   []Message `field:"items" json:"items,omitempty"`
 }

--- a/internal/domain/chat/model.go
+++ b/internal/domain/chat/model.go
@@ -69,7 +69,9 @@ type Message struct {
 }
 
 type MessageCursorView struct {
-	HasNext bool      `field:"hasNext" json:"hasNext"`
-	HasPrev bool      `field:"hasPrev" json:"hasPrev"`
-	Items   []Message `field:"items" json:"items,omitempty"`
+	HasNext bool       `field:"hasNext" json:"hasNext"`
+	NextID  *uuid.UUID `field:"nextID" json:"nextID,omitempty"`
+	HasPrev bool       `field:"hasPrev" json:"hasPrev"`
+	PrevID  *uuid.UUID `field:"prevID" json:"prevID,omitempty"`
+	Items   *[]Message `field:"items" json:"items,omitempty"`
 }

--- a/internal/domain/chat/view.go
+++ b/internal/domain/chat/view.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"github.com/google/uuid"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 )
 
@@ -35,7 +36,10 @@ func ToUserChatRoomsView(
 	rows []databasegen.FindAllUserChatRoomsByUserUIDRow,
 ) *JoinRoomsView {
 	if len(rows) == 0 {
-		return nil
+		// row가 없으면 빈 배열 반환
+		return &JoinRoomsView{
+			Items: []RoomSimpleInfo{},
+		}
 	}
 
 	// rows를 반복하며 JoinRoomsView로 변환
@@ -66,10 +70,16 @@ func ToUserChatRoomView(row databasegen.FindRoomByIDAndUserIDRow) *RoomSimpleInf
 }
 
 func ToUserChatRoomMessageBetweenView(
-	row []databasegen.FindBetweenMessagesByRoomIDRow, hasNext, hasPrev bool,
+	row []databasegen.FindBetweenMessagesByRoomIDRow,
+	hasNext, hasPrev bool,
+	nextMessageID, prevMessageID *uuid.UUID,
 ) *MessageCursorView {
 	if len(row) == 0 {
-		return nil
+		return &MessageCursorView{
+			HasNext: false,
+			HasPrev: false,
+			Items:   &[]Message{},
+		}
 	}
 
 	messages := make([]Message, len(row))
@@ -84,18 +94,55 @@ func ToUserChatRoomMessageBetweenView(
 		}
 	}
 
+	if hasNext && hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nextMessageID,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
+	if hasNext && !hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			HasPrev: hasPrev,
+			NextID:  nextMessageID,
+			PrevID:  nil,
+		}
+	}
+
+	if hasPrev && !hasNext {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nil,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
 	return &MessageCursorView{
-		Items:   messages,
+		Items:   &messages,
 		HasNext: hasNext,
 		HasPrev: hasPrev,
+		NextID:  nil,
+		PrevID:  nil,
 	}
 }
 
 func ToUserChatRoomMessagePrevView(
 	row []databasegen.FindPrevMessageByRoomIDRow, hasNext, hasPrev bool,
+	nextMessageID, prevMessageID *uuid.UUID,
 ) *MessageCursorView {
 	if len(row) == 0 {
-		return nil
+		return &MessageCursorView{
+			HasNext: false,
+			HasPrev: false,
+			Items:   &[]Message{},
+		}
 	}
 
 	messages := make([]Message, len(row))
@@ -110,18 +157,55 @@ func ToUserChatRoomMessagePrevView(
 		}
 	}
 
+	if hasNext && hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nextMessageID,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
+	if hasNext && !hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			HasPrev: hasPrev,
+			NextID:  nextMessageID,
+			PrevID:  nil,
+		}
+	}
+
+	if hasPrev && !hasNext {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nil,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
 	return &MessageCursorView{
-		Items:   messages,
+		Items:   &messages,
 		HasNext: hasNext,
 		HasPrev: hasPrev,
+		NextID:  nil,
+		PrevID:  nil,
 	}
 }
 
 func ToUserChatRoomMessageNextView(
 	row []databasegen.FindNextMessageByRoomIDRow, hasNext, hasPrev bool,
+	nextMessageID, prevMessageID *uuid.UUID,
 ) *MessageCursorView {
 	if len(row) == 0 {
-		return nil
+		return &MessageCursorView{
+			HasNext: false,
+			HasPrev: false,
+			Items:   &[]Message{},
+		}
 	}
 
 	messages := make([]Message, len(row))
@@ -136,18 +220,55 @@ func ToUserChatRoomMessageNextView(
 		}
 	}
 
+	if hasNext && hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nextMessageID,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
+	if hasNext && !hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			HasPrev: hasPrev,
+			NextID:  nextMessageID,
+			PrevID:  nil,
+		}
+	}
+
+	if hasPrev && !hasNext {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nil,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
 	return &MessageCursorView{
-		Items:   messages,
+		Items:   &messages,
 		HasNext: hasNext,
 		HasPrev: hasPrev,
+		NextID:  nil,
+		PrevID:  nil,
 	}
 }
 
 func ToUserChatRoomMessageView(
 	row []databasegen.FindMessagesByRoomIDAndSizeRow, hasNext, hasPrev bool,
+	nextMessageID, prevMessageID *uuid.UUID,
 ) *MessageCursorView {
 	if len(row) == 0 {
-		return nil
+		return &MessageCursorView{
+			HasNext: false,
+			HasPrev: false,
+			Items:   &[]Message{},
+		}
 	}
 
 	messages := make([]Message, len(row))
@@ -162,9 +283,41 @@ func ToUserChatRoomMessageView(
 		}
 	}
 
+	if hasNext && hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			NextID:  nextMessageID,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+		}
+	}
+
+	if hasNext && !hasPrev {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			HasPrev: hasPrev,
+			NextID:  nextMessageID,
+			PrevID:  nil,
+		}
+	}
+
+	if hasPrev && !hasNext {
+		return &MessageCursorView{
+			Items:   &messages,
+			HasNext: hasNext,
+			HasPrev: hasPrev,
+			PrevID:  prevMessageID,
+			NextID:  nil,
+		}
+	}
+
 	return &MessageCursorView{
-		Items:   messages,
+		Items:   &messages,
 		HasNext: hasNext,
 		HasPrev: hasPrev,
+		PrevID:  nil,
+		NextID:  nil,
 	}
 }

--- a/internal/domain/chat/view.go
+++ b/internal/domain/chat/view.go
@@ -74,7 +74,6 @@ func createMessageCursorView(
 	hasNext, hasPrev bool,
 	nextMessageID, prevMessageID *uuid.UUID,
 ) *MessageCursorView {
-	// Type assertion for each possible row type
 	var messages []Message
 
 	switch v := row.(type) {
@@ -134,7 +133,6 @@ func createMessageCursorView(
 		}
 	}
 
-	// Conditionally set NextID and PrevID based on hasNext and hasPrev
 	nextID := nextMessageID
 	prevID := prevMessageID
 	if !hasNext {
@@ -144,7 +142,6 @@ func createMessageCursorView(
 		prevID = nil
 	}
 
-	// Construct and return MessageCursorView
 	return &MessageCursorView{
 		Items:   &messages,
 		HasNext: hasNext,

--- a/internal/domain/chat/view.go
+++ b/internal/domain/chat/view.go
@@ -31,7 +31,9 @@ func ToJoinRoom(row databasegen.JoinRoomRow) *JoinRoom {
 	}
 }
 
-func ToUserChatRoomsView(rows []databasegen.FindAllUserChatRoomsByUserUIDRow) *JoinRoomsView {
+func ToUserChatRoomsView(
+	rows []databasegen.FindAllUserChatRoomsByUserUIDRow,
+) *JoinRoomsView {
 	if len(rows) == 0 {
 		return nil
 	}
@@ -63,7 +65,87 @@ func ToUserChatRoomView(row databasegen.FindRoomByIDAndUserIDRow) *RoomSimpleInf
 	}
 }
 
-func ToUserChatRoomMessageView(row []databasegen.FindMessageByRoomIDRow, hasNext, hasPrev *bool) *MessageCursorView {
+func ToUserChatRoomMessageBetweenView(
+	row []databasegen.FindBetweenMessagesByRoomIDRow, hasNext, hasPrev bool,
+) *MessageCursorView {
+	if len(row) == 0 {
+		return nil
+	}
+
+	messages := make([]Message, len(row))
+	for i, r := range row {
+		messages[i] = Message{
+			ID:          r.ID,
+			UserID:      r.UserID,
+			RoomID:      r.RoomID,
+			MessageType: r.MessageType,
+			Content:     r.Content,
+			CreatedAt:   r.CreatedAt,
+		}
+	}
+
+	return &MessageCursorView{
+		Items:   messages,
+		HasNext: hasNext,
+		HasPrev: hasPrev,
+	}
+}
+
+func ToUserChatRoomMessagePrevView(
+	row []databasegen.FindPrevMessageByRoomIDRow, hasNext, hasPrev bool,
+) *MessageCursorView {
+	if len(row) == 0 {
+		return nil
+	}
+
+	messages := make([]Message, len(row))
+	for i, r := range row {
+		messages[i] = Message{
+			ID:          r.ID,
+			UserID:      r.UserID,
+			RoomID:      r.RoomID,
+			MessageType: r.MessageType,
+			Content:     r.Content,
+			CreatedAt:   r.CreatedAt,
+		}
+	}
+
+	return &MessageCursorView{
+		Items:   messages,
+		HasNext: hasNext,
+		HasPrev: hasPrev,
+	}
+}
+
+func ToUserChatRoomMessageNextView(
+	row []databasegen.FindNextMessageByRoomIDRow, hasNext, hasPrev bool,
+) *MessageCursorView {
+	if len(row) == 0 {
+		return nil
+	}
+
+	messages := make([]Message, len(row))
+	for i, r := range row {
+		messages[i] = Message{
+			ID:          r.ID,
+			UserID:      r.UserID,
+			RoomID:      r.RoomID,
+			MessageType: r.MessageType,
+			Content:     r.Content,
+			CreatedAt:   r.CreatedAt,
+		}
+	}
+
+	return &MessageCursorView{
+		Items:   messages,
+		HasNext: hasNext,
+		HasPrev: hasPrev,
+	}
+}
+
+func ToUserChatRoomMessageView(
+	row []databasegen.FindMessagesByRoomIDAndSizeRow, hasNext, hasPrev bool,
+) *MessageCursorView {
 	if len(row) == 0 {
 		return nil
 	}

--- a/internal/service/chat_service.go
+++ b/internal/service/chat_service.go
@@ -193,6 +193,11 @@ func (s *ChatService) FindChatRoomByUIDAndRoomID(ctx context.Context, fbUID stri
 	return chat.ToUserChatRoomView(row), nil
 }
 
+/**
+ * 채팅방의 메시지를 조회한다. 채팅메시지는 최신순으로 DESC 정렬을 진행한다.
+ * prev - 이전 메시지의 ID
+ * next - 다음 메시지의 ID
+ */
 func (s *ChatService) FindChatRoomMessagesByRoomID(
 	ctx context.Context, roomID uuid.UUID, prev, next uuid.NullUUID, limit int64,
 ) (*chat.MessageCursorView, *pnd.AppError) {
@@ -212,7 +217,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 		// rows의 맨 앞의 ID값을 가져온다.
 		// 이 값이 prev가 존재하는지 여부를 판단하는데 사용된다.
 		if len(rows) == 0 {
-			return chat.ToUserChatRoomMessageBetweenView(rows, false, false), nil
+			return chat.ToUserChatRoomMessageBetweenView(rows, false, false, nil, nil), nil
 		}
 
 		// 가장 최신 메시지의 ID를 가져온다.
@@ -239,7 +244,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 			return nil, pnd.FromPostgresError(hasNextError)
 		}
 
-		return chat.ToUserChatRoomMessageBetweenView(rows, hasNext, hasPrev), nil
+		return chat.ToUserChatRoomMessageBetweenView(rows, hasNext, hasPrev, &firstID, &lastID), nil
 	}
 
 	if prev.Valid {
@@ -254,7 +259,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 		}
 
 		if len(rows) == 0 {
-			return chat.ToUserChatRoomMessagePrevView(rows, false, false), nil
+			return chat.ToUserChatRoomMessagePrevView(rows, false, false, nil, nil), nil
 		}
 
 		firstID := rows[0].ID
@@ -271,7 +276,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 			return nil, hasNextError
 		}
 
-		return chat.ToUserChatRoomMessagePrevView(rows, hasNext, hasPrev), nil
+		return chat.ToUserChatRoomMessagePrevView(rows, hasNext, hasPrev, &firstID, &lastID), nil
 	}
 
 	if next.Valid {
@@ -286,7 +291,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 		}
 
 		if len(rows) == 0 {
-			return chat.ToUserChatRoomMessageNextView(rows, false, false), nil
+			return chat.ToUserChatRoomMessageNextView(rows, false, false, nil, nil), nil
 		}
 
 		firstID := rows[0].ID
@@ -303,7 +308,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 			return nil, hasNextError
 		}
 
-		return chat.ToUserChatRoomMessageNextView(rows, hasNext, hasPrev), nil
+		return chat.ToUserChatRoomMessageNextView(rows, hasNext, hasPrev, &firstID, &lastID), nil
 	}
 
 	// prev와 next가 모두 없는 경우 Size만큼 최신 메시지를 가져온다.
@@ -316,7 +321,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 	}
 
 	if len(rows) == 0 {
-		return chat.ToUserChatRoomMessageView(rows, false, false), nil
+		return chat.ToUserChatRoomMessageView(rows, false, false, nil, nil), nil
 	}
 
 	firstID := rows[0].ID
@@ -333,7 +338,7 @@ func (s *ChatService) FindChatRoomMessagesByRoomID(
 		return nil, hasNextError
 	}
 
-	return chat.ToUserChatRoomMessageView(rows, hasNext, hasPrev), nil
+	return chat.ToUserChatRoomMessageView(rows, hasNext, hasPrev, &firstID, &lastID), nil
 }
 
 // hasPrev 메시지가 있는지 확인


### PR DESCRIPTION
# 주요 수정항목 
1. 전체 채팅 및 채팅방의 ID값을 UUID를 사용하도록 수정 
2. 채팅방 메시지 조회시 기존 하나의 쿼리로 통합되어있던 항목을 각 분기별로 쿼리를 나눠서 진행하도록 수정 

# 쿼리를 나눈 이유 
- prev, next 와 같이 파라미터에 각 어떠한 값이 들어올지 모르고, 특정된 파라미터 값이 들어왔을때 들어온 값을 기준으로 쿼리에 질의하기 위함 
- 동적쿼리로 진행하기 위해선, 현재 컨벤션 ( query sql 작성 후 생성 )을 하지 못하고, service 내 쿼리를 포함시켜야 함 
- 복잡한 쿼리연산을 통한 비용보다 필요한 항목만 질의하여 쿼리 비용을 절약하기 위함 

# 현재 동작 
- prev, next 와 같은 파라미터값이 주어지지 않을경우 최신 메시지를 기준으로 파라미터내 size만큼 조회를 진행 ( DESC ) 
- prev 값만 주어질 경우 해당 메시지를 기준으로 최신 메시지 순서로 리스트 조회를 진행 ( DESC ) 
- next 값만 주어질 경우 해당 메시지를 기준으로 메시지 리스트 조회를 진행 ( ASC ) 