### PR TITLE
커스텀 에러를 error 미들웨어에서 처리합니다.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,8 @@ linters-settings:
     # Such cases aren't reported by default.
     # Default: false
     check-type-assertions: true
+    exclude-functions:
+      - (*github.com/pet-sitter/pets-next-door-api/internal/infra/database.Tx).Rollback
 
   exhaustive:
     # Program elements to check for exhaustiveness.
@@ -490,7 +492,7 @@ linters:
     - nakedret # finds naked returns in functions greater than a specified function length
     - nestif # reports deeply nested if statements
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
-    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    # - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - noctx # finds sending http request without context.Context
     - nolintlint # reports ill-formed or insufficient nolint directives
     - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL

--- a/api/errors.go
+++ b/api/errors.go
@@ -46,6 +46,10 @@ type AppError struct {
 	Message string       `json:"message,omitempty"`
 }
 
+func (e *AppError) Error() string {
+	return e.Message
+}
+
 func NewAppError(err error, statusCode int, code AppErrorCode, message string) *AppError {
 	log.Error().Err(err).Msg(message)
 	return &AppError{

--- a/api/errors.go
+++ b/api/errors.go
@@ -129,7 +129,9 @@ func FromPostgresError(err error) *AppError {
 		return NewAppError(err, http.StatusBadRequest, ErrCodeBadRequest, "잘못된 값입니다")
 	case strings.Contains(errStr, "violates unique constraint"):
 		return NewAppError(err, http.StatusConflict, ErrCodeConflict, "중복된 값입니다")
-	default:
+	case strings.Contains(errStr, "pq:"):
 		return NewAppError(err, http.StatusInternalServerError, ErrCodeUnknown, "알 수 없는 오류가 발생했습니다")
+	default:
+		return nil
 	}
 }

--- a/api/web.go
+++ b/api/web.go
@@ -11,7 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func ParseBody(c echo.Context, payload interface{}) *AppError {
+func ParseBody(c echo.Context, payload interface{}) error {
 	if err := c.Bind(payload); err != nil {
 		return ErrInvalidBody(err)
 	}
@@ -22,7 +22,7 @@ func ParseBody(c echo.Context, payload interface{}) *AppError {
 	return nil
 }
 
-func ParseIDFromPath(c echo.Context, path string) (uuid.UUID, *AppError) {
+func ParseIDFromPath(c echo.Context, path string) (uuid.UUID, error) {
 	idStr := c.Param(path)
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -32,7 +32,7 @@ func ParseIDFromPath(c echo.Context, path string) (uuid.UUID, *AppError) {
 	return id, nil
 }
 
-func ParseOptionalUUIDQuery(c echo.Context, query string) (uuid.NullUUID, *AppError) {
+func ParseOptionalUUIDQuery(c echo.Context, query string) (uuid.NullUUID, error) {
 	queryStr := c.QueryParam(query)
 	if queryStr == "" {
 		return uuid.NullUUID{}, nil
@@ -48,7 +48,7 @@ func ParseOptionalUUIDQuery(c echo.Context, query string) (uuid.NullUUID, *AppEr
 	return uuid.NullUUID{UUID: id, Valid: true}, nil
 }
 
-func ParseOptionalIntQuery(c echo.Context, query string) (*int, *AppError) {
+func ParseOptionalIntQuery(c echo.Context, query string) (*int, error) {
 	queryStr := c.QueryParam(query)
 	if queryStr == "" {
 		return nil, nil
@@ -62,7 +62,7 @@ func ParseOptionalIntQuery(c echo.Context, query string) (*int, *AppError) {
 	return &value, nil
 }
 
-func ParseRequiredStringQuery(c echo.Context, query string) (*string, *AppError) {
+func ParseRequiredStringQuery(c echo.Context, query string) (*string, error) {
 	queryStr := c.QueryParam(query)
 	if queryStr == "" {
 		return nil, ErrInvalidQuery(fmt.Errorf("expected non-empty string for query: %s", query))
@@ -84,7 +84,7 @@ func ParseOptionalStringQuery(c echo.Context, query string) *string {
 func ParsePaginationQueries(
 	c echo.Context,
 	defaultPage, defaultLimit int,
-) (page, size int, err *AppError) {
+) (page, size int, err error) {
 	pageQuery := c.QueryParam("page")
 	sizeQuery := c.QueryParam("size")
 
@@ -116,7 +116,7 @@ func ParsePaginationQueries(
 
 func ParseCursorPaginationQueries(
 	c echo.Context, defaultLimit int,
-) (prev, next uuid.NullUUID, limit int, err *AppError) {
+) (prev, next uuid.NullUUID, limit int, err error) {
 	prevQuery := c.QueryParam("prev")
 	nextQuery := c.QueryParam("next")
 	sizeQuery := c.QueryParam("size")

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/pet-sitter/pets-next-door-api/cmd/import_breeds/breedsimporterservice"
 
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/configs"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
@@ -103,7 +102,7 @@ func importBreed(
 		Name:    utils.StrToNullStr(row.Breed),
 	})
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	if len(existingList) > 1 {
@@ -123,7 +122,7 @@ func importBreed(
 		PetType: petType.String(),
 	})
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	log.Printf(

--- a/cmd/import_breeds/main.go
+++ b/cmd/import_breeds/main.go
@@ -95,7 +95,7 @@ func parseFlags() Flags {
 
 func importBreed(
 	ctx context.Context, conn *database.DB, petType commonvo.PetType, row breedsimporterservice.Row,
-) (*breed.DetailView, *pnd.AppError) {
+) (*breed.DetailView, error) {
 	log.Printf("Importing breed with pet_type: %s, name: %s to database", petType, row.Breed)
 
 	existingList, err := databasegen.New(conn).FindBreeds(ctx, databasegen.FindBreedsParams{

--- a/cmd/import_conditions/main.go
+++ b/cmd/import_conditions/main.go
@@ -21,9 +21,9 @@ func main() {
 	ctx := context.Background()
 
 	conditionService := service.NewSOSConditionService(db)
-	conditionList, err2 := conditionService.InitConditions(ctx)
-	if err2 != nil {
-		log.Fatalf("error initializing conditions: %v\n", err2)
+	conditionList, err := conditionService.InitConditions(ctx)
+	if err != nil {
+		log.Fatalf("error initializing conditions: %v\n", err)
 	}
 
 	log.Println("Total conditions imported: ", len(conditionList))

--- a/cmd/migrateuuids/main.go
+++ b/cmd/migrateuuids/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	pndErr := migrate(ctx, db, MigrateOptions{ReadOnly: *readOnlyPtr, Force: *forcePtr})
 	if pndErr != nil {
-		panic(pndErr.Err)
+		panic(pndErr)
 	}
 
 	log.Println("Completed migration")

--- a/cmd/migrateuuids/uuidmigrator.go
+++ b/cmd/migrateuuids/uuidmigrator.go
@@ -174,7 +174,7 @@ type MigrateOptions struct {
 	Log      bool
 }
 
-func migrate(ctx context.Context, db *database.DB, options MigrateOptions) *pnd.AppError {
+func migrate(ctx context.Context, db *database.DB, options MigrateOptions) error {
 	log.Println("Migrating UUIDs for tables")
 	tx, err := db.BeginTx(ctx)
 	if err != nil {
@@ -210,7 +210,7 @@ func migrate(ctx context.Context, db *database.DB, options MigrateOptions) *pnd.
 	return nil
 }
 
-func MigrateUUID(tx *database.Tx, options MigrateOptions) *pnd.AppError {
+func MigrateUUID(tx *database.Tx, options MigrateOptions) error {
 	type Row struct {
 		ID   int
 		UUID *string
@@ -309,7 +309,7 @@ func MigrateUUID(tx *database.Tx, options MigrateOptions) *pnd.AppError {
 }
 
 // FK 컬럼을 연관된 테이블의 uuid 컬럼을 조회해 업데이트
-func MigrateFK(tx *database.Tx, options MigrateOptions) *pnd.AppError {
+func MigrateFK(tx *database.Tx, options MigrateOptions) error {
 	for _, target := range Targets {
 		log.Printf("Processing table %s\n", target.Table)
 

--- a/cmd/server/handler/auth_handler.go
+++ b/cmd/server/handler/auth_handler.go
@@ -66,12 +66,12 @@ func (h *AuthHandler) KakaoCallback(c echo.Context) error {
 		return c.JSON(pndErr.StatusCode, pndErr)
 	}
 
-	customToken, err2 := h.authService.CustomToken(
+	customToken, err := h.authService.CustomToken(
 		c.Request().Context(),
 		strconv.FormatInt(userProfile.ID, 10),
 	)
-	if err2 != nil {
-		return c.JSON(err2.StatusCode, err2)
+	if err != nil {
+		return err
 	}
 
 	return c.JSON(http.StatusOK, auth.NewKakaoCallbackView(*customToken, userProfile))
@@ -90,16 +90,15 @@ func (h *AuthHandler) KakaoCallback(c echo.Context) error {
 func (h *AuthHandler) GenerateFBCustomTokenFromKakao(c echo.Context) error {
 	var tokenRequest auth.GenerateFBCustomTokenRequest
 	if err := pnd.ParseBody(c, &tokenRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
-	userProfile, err2 := h.kakaoClient.FetchUserProfile(
+	userProfile, err := h.kakaoClient.FetchUserProfile(
 		c.Request().Context(),
 		tokenRequest.OAuthToken,
 	)
-	if err2 != nil {
-		pndErr := pnd.ErrBadRequest(errors.New("유효하지 않은 Kakao 인증 정보입니다"))
-		return c.JSON(pndErr.StatusCode, pndErr)
+	if err != nil {
+		return pnd.ErrBadRequest(errors.New("유효하지 않은 Kakao 인증 정보입니다"))
 	}
 
 	customToken, err := h.authService.CustomToken(
@@ -107,7 +106,7 @@ func (h *AuthHandler) GenerateFBCustomTokenFromKakao(c echo.Context) error {
 		strconv.FormatInt(userProfile.ID, 10),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(

--- a/cmd/server/handler/breed_handler.go
+++ b/cmd/server/handler/breed_handler.go
@@ -33,7 +33,7 @@ func (h *BreedHandler) FindBreeds(c echo.Context) error {
 	petType := pnd.ParseOptionalStringQuery(c, "pet_type")
 	page, size, err := pnd.ParsePaginationQueries(c, 1, 20)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.breedService.FindBreeds(c.Request().Context(), &breed.FindBreedsParams{
@@ -42,7 +42,7 @@ func (h *BreedHandler) FindBreeds(c echo.Context) error {
 		PetType: petType,
 	})
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)

--- a/cmd/server/handler/chat_handler.go
+++ b/cmd/server/handler/chat_handler.go
@@ -40,12 +40,12 @@ func (h ChatHandler) FindRoomByID(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	roomID, err := pnd.ParseIDFromPath(c, "roomID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.chatService.FindChatRoomByUIDAndRoomID(
@@ -54,7 +54,7 @@ func (h ChatHandler) FindRoomByID(c echo.Context) error {
 		roomID,
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -76,12 +76,12 @@ func (h ChatHandler) CreateRoom(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 	var createRoomRequest domain.CreateRoomRequest
 
 	if bodyError := pnd.ParseBody(c, &createRoomRequest); bodyError != nil {
-		return c.JSON(bodyError.StatusCode, err)
+		return err
 	}
 
 	res, err := h.chatService.CreateRoom(
@@ -91,7 +91,7 @@ func (h ChatHandler) CreateRoom(c echo.Context) error {
 		user.FirebaseUID,
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusCreated, res)
@@ -113,17 +113,17 @@ func (h ChatHandler) JoinChatRoom(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	roomID, err := pnd.ParseIDFromPath(c, "roomID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.chatService.JoinRoom(c.Request().Context(), roomID, foundUser.FirebaseUID)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -145,12 +145,12 @@ func (h ChatHandler) LeaveChatRoom(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	roomID, err := pnd.ParseIDFromPath(c, "roomID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res := h.chatService.LeaveRoom(c.Request().Context(), roomID, foundUser.FirebaseUID)
@@ -172,12 +172,12 @@ func (h ChatHandler) FindAllRooms(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	rooms, err := h.chatService.FindAllByUserUID(c.Request().Context(), foundUser.FirebaseUID)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 	return c.JSON(http.StatusOK, rooms)
 }
@@ -198,12 +198,12 @@ func (h ChatHandler) FindAllRooms(c echo.Context) error {
 func (h ChatHandler) FindMessagesByRoomID(c echo.Context) error {
 	roomID, err := pnd.ParseIDFromPath(c, "roomID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
-	prev, next, limit, appError := pnd.ParseCursorPaginationQueries(c, 30)
-	if appError != nil {
-		return c.JSON(appError.StatusCode, appError)
+	prev, next, limit, err := pnd.ParseCursorPaginationQueries(c, 30)
+	if err != nil {
+		return err
 	}
 
 	res, err := h.chatService.FindChatRoomMessagesByRoomID(
@@ -214,7 +214,7 @@ func (h ChatHandler) FindMessagesByRoomID(c echo.Context) error {
 		int64(limit),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)

--- a/cmd/server/handler/condition_handler.go
+++ b/cmd/server/handler/condition_handler.go
@@ -27,7 +27,7 @@ func NewConditionHandler(conditionService service.SOSConditionService) *Conditio
 func (h *ConditionHandler) FindConditions(c echo.Context) error {
 	res, err := h.conditionService.FindConditions(c.Request().Context())
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)

--- a/cmd/server/handler/sos_post_handler.go
+++ b/cmd/server/handler/sos_post_handler.go
@@ -41,12 +41,12 @@ func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	var writeSOSPostRequest sospost.WriteSOSPostRequest
 	if err = pnd.ParseBody(c, &writeSOSPostRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.sosPostService.WriteSOSPost(
@@ -55,7 +55,7 @@ func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
 		&writeSOSPostRequest,
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusCreated, res)
@@ -77,7 +77,7 @@ func (h *SOSPostHandler) WriteSOSPost(c echo.Context) error {
 func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
 	authorID, err := pnd.ParseOptionalUUIDQuery(c, "author_id")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	sortBy := "newest"
@@ -91,7 +91,7 @@ func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
 
 	page, size, err := pnd.ParsePaginationQueries(c, 1, 20)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	var res *sospost.FindSOSPostListView
@@ -99,12 +99,12 @@ func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
 		res, err = h.sosPostService.FindSOSPostsByAuthorID(
 			c.Request().Context(), authorID.UUID, page, size, sortBy, filterType)
 		if err != nil {
-			return c.JSON(err.StatusCode, err)
+			return err
 		}
 	} else {
 		res, err = h.sosPostService.FindSOSPosts(c.Request().Context(), page, size, sortBy, filterType)
 		if err != nil {
-			return c.JSON(err.StatusCode, err)
+			return err
 		}
 	}
 
@@ -122,11 +122,11 @@ func (h *SOSPostHandler) FindSOSPosts(c echo.Context) error {
 func (h *SOSPostHandler) FindSOSPostByID(c echo.Context) error {
 	id, err := pnd.ParseIDFromPath(c, "id")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 	res, err := h.sosPostService.FindSOSPostByID(c.Request().Context(), id)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -148,12 +148,12 @@ func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	var updateSOSPostRequest sospost.UpdateSOSPostRequest
 	if err = pnd.ParseBody(c, &updateSOSPostRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	permission, err := h.sosPostService.CheckUpdatePermission(
@@ -162,16 +162,15 @@ func (h *SOSPostHandler) UpdateSOSPost(c echo.Context) error {
 		updateSOSPostRequest.ID,
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 	if !permission {
-		pndErr := pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
-		return c.JSON(pndErr.StatusCode, pndErr)
+		return pnd.ErrForbidden(errors.New("해당 게시글에 대한 수정 권한이 없습니다"))
 	}
 
 	res, err := h.sosPostService.UpdateSOSPost(c.Request().Context(), &updateSOSPostRequest)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)

--- a/cmd/server/handler/user_handler.go
+++ b/cmd/server/handler/user_handler.go
@@ -37,12 +37,12 @@ func NewUserHandler(userService service.UserService, authService service.AuthSer
 func (h *UserHandler) RegisterUser(c echo.Context) error {
 	var registerUserRequest user.RegisterUserRequest
 	if err := pnd.ParseBody(c, &registerUserRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.userService.RegisterUser(c.Request().Context(), &registerUserRequest)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusCreated, res)
@@ -60,7 +60,7 @@ func (h *UserHandler) RegisterUser(c echo.Context) error {
 func (h *UserHandler) CheckUserNickname(c echo.Context) error {
 	var checkUserNicknameRequest user.CheckNicknameRequest
 	if err := pnd.ParseBody(c, &checkUserNicknameRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	exists, err := h.userService.ExistsByNickname(
@@ -68,7 +68,7 @@ func (h *UserHandler) CheckUserNickname(c echo.Context) error {
 		checkUserNicknameRequest.Nickname,
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, user.CheckNicknameView{IsAvailable: !exists})
@@ -86,7 +86,7 @@ func (h *UserHandler) CheckUserNickname(c echo.Context) error {
 func (h *UserHandler) FindUserStatusByEmail(c echo.Context) error {
 	var providerRequest user.UserStatusRequest
 	if err := pnd.ParseBody(c, &providerRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	userData, err := h.userService.FindUser(
@@ -119,13 +119,13 @@ func (h *UserHandler) FindUsers(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	nickname := pnd.ParseOptionalStringQuery(c, "nickname")
 	page, size, err := pnd.ParsePaginationQueries(c, 1, 10)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	var res *user.ListWithoutPrivateInfo
@@ -133,7 +133,7 @@ func (h *UserHandler) FindUsers(c echo.Context) error {
 	res, err = h.userService.FindUsers(c.Request().Context(),
 		user.FindUsersParams{Page: page, Size: size, Nickname: nickname})
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -154,12 +154,12 @@ func (h *UserHandler) FindUserByID(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	userID, err := pnd.ParseIDFromPath(c, "userID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.userService.FindUserProfile(
@@ -167,7 +167,7 @@ func (h *UserHandler) FindUserByID(c echo.Context) error {
 		user.FindUserParams{ID: uuid.NullUUID{UUID: userID, Valid: true}},
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -187,7 +187,7 @@ func (h *UserHandler) FindMyProfile(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res.ToMyProfileView())
@@ -209,14 +209,14 @@ func (h *UserHandler) UpdateMyProfile(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	uid := foundUser.FirebaseUID
 
 	var updateUserRequest user.UpdateUserRequest
 	if err = pnd.ParseBody(c, &updateUserRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	view, err := h.userService.UpdateUserByUID(
@@ -226,7 +226,7 @@ func (h *UserHandler) UpdateMyProfile(c echo.Context) error {
 		updateUserRequest.ProfileImageID,
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, view)
@@ -245,11 +245,11 @@ func (h *UserHandler) DeleteMyAccount(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	if err := h.userService.DeleteUserByUID(c.Request().Context(), loggedInUser.FirebaseUID); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -271,18 +271,18 @@ func (h *UserHandler) AddMyPets(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	uid := foundUser.FirebaseUID
 
 	var addPetsToOwnerRequest pet.AddPetsToOwnerRequest
 	if err := pnd.ParseBody(c, &addPetsToOwnerRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	if _, err := h.userService.AddPetsToOwner(c.Request().Context(), uid, addPetsToOwnerRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -302,7 +302,7 @@ func (h *UserHandler) FindMyPets(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.userService.FindPets(c.Request().Context(), pet.FindPetsParams{
@@ -312,7 +312,7 @@ func (h *UserHandler) FindMyPets(c echo.Context) error {
 	},
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -335,23 +335,23 @@ func (h *UserHandler) UpdateMyPet(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 	uid := foundUser.FirebaseUID
 
 	petID, err := pnd.ParseIDFromPath(c, "petID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	var updatePetRequest pet.UpdatePetRequest
 	if err = pnd.ParseBody(c, &updatePetRequest); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	res, err := h.userService.UpdatePet(c.Request().Context(), uid, petID, updatePetRequest)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -371,17 +371,17 @@ func (h *UserHandler) DeleteMyPet(c echo.Context) error {
 		c.Request().Header.Get("Authorization"),
 	)
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 	uid := foundUser.FirebaseUID
 
 	petID, err := pnd.ParseIDFromPath(c, "petID")
 	if err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	if err := h.userService.DeletePet(c.Request().Context(), uid, petID); err != nil {
-		return c.JSON(err.StatusCode, err)
+		return err
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -103,6 +103,12 @@ func NewRouter(app *firebaseinfra.FirebaseApp) (*echo.Echo, error) {
 					return c.JSON(appErr.StatusCode, appErr)
 				}
 
+				if err := pnd.FromPostgresError(err); err != nil {
+					if errors.As(err, &appErr) {
+						return c.JSON(appErr.StatusCode, appErr)
+					}
+				}
+
 				return c.JSON(http.StatusInternalServerError, pnd.ErrUnknown(err))
 			}
 

--- a/internal/common/null.go
+++ b/internal/common/null.go
@@ -100,7 +100,7 @@ func Int64PtrToNullInt32(val *int64) sql.NullInt32 {
 	}
 }
 
-func StrToNullTime(val string) (sql.NullTime, *pnd.AppError) {
+func StrToNullTime(val string) (sql.NullTime, error) {
 	const timeLayout = "2006-01-02"
 	parsedTime, err := time.Parse(timeLayout, val)
 	if err != nil {

--- a/internal/common/null.go
+++ b/internal/common/null.go
@@ -3,8 +3,6 @@ package utils
 import (
 	"database/sql"
 	"time"
-
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )
 
 func DerefOrEmpty[T any](val *T) T {
@@ -106,7 +104,7 @@ func StrToNullTime(val string) (sql.NullTime, error) {
 	if err != nil {
 		return sql.NullTime{
 			Valid: false,
-		}, pnd.FromPostgresError(err)
+		}, err
 	}
 	return sql.NullTime{
 		Time:  parsedTime,

--- a/internal/datatype/uuid.go
+++ b/internal/datatype/uuid.go
@@ -5,7 +5,7 @@ import (
 	pnd "github.com/pet-sitter/pets-next-door-api/api"
 )
 
-func NewV7() (uuid.UUID, *pnd.AppError) {
+func NewV7() (uuid.UUID, error) {
 	id, err := uuid.NewV7()
 	if err != nil {
 		return uuid.Nil, pnd.ErrUnknown(err)

--- a/internal/infra/bucket/client.go
+++ b/internal/infra/bucket/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 type FileUploader interface {
-	UploadFile(file io.ReadSeeker, fileName string) (url string, appError *pnd.AppError)
+	UploadFile(file io.ReadSeeker, fileName string) (string, error)
 }
 
 type S3Client struct {
@@ -45,7 +45,7 @@ func NewS3Client(keyID, key, endpoint, region, bucketName string) (*S3Client, er
 	}, nil
 }
 
-func (c *S3Client) UploadFile(file io.ReadSeeker, fileName string) (string, *pnd.AppError) {
+func (c *S3Client) UploadFile(file io.ReadSeeker, fileName string) (string, error) {
 	randomFileName := generateRandomFileName(fileName)
 	fullPath := "media/" + randomFileName
 

--- a/internal/infra/database/transaction.go
+++ b/internal/infra/database/transaction.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"errors"
 
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
-
 	"github.com/rs/zerolog/log"
 )
 
@@ -20,7 +18,7 @@ type Transactioner interface {
 func (db *DB) BeginTx(ctx context.Context) (*Tx, error) {
 	tx, err := db.DB.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	return &Tx{tx}, nil
@@ -54,18 +52,14 @@ func (tx *Tx) Rollback() error {
 		if errors.Is(err, sql.ErrTxDone) {
 			return nil
 		}
-		return pnd.FromPostgresError(err)
+		return err
 	}
 
 	return nil
 }
 
 func (tx *Tx) Commit() error {
-	if err := tx.Tx.Commit(); err != nil {
-		return pnd.FromPostgresError(err)
-	}
-
-	return nil
+	return tx.Tx.Commit()
 }
 
 func WithTransaction(ctx context.Context, conn *DB, f func(tx *Tx) error) error {

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -11,8 +11,8 @@ import (
 )
 
 type AuthService interface {
-	VerifyAuthAndGetUser(ctx context.Context, authHeader string) (*user.InternalView, *pnd.AppError)
-	CustomToken(ctx context.Context, uid string) (*string, *pnd.AppError)
+	VerifyAuthAndGetUser(ctx context.Context, authHeader string) (*user.InternalView, error)
+	CustomToken(ctx context.Context, uid string) (*string, error)
 }
 
 type FirebaseBearerAuthService struct {
@@ -32,15 +32,15 @@ func NewFirebaseBearerAuthService(
 
 func (service *FirebaseBearerAuthService) verifyAuth(
 	ctx context.Context, authHeader string,
-) (*auth.Token, *pnd.AppError) {
+) (*auth.Token, error) {
 	idToken, err := service.stripBearerToken(authHeader)
 	if err != nil {
 		return nil, err
 	}
 
-	authToken, err2 := service.authClient.VerifyIDToken(ctx, idToken)
-	if err2 != nil {
-		return nil, pnd.ErrInvalidFBToken(err2)
+	authToken, err := service.authClient.VerifyIDToken(ctx, idToken)
+	if err != nil {
+		return nil, pnd.ErrInvalidFBToken(err)
 	}
 
 	return authToken, nil
@@ -48,7 +48,7 @@ func (service *FirebaseBearerAuthService) verifyAuth(
 
 func (service *FirebaseBearerAuthService) VerifyAuthAndGetUser(
 	ctx context.Context, authHeader string,
-) (*user.InternalView, *pnd.AppError) {
+) (*user.InternalView, error) {
 	authToken, err := service.verifyAuth(ctx, authHeader)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (service *FirebaseBearerAuthService) VerifyAuthAndGetUser(
 func (service *FirebaseBearerAuthService) CustomToken(
 	ctx context.Context,
 	uid string,
-) (*string, *pnd.AppError) {
+) (*string, error) {
 	customToken, err := service.authClient.CustomToken(ctx, uid)
 	if err != nil {
 		return nil, pnd.ErrUnknown(err)
@@ -76,7 +76,7 @@ func (service *FirebaseBearerAuthService) CustomToken(
 
 func (service *FirebaseBearerAuthService) stripBearerToken(
 	authHeader string,
-) (string, *pnd.AppError) {
+) (string, error) {
 	if len(authHeader) > 6 && strings.ToUpper(authHeader[0:7]) == "BEARER " {
 		return authHeader[7:], nil
 	}

--- a/internal/service/breed_service.go
+++ b/internal/service/breed_service.go
@@ -22,7 +22,7 @@ func NewBreedService(conn *database.DB) *BreedService {
 
 func (s *BreedService) FindBreeds(
 	ctx context.Context, params *breed.FindBreedsParams,
-) (*breed.ListView, *pnd.AppError) {
+) (*breed.ListView, error) {
 	rows, err := databasegen.New(s.conn).FindBreeds(ctx, params.ToDBParams())
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)

--- a/internal/service/breed_service.go
+++ b/internal/service/breed_service.go
@@ -5,7 +5,6 @@ import (
 
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/breed"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
@@ -25,7 +24,7 @@ func (s *BreedService) FindBreeds(
 ) (*breed.ListView, error) {
 	rows, err := databasegen.New(s.conn).FindBreeds(ctx, params.ToDBParams())
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	return breed.ToListViewFromRows(params.Page, params.Size, rows), nil

--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -13,7 +13,6 @@ import (
 
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/media"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
@@ -65,7 +64,7 @@ func (s *MediaService) CreateMedia(
 		Url:       url,
 	})
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -83,7 +82,7 @@ func (s *MediaService) FindMediaByID(
 			ID: uuid.NullUUID{UUID: id, Valid: true},
 		})
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	return media.ToDetailView(mediaData), nil
@@ -106,7 +105,7 @@ func (s *MediaService) FindMediasByIDs(
 			IncludeDeleted: false,
 		})
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 	views := make([]media.DetailView, 0)
 	for _, mediaData := range mediaDataList {

--- a/internal/service/sos_condition_service.go
+++ b/internal/service/sos_condition_service.go
@@ -26,7 +26,7 @@ func NewSOSConditionService(conn *database.DB) *SOSConditionService {
 
 func (service *SOSConditionService) InitConditions(
 	ctx context.Context,
-) (soscondition.ListView, *pnd.AppError) {
+) (soscondition.ListView, error) {
 	tx, err := service.conn.BeginTx(ctx)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (service *SOSConditionService) InitConditions(
 
 func (service *SOSConditionService) FindConditions(
 	ctx context.Context,
-) (soscondition.ListView, *pnd.AppError) {
+) (soscondition.ListView, error) {
 	conditionList, err := databasegen.New(service.conn).FindConditions(ctx, false)
 	if err != nil {
 		return nil, pnd.FromPostgresError(err)

--- a/internal/service/sos_condition_service.go
+++ b/internal/service/sos_condition_service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/soscondition"
 	databasegen "github.com/pet-sitter/pets-next-door-api/internal/infra/database/gen"
 
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 )
 
@@ -41,7 +40,7 @@ func (service *SOSConditionService) InitConditions(
 				Name: utils.StrToNullStr(conditionName.String()),
 			})
 		if err != nil {
-			return nil, pnd.FromPostgresError(err)
+			return nil, err
 		}
 
 		conditionList[idx] = created
@@ -59,7 +58,7 @@ func (service *SOSConditionService) FindConditions(
 ) (soscondition.ListView, error) {
 	conditionList, err := databasegen.New(service.conn).FindConditions(ctx, false)
 	if err != nil {
-		return nil, pnd.FromPostgresError(err)
+		return nil, err
 	}
 
 	return soscondition.ToListViewFromRows(conditionList), nil

--- a/internal/service/tests/sos_post_service_test.go
+++ b/internal/service/tests/sos_post_service_test.go
@@ -22,8 +22,8 @@ func setUp(ctx context.Context, t *testing.T) (*database.DB, func(t *testing.T))
 	db, tearDown := tests.SetUp(t)
 
 	conditionService := service.NewSOSConditionService(db)
-	if _, err2 := conditionService.InitConditions(ctx); err2 != nil {
-		t.Errorf("InitConditions failed: %v", err2)
+	if _, err := conditionService.InitConditions(ctx); err != nil {
+		t.Errorf("InitConditions failed: %v", err)
 	}
 
 	return db, tearDown
@@ -230,7 +230,7 @@ func TestFindSOSPosts(t *testing.T) {
 				i,
 				conditionIDs,
 			)
-			sosPostService.WriteSOSPost(ctx, uid, request)
+			_, _ = sosPostService.WriteSOSPost(ctx, uid, request)
 			sosPostRequests = append(sosPostRequests, *request)
 		}
 
@@ -299,7 +299,7 @@ func TestFindSOSPosts(t *testing.T) {
 				i,
 				conditionIDs,
 			)
-			sosPostService.WriteSOSPost(ctx, uid, request)
+			_, _ = sosPostService.WriteSOSPost(ctx, uid, request)
 			writeRequests = append(writeRequests, *request)
 		}
 
@@ -310,7 +310,7 @@ func TestFindSOSPosts(t *testing.T) {
 			3,
 			conditionIDs,
 		)
-		sosPostService.WriteSOSPost(ctx, uid, request)
+		_, _ = sosPostService.WriteSOSPost(ctx, uid, request)
 		writeRequests = append(writeRequests, *request)
 
 		// 강아지, 고양이인 경우
@@ -320,7 +320,7 @@ func TestFindSOSPosts(t *testing.T) {
 			4,
 			conditionIDs,
 		)
-		sosPostService.WriteSOSPost(ctx, uid, request)
+		_, _ = sosPostService.WriteSOSPost(ctx, uid, request)
 		writeRequests = append(writeRequests, *request)
 
 		// when
@@ -388,7 +388,7 @@ func TestFindSOSPosts(t *testing.T) {
 				i,
 				conditionIDs,
 			)
-			sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
+			_, _ = sosPostService.WriteSOSPost(ctx, owner.FirebaseUID, request)
 			writeRequests = append(writeRequests, *request)
 		}
 

--- a/internal/service/tests/user_service_test.go
+++ b/internal/service/tests/user_service_test.go
@@ -77,7 +77,7 @@ func TestRegisterUser(t *testing.T) {
 		userRequest := tests.NewDummyRegisterUserRequest(
 			uuid.NullUUID{UUID: profileImage.ID, Valid: true},
 		)
-		userService.RegisterUser(ctx, userRequest)
+		_, _ = userService.RegisterUser(ctx, userRequest)
 
 		// When
 		_, err := userService.RegisterUser(ctx, userRequest)
@@ -108,9 +108,9 @@ func TestFindUsers(t *testing.T) {
 			FirebaseUID:          "uid",
 		}
 
-		userService.RegisterUser(ctx, targetUserRequest)
+		_, _ = userService.RegisterUser(ctx, targetUserRequest)
 		for i := 0; i < 2; i++ {
-			userService.RegisterUser(ctx, &user.RegisterUserRequest{
+			_, _ = userService.RegisterUser(ctx, &user.RegisterUserRequest{
 				Email:                fmt.Sprintf("test%d@example.com", i),
 				Nickname:             fmt.Sprintf("nickname%d", i),
 				Fullname:             fmt.Sprintf("fullname%d", i),
@@ -246,7 +246,7 @@ func TestExistsByEmail(t *testing.T) {
 		userRequest := tests.NewDummyRegisterUserRequest(
 			uuid.NullUUID{UUID: profileImage.ID, Valid: true},
 		)
-		userService.RegisterUser(ctx, userRequest)
+		_, _ = userService.RegisterUser(ctx, userRequest)
 
 		// When
 		exists, _ := userService.ExistsByNickname(ctx, userRequest.Nickname)
@@ -279,7 +279,7 @@ func TestUpdateUserByUID(t *testing.T) {
 			media.TypeImage,
 			"updated_profile_image.jpg",
 		)
-		userService.UpdateUserByUID(
+		_, _ = userService.UpdateUserByUID(
 			ctx,
 			targetUser.FirebaseUID,
 			updatedNickname,
@@ -461,7 +461,7 @@ func TestDeletePet(t *testing.T) {
 		createdPet := createdPets.Pets[0]
 
 		// When
-		userService.DeletePet(ctx, registeredUser.FirebaseUID, createdPet.ID)
+		_ = userService.DeletePet(ctx, registeredUser.FirebaseUID, createdPet.ID)
 
 		// Then
 		found, _ := userService.FindPets(ctx, pet.FindPetsParams{

--- a/internal/tests/service.go
+++ b/internal/tests/service.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/pet-sitter/pets-next-door-api/internal/infra/database"
 
-	pnd "github.com/pet-sitter/pets-next-door-api/api"
 	bucketinfra "github.com/pet-sitter/pets-next-door-api/internal/infra/bucket"
 
 	"github.com/pet-sitter/pets-next-door-api/internal/domain/pet"
@@ -23,7 +22,7 @@ type StubUploader struct{}
 func (u StubUploader) UploadFile(
 	_ io.ReadSeeker,
 	fileName string,
-) (url string, appError *pnd.AppError) {
+) (string, error) {
 	return "https://example.com/files/" + fileName, nil
 }
 

--- a/internal/wschat/server.go
+++ b/internal/wschat/server.go
@@ -56,20 +56,20 @@ func (s *WSServer) HandleConnections(
 ) error {
 	log.Info().Msg("Handling connections")
 
-	foundUser, err2 := s.authService.VerifyAuthAndGetUser(
+	foundUser, err := s.authService.VerifyAuthAndGetUser(
 		c.Request().Context(),
 		c.Request().Header.Get("Authorization"),
 	)
-	if err2 != nil {
-		return c.JSON(err2.StatusCode, err2)
+	if err != nil {
+		return err
 	}
 	userID := foundUser.ID
 
 	conn, err := s.upgrader.Upgrade(c.Response().Writer, c.Request(), nil)
 	defer func() {
-		err2 := conn.Close()
-		if err2 != nil {
-			log.Error().Err(err2).Msg("Failed to close connection")
+		err := conn.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to close connection")
 		}
 		delete(s.clients, userID)
 	}()
@@ -145,7 +145,7 @@ func (s *WSServer) LoopOverClientMessages() {
 					}
 					medias, err := s.mediaService.FindMediasByIDs(ctx, ids)
 					if err != nil {
-						log.Error().Err(err.Err).Msg("Failed to find media")
+						log.Error().Err(err).Msg("Failed to find media")
 						msg = NewErrorMessageResponse(msgReq.MessageID, msgReq.Sender, msgReq.Room, "Failed to find media", time.Now())
 					} else {
 						msg = NewMediaMessageResponse(msgReq.MessageID, msgReq.Sender, msgReq.Room, medias, time.Now())


### PR DESCRIPTION
### 기존 방식의 단점

- 서비스 함수의 시그니처가 항상 `error` 대신 `*pnd.AppError`로 강제되어 비즈니스 로직과 별개로 존재하는 함수도 래핑해서 생성해야 했음.
- 호환되지 않는 두 타입 `error`와 `*pnd.AppError`가 혼재하여 `err` 외에도 `err2`, `err3`을 써야하는 경우가 많았음.
- AppError가 나가는 방식은 항상 `c.JSON(appErr.code, appErr.response)`로 동일한데 매번 명시해줘야 했음.
- DB 에러 발생 시 `FromPostgresError`를 까먹고 안하면 문제 발생.

### 해결 방안

- `pnd.AppError`은 [error 인터페이스](https://go.dev/tour/methods/19)를 구현합니다.
- `router.go`에 에러 미들웨어를 추가해 `AppError`, `FromPostgresError`를 한 곳에서 처리합니다.
- 기존 서비스 코드에서 Error를 발생하는 함수에는 error을 반환하도록 하고, 에러 유틸을 이용해 응답을 만듭니다.
- 기존 코드에서 DB 에러 발생 시 `FromPostgresError` 래핑하는 부분 일괄 제거합니다.

### 앞으로의 방안

앞으로 이렇게 서비스 함수를 작성하면 됩니다.
1. 함수에서 error가 발생한다면 정의 부분에선 항상 `error` 타입으로 넣어줍니다.
2. DB 에러 발생시에는 그냥 `return err` 해주면 됩니다. (`FromPostgresError`는 직접 호출하지 않습니다.)
3. 이외의 에러는 기존처럼 에러 응답을 만들 땐 에러 유틸 코드를 이용해 응답을 만들어 반환합니다.
4. 서비스에서 `AppError`를 만들었다면 핸들러에서 에러 응답을 가공하지 않아도 됩니다. 그냥 err을 리턴해버리면 됩니다.

```go
// 예시로 만든 코드
func (s *PetService) CheckPermission(owner User, pet Pet) error {
	// ...

	if petToUpdate.OwnerID != owner.ID {
		return pnd.ErrForbidden(errors.New("해당 반려동물을 수정할 권한이 없습니다"))
	}

	// ...

	return nil
}
```