### PR TITLE
Makefile의 docker 스크립트에서 Project flag 제거합니다.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,18 +76,18 @@ test\:run:
 
 ## Database ##
 db\:up:
-	docker compose -p pets-next-door-api-dev up -d --remove-orphans
+	docker compose up -d --remove-orphans
 db\:down:
-	docker compose -p pets-next-door-api-dev down
+	docker compose down
 db\:destroy:
-	docker compose -p pets-next-door-api-dev down -v
+	docker compose down -v
 
 db\:test\:up:
-	docker compose -f docker-compose-test.yml -p pets-next-door-api-test up -d --remove-orphans
+	docker compose -f docker-compose-test.yml up -d --remove-orphans
 db\:test\:down:
-	docker compose -f docker-compose-test.yml -p pets-next-door-api-test down
+	docker compose -f docker-compose-test.yml down
 db\:test\:destroy:
-	docker compose -f docker-compose-test.yml -p pets-next-door-api-test down -v
+	docker compose -f docker-compose-test.yml down -v
 
 ## Migrate ##
 migrate\:install:


### PR DESCRIPTION
프로젝트명을 못찾아 `make db:*` 실행이 안됐는데 어차피 `-f`로 파일명을 주고 있으므로 프로젝트 플래그 `-p`를 제거합니다.

~~@JoeCP17 이건 바로 머지가겠습니다~~
갑자기 또 잘되는군요..